### PR TITLE
feat: add OTP-based authentication

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from './src/lib/auth';
+
+export const config = {
+  matcher: ['/((?!api/auth|signin).*)'],
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "next": "15.5.0",
-    "mongoose": "^8.0.0"
+    "mongoose": "^8.0.0",
+    "next-auth": "^5.0.0",
+    "resend": "^2.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from '@/lib/auth';

--- a/src/app/api/auth/otp/request/route.ts
+++ b/src/app/api/auth/otp/request/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { generateOtp, createOtpToken, checkRateLimit } from '@/lib/otp';
+import { sendOtpEmail } from '@/lib/email';
+
+export async function POST(req: Request) {
+  const { email } = await req.json();
+  if (!email) {
+    return NextResponse.json(
+      {
+        type: 'https://example.com/otp/invalid-request',
+        title: 'Invalid request',
+        status: 400,
+        detail: 'Email is required',
+      },
+      { status: 400 }
+    );
+  }
+  const ip = req.headers.get('x-forwarded-for') || 'unknown';
+  const emailAllowed = await checkRateLimit(`otp:email:${email}`);
+  const ipAllowed = await checkRateLimit(`otp:ip:${ip}`);
+  if (!emailAllowed || !ipAllowed) {
+    return NextResponse.json(
+      {
+        type: 'https://example.com/otp/rate-limit',
+        title: 'Rate limit exceeded',
+        status: 429,
+        detail: 'Too many requests. Try again later.',
+      },
+      { status: 429 }
+    );
+  }
+  const code = generateOtp();
+  try {
+    await createOtpToken(email, ip, code);
+  } catch {
+    return NextResponse.json(
+      {
+        type: 'https://example.com/otp/cooldown',
+        title: 'Cooldown active',
+        status: 429,
+        detail: 'Please wait before requesting another code.',
+      },
+      { status: 429 }
+    );
+  }
+  await sendOtpEmail(email, code);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { verifyAndConsumeOtp } from '@/lib/otp';
+import dbConnect from '@/lib/db';
+import User from '@/models/User';
+import { signIn } from '@/lib/auth';
+
+export async function POST(req: Request) {
+  const { email, code } = await req.json();
+  if (!email || !code) {
+    return NextResponse.json(
+      {
+        type: 'https://example.com/otp/invalid-request',
+        title: 'Invalid request',
+        status: 400,
+        detail: 'Email and code are required',
+      },
+      { status: 400 }
+    );
+  }
+  const result = await verifyAndConsumeOtp(email, code);
+  if (!result.valid) {
+    const detailMap: Record<string, string> = {
+      invalid: 'The provided code is invalid.',
+      expired: 'The code has expired.',
+      attempts: 'Too many invalid attempts.',
+    };
+    const status = result.reason === 'attempts' ? 429 : 400;
+    return NextResponse.json(
+      {
+        type: `https://example.com/otp/${result.reason}`,
+        title: 'OTP verification failed',
+        status,
+        detail: detailMap[result.reason ?? 'invalid'],
+      },
+      { status }
+    );
+  }
+  await dbConnect();
+  await User.updateOne(
+    { email },
+    {
+      $setOnInsert: { name: email.split('@')[0], email },
+    },
+    { upsert: true }
+  );
+  return signIn('credentials', { email, otpVerified: true, redirectTo: '/tasks' });
+}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function SignInPage() {
+  const [email, setEmail] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/otp/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) {
+      router.push(`/signin/verify?email=${encodeURIComponent(email)}`);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="you@example.com"
+        required
+        className="border p-2"
+      />
+      <button type="submit" className="bg-blue-500 text-white p-2">
+        Send Code
+      </button>
+    </form>
+  );
+}

--- a/src/app/signin/verify/page.tsx
+++ b/src/app/signin/verify/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function VerifyPage() {
+  const params = useSearchParams();
+  const email = params.get('email') || '';
+  const router = useRouter();
+  const [code, setCode] = useState('');
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const id = setInterval(() => setCooldown((c) => c - 1), 1000);
+    return () => clearInterval(id);
+  }, [cooldown]);
+
+  const verify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/auth/otp/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, code }),
+    });
+    if (res.ok) {
+      router.push('/tasks');
+    }
+  };
+
+  const resend = async () => {
+    const res = await fetch('/api/auth/otp/request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) setCooldown(60);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      <p>Enter the code sent to {email}</p>
+      <form onSubmit={verify} className="flex flex-col gap-2">
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          maxLength={6}
+          className="border p-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white p-2">
+          Verify
+        </button>
+      </form>
+      <button onClick={resend} disabled={cooldown > 0} className="p-2 border">
+        Resend {cooldown > 0 && `(${cooldown})`}
+      </button>
+    </div>
+  );
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,0 +1,3 @@
+export default function TasksPage() {
+  return <h1 className="p-4">Tasks</h1>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,67 @@
+import NextAuth from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import dbConnect from '@/lib/db';
+import User from '@/models/User';
+
+interface AuthUser {
+  id: string;
+  email: string;
+  teamId?: string;
+}
+
+interface ExtendedToken {
+  userId?: string;
+  email?: string;
+  teamId?: string;
+  [key: string]: unknown;
+}
+
+interface ExtendedSession {
+  userId?: string;
+  email?: string;
+  teamId?: string;
+  [key: string]: unknown;
+}
+
+export const authOptions = {
+  session: { strategy: 'jwt' },
+  providers: [
+    Credentials({
+      name: 'OTP',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        otpVerified: { label: 'OTP Verified', type: 'boolean' },
+      },
+      authorize: async (credentials): Promise<AuthUser | null> => {
+        if (!credentials?.otpVerified || !credentials.email) return null;
+        await dbConnect();
+        const user = await User.findOne({ email: credentials.email });
+        if (!user) return null;
+        return {
+          id: user._id.toString(),
+          email: user.email,
+          teamId: user.teamId?.toString(),
+        };
+      },
+    }),
+  ],
+  callbacks: {
+    async jwt({ token, user }: { token: ExtendedToken; user?: AuthUser }) {
+      if (user) {
+        token.userId = user.id;
+        token.email = user.email;
+        token.teamId = user.teamId;
+      }
+      return token;
+    },
+    async session({ session, token }: { session: ExtendedSession; token: ExtendedToken }) {
+      session.userId = token.userId;
+      session.email = token.email;
+      session.teamId = token.teamId;
+      return session;
+    },
+  },
+};
+
+export const { handlers, auth, signIn } = NextAuth(authOptions);
+export const { GET, POST } = handlers;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,18 @@
+import { Resend } from 'resend';
+
+const resend = process.env.RESEND_API_KEY
+  ? new Resend(process.env.RESEND_API_KEY)
+  : null;
+
+export async function sendOtpEmail(to: string, code: string) {
+  if (resend) {
+    await resend.emails.send({
+      from: 'otp@example.com',
+      to,
+      subject: 'Your login code',
+      text: `Your verification code is ${code}`,
+    });
+  } else {
+    console.log(`OTP for ${to}: ${code}`);
+  }
+}

--- a/src/lib/otp.ts
+++ b/src/lib/otp.ts
@@ -1,0 +1,80 @@
+import crypto from 'crypto';
+import dbConnect from '@/lib/db';
+import OtpToken from '@/models/OtpToken';
+import RateLimit from '@/models/RateLimit';
+
+const OTP_EXPIRY_MINUTES = 10;
+const RESEND_COOLDOWN = 60; // seconds
+const MAX_REQUESTS_PER_HOUR = 5;
+const MAX_ATTEMPTS = 5;
+
+export function generateOtp(): string {
+  return Math.floor(100000 + Math.random() * 900000).toString();
+}
+
+export function hashOtp(code: string): string {
+  return crypto.createHash('sha256').update(code).digest('hex');
+}
+
+export function verifyOtp(code: string, hash: string): boolean {
+  return hashOtp(code) === hash;
+}
+
+export async function checkRateLimit(key: string): Promise<boolean> {
+  await dbConnect();
+  const now = new Date();
+  const windowEndsAt = new Date(now.getTime() + 60 * 60 * 1000);
+  const record = await RateLimit.findOne({ key });
+  if (!record || record.windowEndsAt < now) {
+    await RateLimit.updateOne(
+      { key },
+      { $set: { count: 1, windowEndsAt } },
+      { upsert: true }
+    );
+    return true;
+  }
+  if (record.count >= MAX_REQUESTS_PER_HOUR) {
+    return false;
+  }
+  await RateLimit.updateOne({ key }, { $inc: { count: 1 } });
+  return true;
+}
+
+export async function createOtpToken(email: string, ip: string, code: string) {
+  await dbConnect();
+  const latest = await OtpToken.findOne({ email }).sort({ createdAt: -1 });
+  if (latest && Date.now() - latest.createdAt.getTime() < RESEND_COOLDOWN * 1000) {
+    throw new Error('cooldown');
+  }
+  const codeHash = hashOtp(code);
+  const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
+  await OtpToken.create({ email, codeHash, ip, expiresAt });
+}
+
+export async function verifyAndConsumeOtp(
+  email: string,
+  code: string
+): Promise<{ valid: boolean; reason?: string }> {
+  await dbConnect();
+  const token = await OtpToken.findOne({ email }).sort({ createdAt: -1 });
+  if (!token) return { valid: false, reason: 'invalid' };
+  if (token.expiresAt < new Date()) {
+    await OtpToken.deleteMany({ email });
+    return { valid: false, reason: 'expired' };
+  }
+  if (token.attempts >= MAX_ATTEMPTS) {
+    return { valid: false, reason: 'attempts' };
+  }
+  const match = verifyOtp(code, token.codeHash);
+  if (!match) {
+    token.attempts += 1;
+    await token.save();
+    if (token.attempts >= MAX_ATTEMPTS) {
+      return { valid: false, reason: 'attempts' };
+    }
+    return { valid: false, reason: 'invalid' };
+  }
+  await OtpToken.deleteMany({ email });
+  return { valid: true };
+}
+


### PR DESCRIPTION
## Summary
- implement OTP email flow with rate limiting and single-use tokens
- configure NextAuth credentials provider for OTP sessions
- add protected routes and sign-in pages for requesting and verifying codes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run dev` *(fails: Module not found: Can't resolve 'mongoose', 'next-auth')*


------
https://chatgpt.com/codex/tasks/task_e_68aac5d8748c832895521765e444d1e6