### PR TITLE
feat: add mongoose models and db connector

### DIFF
--- a/scripts/sanity.ts
+++ b/scripts/sanity.ts
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+import dbConnect from '@/lib/db';
+
+(async () => {
+  await dbConnect();
+  console.log(mongoose.modelNames());
+  await mongoose.disconnect();
+})();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -7,22 +7,24 @@ if (!MONGODB_URI) {
 }
 
 declare global {
-  var mongoose: {
-    conn: typeof mongoose | null;
-    promise: Promise<typeof mongoose> | null;
-  } | undefined;
+  var mongooseCache:
+    | {
+        conn: typeof mongoose | null;
+        promise: Promise<typeof mongoose> | null;
+      }
+    | undefined;
 }
 
-let cached = global.mongoose;
+let cached = global.mongooseCache;
 
 if (!cached) {
-  cached = global.mongoose = { conn: null, promise: null };
+  cached = global.mongooseCache = { conn: null, promise: null };
 }
 
 export default async function dbConnect(): Promise<typeof mongoose> {
   if (cached.conn) return cached.conn;
   if (!cached.promise) {
-    cached.promise = mongoose.connect(MONGODB_URI).then((m) => m);
+    cached.promise = mongoose.connect(MONGODB_URI, { bufferCommands: false });
   }
   cached.conn = await cached.promise;
   return cached.conn;

--- a/src/models/ActivityLog.ts
+++ b/src/models/ActivityLog.ts
@@ -1,18 +1,21 @@
 import { Schema, model, models, type Document, type Types } from 'mongoose';
 
 export interface IActivityLog extends Document {
-  userId?: Types.ObjectId;
-  action: string;
-  meta?: Record<string, unknown>;
+  taskId: Types.ObjectId;
+  actorId: Types.ObjectId;
+  type: string;
+  payload: unknown;
+  createdAt: Date;
 }
 
 const activityLogSchema = new Schema<IActivityLog>(
   {
-    userId: { type: Schema.Types.ObjectId, ref: 'User' },
-    action: { type: String, required: true },
-    meta: Schema.Types.Mixed,
+    taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true, index: true },
+    actorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    type: { type: String, required: true },
+    payload: Schema.Types.Mixed,
   },
-  { timestamps: true }
+  { timestamps: { createdAt: true, updatedAt: false } }
 );
 
 export default models.ActivityLog || model<IActivityLog>('ActivityLog', activityLogSchema);

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -3,14 +3,18 @@ import { Schema, model, models, type Document, type Types } from 'mongoose';
 export interface IComment extends Document {
   taskId: Types.ObjectId;
   authorId: Types.ObjectId;
-  content: string;
+  body: string;
+  mentions: Types.ObjectId[];
+  attachments: string[];
 }
 
 const commentSchema = new Schema<IComment>(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     authorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-    content: { type: String, required: true },
+    body: { type: String, required: true },
+    mentions: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    attachments: [String],
   },
   { timestamps: true }
 );

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -2,17 +2,21 @@ import { Schema, model, models, type Document, type Types } from 'mongoose';
 
 export interface INotification extends Document {
   userId: Types.ObjectId;
-  message: string;
-  read: boolean;
+  type: string;
+  entityRef: unknown;
+  deliveredAt?: Date;
+  readAt?: Date;
 }
 
 const notificationSchema = new Schema<INotification>(
   {
-    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-    message: { type: String, required: true },
-    read: { type: Boolean, default: false },
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    type: { type: String, required: true },
+    entityRef: Schema.Types.Mixed,
+    deliveredAt: Date,
+    readAt: Date,
   },
-  { timestamps: true }
+  { timestamps: { createdAt: true, updatedAt: false } }
 );
 
 export default models.Notification || model<INotification>('Notification', notificationSchema);

--- a/src/models/Objective.ts
+++ b/src/models/Objective.ts
@@ -1,18 +1,24 @@
 import { Schema, model, models, type Document, type Types } from 'mongoose';
 
+export type ObjectiveStatus = 'OPEN' | 'DONE';
+
 export interface IObjective extends Document {
+  date: string;
   teamId: Types.ObjectId;
   title: string;
-  description?: string;
-  targetDate?: Date;
+  ownerId: Types.ObjectId;
+  linkedTaskIds: Types.ObjectId[];
+  status: ObjectiveStatus;
 }
 
 const objectiveSchema = new Schema<IObjective>(
   {
+    date: { type: String, required: true },
     teamId: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
     title: { type: String, required: true },
-    description: String,
-    targetDate: Date,
+    ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    linkedTaskIds: [{ type: Schema.Types.ObjectId, ref: 'Task' }],
+    status: { type: String, enum: ['OPEN', 'DONE'], default: 'OPEN' },
   },
   { timestamps: true }
 );

--- a/src/models/OtpToken.ts
+++ b/src/models/OtpToken.ts
@@ -1,18 +1,26 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import { Schema, model, models, type Document } from 'mongoose';
 
 export interface IOtpToken extends Document {
-  userId: Types.ObjectId;
-  token: string;
+  email: string;
+  codeHash: string;
+  attempts: number;
+  ip: string;
+  createdAt: Date;
   expiresAt: Date;
 }
 
 const otpTokenSchema = new Schema<IOtpToken>(
   {
-    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-    token: { type: String, required: true },
+    email: { type: String, required: true, lowercase: true, index: true },
+    codeHash: { type: String, required: true },
+    attempts: { type: Number, default: 0 },
+    ip: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now },
     expiresAt: { type: Date, required: true },
   },
-  { timestamps: true }
+  { timestamps: false }
 );
+
+otpTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 export default models.OtpToken || model<IOtpToken>('OtpToken', otpTokenSchema);

--- a/src/models/RateLimit.ts
+++ b/src/models/RateLimit.ts
@@ -3,16 +3,18 @@ import { Schema, model, models, type Document } from 'mongoose';
 export interface IRateLimit extends Document {
   key: string;
   count: number;
-  expiresAt: Date;
+  windowEndsAt: Date;
 }
 
 const rateLimitSchema = new Schema<IRateLimit>(
   {
     key: { type: String, required: true, index: true },
     count: { type: Number, default: 0 },
-    expiresAt: { type: Date, required: true },
+    windowEndsAt: { type: Date, required: true },
   },
-  { timestamps: true }
+  { timestamps: false }
 );
+
+rateLimitSchema.index({ windowEndsAt: 1 }, { expireAfterSeconds: 0 });
 
 export default models.RateLimit || model<IRateLimit>('RateLimit', rateLimitSchema);

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,14 +1,12 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import { Schema, model, models, type Document } from 'mongoose';
 
 export interface ITeam extends Document {
   name: string;
-  memberIds: Types.ObjectId[];
 }
 
 const teamSchema = new Schema<ITeam>(
   {
     name: { type: String, required: true },
-    memberIds: [{ type: Schema.Types.ObjectId, ref: 'User' }],
   },
   { timestamps: true }
 );

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -3,14 +3,24 @@ import { Schema, model, models, type Document, type Types } from 'mongoose';
 export interface IUser extends Document {
   name: string;
   email: string;
-  teamIds: Types.ObjectId[];
+  teamId?: Types.ObjectId;
+  timezone: string;
+  isActive: boolean;
 }
 
 const userSchema = new Schema<IUser>(
   {
     name: { type: String, required: true },
-    email: { type: String, required: true, unique: true },
-    teamIds: [{ type: Schema.Types.ObjectId, ref: 'Team' }],
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      index: true,
+    },
+    teamId: { type: Schema.Types.ObjectId, ref: 'Team' },
+    timezone: { type: String, default: 'Asia/Kolkata' },
+    isActive: { type: Boolean, default: true },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- add hot-reload-safe MongoDB connector
- define Mongoose schemas for core entities with indexes and types
- provide sanity script to list model names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsx scripts/sanity.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aac4192cf08328914b88359361e8af