### PR TITLE
feat: add mongoose connection and models

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.0"
+    "next": "15.5.0",
+    "mongoose": "^8.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,29 @@
+import mongoose from 'mongoose';
+
+const MONGODB_URI = process.env.MONGODB_URI as string;
+
+if (!MONGODB_URI) {
+  throw new Error('MONGODB_URI is not defined');
+}
+
+declare global {
+  var mongoose: {
+    conn: typeof mongoose | null;
+    promise: Promise<typeof mongoose> | null;
+  } | undefined;
+}
+
+let cached = global.mongoose;
+
+if (!cached) {
+  cached = global.mongoose = { conn: null, promise: null };
+}
+
+export default async function dbConnect(): Promise<typeof mongoose> {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGODB_URI).then((m) => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/src/models/ActivityLog.ts
+++ b/src/models/ActivityLog.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IActivityLog extends Document {
+  userId?: Types.ObjectId;
+  action: string;
+  meta?: Record<string, unknown>;
+}
+
+const activityLogSchema = new Schema<IActivityLog>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User' },
+    action: { type: String, required: true },
+    meta: Schema.Types.Mixed,
+  },
+  { timestamps: true }
+);
+
+export default models.ActivityLog || model<IActivityLog>('ActivityLog', activityLogSchema);

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IComment extends Document {
+  taskId: Types.ObjectId;
+  authorId: Types.ObjectId;
+  content: string;
+}
+
+const commentSchema = new Schema<IComment>(
+  {
+    taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
+    authorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    content: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export default models.Comment || model<IComment>('Comment', commentSchema);

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface INotification extends Document {
+  userId: Types.ObjectId;
+  message: string;
+  read: boolean;
+}
+
+const notificationSchema = new Schema<INotification>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    message: { type: String, required: true },
+    read: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+export default models.Notification || model<INotification>('Notification', notificationSchema);

--- a/src/models/Objective.ts
+++ b/src/models/Objective.ts
@@ -1,0 +1,20 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IObjective extends Document {
+  teamId: Types.ObjectId;
+  title: string;
+  description?: string;
+  targetDate?: Date;
+}
+
+const objectiveSchema = new Schema<IObjective>(
+  {
+    teamId: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
+    title: { type: String, required: true },
+    description: String,
+    targetDate: Date,
+  },
+  { timestamps: true }
+);
+
+export default models.Objective || model<IObjective>('Objective', objectiveSchema);

--- a/src/models/OtpToken.ts
+++ b/src/models/OtpToken.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IOtpToken extends Document {
+  userId: Types.ObjectId;
+  token: string;
+  expiresAt: Date;
+}
+
+const otpTokenSchema = new Schema<IOtpToken>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    token: { type: String, required: true },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true }
+);
+
+export default models.OtpToken || model<IOtpToken>('OtpToken', otpTokenSchema);

--- a/src/models/RateLimit.ts
+++ b/src/models/RateLimit.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document } from 'mongoose';
+
+export interface IRateLimit extends Document {
+  key: string;
+  count: number;
+  expiresAt: Date;
+}
+
+const rateLimitSchema = new Schema<IRateLimit>(
+  {
+    key: { type: String, required: true, index: true },
+    count: { type: Number, default: 0 },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true }
+);
+
+export default models.RateLimit || model<IRateLimit>('RateLimit', rateLimitSchema);

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,0 +1,59 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+interface IParticipant {
+  userId: Types.ObjectId;
+  role: string;
+}
+
+interface IStep {
+  title: string;
+  description?: string;
+  completed: boolean;
+}
+
+export interface ITask extends Document {
+  title: string;
+  description?: string;
+  creatorId: Types.ObjectId;
+  participants: IParticipant[];
+  participantIds: Types.ObjectId[];
+  steps: IStep[];
+  currentStepIndex: number;
+}
+
+const participantSchema = new Schema<IParticipant>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    role: { type: String, default: 'member' },
+  },
+  { _id: false }
+);
+
+const stepSchema = new Schema<IStep>(
+  {
+    title: { type: String, required: true },
+    description: String,
+    completed: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+
+const taskSchema = new Schema<ITask>(
+  {
+    title: { type: String, required: true },
+    description: String,
+    creatorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    participants: [participantSchema],
+    participantIds: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    steps: [stepSchema],
+    currentStepIndex: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+taskSchema.pre('save', function (next) {
+  this.participantIds = this.participants.map((p) => p.userId);
+  next();
+});
+
+export default models.Task || model<ITask>('Task', taskSchema);

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,0 +1,16 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface ITeam extends Document {
+  name: string;
+  memberIds: Types.ObjectId[];
+}
+
+const teamSchema = new Schema<ITeam>(
+  {
+    name: { type: String, required: true },
+    memberIds: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+  },
+  { timestamps: true }
+);
+
+export default models.Team || model<ITeam>('Team', teamSchema);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,18 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IUser extends Document {
+  name: string;
+  email: string;
+  teamIds: Types.ObjectId[];
+}
+
+const userSchema = new Schema<IUser>(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    teamIds: [{ type: Schema.Types.ObjectId, ref: 'Team' }],
+  },
+  { timestamps: true }
+);
+
+export default models.User || model<IUser>('User', userSchema);


### PR DESCRIPTION
## Summary
- set up cached mongoose connection helper
- add schemas/models for core entities (users, teams, tasks, comments, objectives, activity logs, notifications, otp tokens, rate limits)
- task model tracks participant ids and step progress

## Testing
- `npm install` *(fails: 403 Forbidden - registry access)*
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aaba0448908328b3bb05aaa70f313a