### PR TITLE
feat: add task transition endpoint with websocket

### DIFF
--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types, startSession } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Task from '@/models/Task';
+import ActivityLog from '@/models/ActivityLog';
+import { auth } from '@/lib/auth';
+import { emitTaskTransition } from '@/lib/ws';
+
+const bodySchema = z.object({
+  action: z.enum(['START', 'SEND_FOR_REVIEW', 'REQUEST_CHANGES', 'DONE']),
+});
+
+function problem(status: number, title: string, detail: string) {
+  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.userId) return problem(401, 'Unauthorized', 'You must be signed in.');
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+
+  await dbConnect();
+  const task = await Task.findById(params.id);
+  if (!task) return problem(404, 'Not Found', 'Task not found');
+
+  const actorId = session.userId;
+  const isCreator = task.creatorId.toString() === actorId;
+  const isOwner = task.ownerId.toString() === actorId;
+  if (!isCreator && !isOwner) {
+    return problem(403, 'Forbidden', 'You cannot transition this task');
+  }
+
+  if (task.steps?.length) {
+    // Only DONE is meaningful when steps exist
+    if (body.action !== 'DONE') {
+      return problem(400, 'Invalid action', 'Only DONE is allowed for step tasks');
+    }
+    if (!isOwner) {
+      return problem(403, 'Forbidden', 'Only current step owner may complete the step');
+    }
+
+    const mongoSession = await startSession();
+    let updated: any;
+    await mongoSession.withTransaction(async () => {
+      const t = await Task.findById(task._id).session(mongoSession);
+      if (!t) throw new Error('Task not found');
+      const idx = t.currentStepIndex ?? 0;
+      const step = t.steps[idx];
+      if (!step || step.status === 'DONE') return;
+      step.status = 'DONE';
+      step.completedAt = new Date();
+      if (idx + 1 < t.steps.length) {
+        t.currentStepIndex = idx + 1;
+        t.ownerId = t.steps[idx + 1].ownerId;
+        t.status = 'FLOW_IN_PROGRESS';
+      } else {
+        t.status = 'DONE';
+      }
+      await t.save({ session: mongoSession });
+      await ActivityLog.create(
+        [
+          {
+            taskId: t._id,
+            actorId: new Types.ObjectId(actorId),
+            type: 'TRANSITIONED',
+            payload: { action: body.action },
+          },
+        ],
+        { session: mongoSession }
+      );
+      updated = t;
+    });
+    if (!updated) return problem(500, 'Error', 'Transition failed');
+    emitTaskTransition(updated);
+    return NextResponse.json(updated);
+  } else {
+    let newStatus = task.status;
+    switch (body.action) {
+      case 'START':
+        if (task.status !== 'OPEN') return problem(400, 'Invalid action', 'Task is not OPEN');
+        newStatus = 'IN_PROGRESS';
+        break;
+      case 'SEND_FOR_REVIEW':
+        if (task.status !== 'IN_PROGRESS' && task.status !== 'REVISIONS')
+          return problem(400, 'Invalid action', 'Task not ready for review');
+        newStatus = 'IN_REVIEW';
+        break;
+      case 'REQUEST_CHANGES':
+        if (task.status !== 'IN_REVIEW')
+          return problem(400, 'Invalid action', 'Task not in review');
+        newStatus = 'REVISIONS';
+        break;
+      case 'DONE':
+        if (task.status !== 'IN_REVIEW' && task.status !== 'REVISIONS')
+          return problem(400, 'Invalid action', 'Task cannot be completed');
+        newStatus = 'DONE';
+        break;
+    }
+    task.status = newStatus;
+    await task.save();
+    await ActivityLog.create({
+      taskId: task._id,
+      actorId: new Types.ObjectId(actorId),
+      type: 'TRANSITIONED',
+      payload: { action: body.action },
+    });
+    emitTaskTransition(task);
+    return NextResponse.json(task);
+  }
+}
+

--- a/src/app/api/tasks/transition.test.ts
+++ b/src/app/api/tasks/transition.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from './[id]/transition/route';
+
+// mock mongoose before import
+vi.mock('mongoose', async () => {
+  const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+  return {
+    ...actual,
+    startSession: vi.fn(async () => ({
+      withTransaction: async (fn: any) => {
+        await fn();
+      },
+    })),
+  };
+});
+import mongoose from 'mongoose';
+
+// mocks
+vi.mock('@/lib/db', () => ({ default: vi.fn() }));
+
+const tasks = new Map<string, any>();
+
+vi.mock('@/models/Task', () => ({
+  default: {
+    findById: vi.fn(async (id: string) => {
+      const doc = tasks.get(id);
+      if (!doc) return null;
+      doc.save = async function () {
+        tasks.set(id, doc);
+      };
+      doc.session = function () {
+        return doc;
+      };
+      return doc;
+    }),
+  },
+}));
+
+vi.mock('@/models/ActivityLog', () => ({
+  default: { create: vi.fn() },
+}));
+
+let currentUserId = '';
+vi.mock('@/lib/auth', () => ({ auth: vi.fn(async () => ({ userId: currentUserId })) }));
+
+vi.mock('@/lib/ws', () => ({ emitTaskTransition: vi.fn() }));
+
+const { Types } = mongoose;
+
+describe('task flow with steps', () => {
+  beforeEach(() => {
+    tasks.clear();
+  });
+
+  it('advances through steps and completes', async () => {
+    const u1 = new Types.ObjectId();
+    const u2 = new Types.ObjectId();
+    const u3 = new Types.ObjectId();
+    const taskId = new Types.ObjectId();
+    tasks.set(taskId.toString(), {
+      _id: taskId,
+      title: 'Test',
+      creatorId: u1,
+      ownerId: u1,
+      status: 'FLOW_IN_PROGRESS',
+      steps: [
+        { ownerId: u1, status: 'OPEN' },
+        { ownerId: u2, status: 'OPEN' },
+        { ownerId: u3, status: 'OPEN' },
+      ],
+      currentStepIndex: 0,
+    });
+
+    currentUserId = u1.toString();
+    await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'DONE' }),
+      }),
+      { params: { id: taskId.toString() } }
+    );
+    let t = tasks.get(taskId.toString());
+    expect(t.currentStepIndex).toBe(1);
+    expect(t.ownerId.toString()).toBe(u2.toString());
+    expect(t.status).toBe('FLOW_IN_PROGRESS');
+
+    currentUserId = u2.toString();
+    await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'DONE' }),
+      }),
+      { params: { id: taskId.toString() } }
+    );
+    t = tasks.get(taskId.toString());
+    expect(t.currentStepIndex).toBe(2);
+    expect(t.ownerId.toString()).toBe(u3.toString());
+    expect(t.status).toBe('FLOW_IN_PROGRESS');
+
+    currentUserId = u3.toString();
+    await POST(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({ action: 'DONE' }),
+      }),
+      { params: { id: taskId.toString() } }
+    );
+    t = tasks.get(taskId.toString());
+    expect(t.status).toBe('DONE');
+    expect(t.currentStepIndex).toBe(2);
+  });
+});

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,0 +1,15 @@
+import { addClient } from '@/lib/ws';
+
+export async function GET(request: Request) {
+  const upgrade = request.headers.get('upgrade');
+  if (upgrade?.toLowerCase() !== 'websocket') {
+    return new Response('Expected websocket', { status: 400 });
+  }
+  const { 0: client, 1: server } = Object.values(new WebSocketPair()) as unknown as [
+    WebSocket,
+    WebSocket
+  ];
+  server.accept();
+  addClient(server);
+  return new Response(null, { status: 101, webSocket: client });
+}

--- a/src/hooks/useTaskChannel.ts
+++ b/src/hooks/useTaskChannel.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+export default function useTaskChannel(
+  taskId: string,
+  onMessage: (task: any) => void
+) {
+  useEffect(() => {
+    if (!taskId) return;
+    const url = `${window.location.origin.replace(/^http/, 'ws')}/api/ws`;
+    const ws = new WebSocket(url);
+    ws.addEventListener('message', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.event === 'task.transitioned' && data.taskId === taskId) {
+          onMessage(data.task);
+        }
+      } catch {
+        // ignore
+      }
+    });
+    return () => {
+      ws.close();
+    };
+  }, [taskId, onMessage]);
+}

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -1,0 +1,21 @@
+const clients = new Set<WebSocket>();
+
+export function addClient(ws: WebSocket) {
+  clients.add(ws);
+  ws.addEventListener('close', () => clients.delete(ws));
+}
+
+export function emitTaskTransition(task: any) {
+  const message = JSON.stringify({
+    event: 'task.transitioned',
+    taskId: task._id?.toString(),
+    task,
+  });
+  clients.forEach((ws) => {
+    try {
+      ws.send(message);
+    } catch {
+      clients.delete(ws);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add POST /api/tasks/[id]/transition to move tasks through workflow and step flows
- broadcast task.transitioned websocket events and client hook
- websocket route for clients to subscribe

## Testing
- `npx vitest run src/app/api/tasks/transition.test.ts` *(fails: 403 Forbidden fetching vitest)*
- `node - <<'NODE'
const task={ status:'FLOW_IN_PROGRESS', ownerId:'u1', steps:[{ownerId:'u1',status:'OPEN'},{ownerId:'u2',status:'OPEN'},{ownerId:'u3',status:'OPEN'}], currentStepIndex:0};
function completeStep(u){ if(task.ownerId!==u){console.log('forbidden');return;} const i=task.currentStepIndex; task.steps[i].status='DONE'; if(i+1<task.steps.length){task.currentStepIndex++; task.ownerId=task.steps[i+1].ownerId; task.status='FLOW_IN_PROGRESS';} else {task.status='DONE';} console.log(`step ${i} done; owner now ${task.ownerId}; status ${task.status}`); }
completeStep('u1');
completeStep('u2');
completeStep('u3');
console.log(task);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68aaca458e648328b4e982ed5fbb0a75