### PR TITLE
Add comment system with mentions and realtime updates

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import { auth } from '@/lib/auth';
+import { canReadTask } from '@/lib/access';
+import Comment from '@/models/Comment';
+import Task from '@/models/Task';
+import User from '@/models/User';
+import ActivityLog from '@/models/ActivityLog';
+import Notification from '@/models/Notification';
+import { parseMentions } from '@/lib/mentions';
+import { emitCommentCreated } from '@/lib/ws';
+
+const postSchema = z.object({
+  taskId: z.string(),
+  body: z.string(),
+});
+
+const listQuerySchema = z.object({
+  taskId: z.string(),
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+function problem(status: number, title: string, detail: string) {
+  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  let body: z.infer<typeof postSchema>;
+  try {
+    body = postSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  const task = await Task.findById(body.taskId);
+  if (!task || !canReadTask(session, task)) {
+    return problem(404, 'Not Found', 'Task not found');
+  }
+  const mentionEmails = parseMentions(body.body);
+  const users = mentionEmails.length
+    ? await User.find({ email: { $in: mentionEmails } })
+    : [];
+  const mentionIds = users.map((u) => u._id);
+  const comment = await Comment.create({
+    taskId: new Types.ObjectId(body.taskId),
+    authorId: new Types.ObjectId(session.userId),
+    body: body.body,
+    mentions: mentionIds,
+    attachments: [],
+  });
+  if (mentionIds.length) {
+    await Task.updateOne(
+      { _id: body.taskId },
+      { $addToSet: { participantIds: { $each: mentionIds } } }
+    );
+    const notifications = mentionIds
+      .filter((id) => id.toString() !== session.userId)
+      .map((id) => ({
+        userId: id,
+        type: 'COMMENT_MENTION',
+        entityRef: { taskId: comment.taskId, commentId: comment._id },
+      }));
+    if (notifications.length) {
+      await Notification.insertMany(notifications);
+    }
+  }
+  await ActivityLog.create({
+    taskId: comment.taskId,
+    actorId: new Types.ObjectId(session.userId),
+    type: 'COMMENT',
+    payload: { commentId: comment._id },
+  });
+  emitCommentCreated({ ...comment.toObject(), taskId: comment.taskId });
+  return NextResponse.json(comment, { status: 201 });
+}
+
+export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  const url = new URL(req.url);
+  const raw: Record<string, any> = {};
+  url.searchParams.forEach((value, key) => {
+    raw[key] = value;
+  });
+  let query: z.infer<typeof listQuerySchema>;
+  try {
+    query = listQuerySchema.parse(raw);
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  const task = await Task.findById(query.taskId);
+  if (!task || !canReadTask(session, task)) {
+    return problem(404, 'Not Found', 'Task not found');
+  }
+  const page = query.page ?? 1;
+  const limit = query.limit ?? 20;
+  const comments = await Comment.find({ taskId: new Types.ObjectId(query.taskId) })
+    .sort({ createdAt: -1 })
+    .skip((page - 1) * limit)
+    .limit(limit);
+  return NextResponse.json(comments);
+}

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useTaskChannel from '@/hooks/useTaskChannel';
+
+export default function TaskPage({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const [comments, setComments] = useState<any[]>([]);
+  const [body, setBody] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/comments?taskId=${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setComments(data);
+      }
+    };
+    load();
+  }, [id]);
+
+  useTaskChannel(id, (data) => {
+    if (data.event === 'comment.created') {
+      setComments((prev) => [data.comment, ...prev]);
+    }
+  });
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ taskId: id, body }),
+    });
+    if (res.ok) {
+      setBody('');
+    }
+  };
+
+  return (
+    <div className="p-4 flex flex-col gap-2">
+      <h1>Task {id}</h1>
+      <ul className="flex flex-col gap-1">
+        {comments.map((c) => (
+          <li key={c._id}>{c.body}</li>
+        ))}
+      </ul>
+      <form onSubmit={submit} className="flex gap-2">
+        <input
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          className="border p-1 flex-1"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2">
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/hooks/useTaskChannel.ts
+++ b/src/hooks/useTaskChannel.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export default function useTaskChannel(
   taskId: string,
-  onMessage: (task: any) => void
+  onMessage: (data: any) => void
 ) {
   useEffect(() => {
     if (!taskId) return;
@@ -11,8 +11,8 @@ export default function useTaskChannel(
     ws.addEventListener('message', (event) => {
       try {
         const data = JSON.parse(event.data);
-        if (data.event === 'task.transitioned' && data.taskId === taskId) {
-          onMessage(data.task);
+        if (data.taskId === taskId) {
+          onMessage(data);
         }
       } catch {
         // ignore

--- a/src/lib/mentions.test.ts
+++ b/src/lib/mentions.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parseMentions } from './mentions';
+
+describe('parseMentions', () => {
+  it('parses @email', () => {
+    const emails = parseMentions('Hello @alice@example.com');
+    expect(emails).toEqual(['alice@example.com']);
+  });
+
+  it('parses @Name <email>', () => {
+    const emails = parseMentions('Hi @Alice <alice@example.com> and @Bob <bob@example.com>');
+    expect(emails).toEqual(['alice@example.com', 'bob@example.com']);
+  });
+
+  it('deduplicates and handles mix', () => {
+    const emails = parseMentions('@a@example.com hi @A <a@example.com>');
+    expect(emails).toEqual(['a@example.com']);
+  });
+});

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -1,0 +1,9 @@
+export function parseMentions(body: string): string[] {
+  const emails = new Set<string>();
+  const regex = /@(?:([\w.+-]+@[\w.-]+\.[\w-]+)|[^<@\n]*<([\w.+-]+@[\w.-]+\.[\w-]+)>)/g;
+  for (const match of body.matchAll(regex)) {
+    const email = match[1] || match[2];
+    if (email) emails.add(email.toLowerCase());
+  }
+  return Array.from(emails);
+}

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -19,3 +19,18 @@ export function emitTaskTransition(task: any) {
     }
   });
 }
+
+export function emitCommentCreated(comment: any) {
+  const message = JSON.stringify({
+    event: 'comment.created',
+    taskId: comment.taskId?.toString(),
+    comment,
+  });
+  clients.forEach((ws) => {
+    try {
+      ws.send(message);
+    } catch {
+      clients.delete(ws);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add comment API with mention parsing and notification support
- stream comment.created over websockets and hook into task channel
- provide task detail page with live comments and parser unit tests

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68aacbd92c34832891431cb616eb783d