### PR TITLE
feat: add objectives endpoints and dashboard

### DIFF
--- a/src/app/api/objectives/[id]/route.ts
+++ b/src/app/api/objectives/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import Objective from '@/models/Objective';
+import { auth } from '@/lib/auth';
+
+function problem(status: number, title: string, detail: string) {
+  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  await dbConnect();
+  const objective = await Objective.findById(params.id);
+  if (!objective) {
+    return problem(404, 'Not Found', 'Objective not found');
+  }
+  if (session.teamId && objective.teamId.toString() !== session.teamId) {
+    return problem(403, 'Forbidden', 'Wrong team');
+  }
+  objective.status = objective.status === 'DONE' ? 'OPEN' : 'DONE';
+  await objective.save();
+  return NextResponse.json(objective);
+}
+

--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mongoose from 'mongoose';
+import { POST as upsertObjective, GET as listObjectives } from './route';
+import { PATCH as toggleObjective } from './[id]/route';
+import { GET as dailyDashboard } from '../dashboard/daily/route';
+
+vi.mock('@/lib/db', () => ({ default: vi.fn() }));
+
+const objectives = new Map<string, any>();
+const tasks = new Map<string, any>();
+
+vi.mock('@/models/Objective', () => ({
+  default: {
+    create: vi.fn(async (doc: any) => {
+      const _id = doc._id || new Types.ObjectId();
+      const objective = { ...doc, _id };
+      objective.save = async () => {
+        objectives.set(_id.toString(), objective);
+      };
+      objectives.set(_id.toString(), objective);
+      return objective;
+    }),
+    find: vi.fn(async (filter: any) => {
+      return Array.from(objectives.values()).filter(
+        (o) =>
+          o.date === filter.date &&
+          o.teamId.toString() === filter.teamId.toString()
+      );
+    }),
+    findById: vi.fn(async (id: string) => {
+      const obj = objectives.get(id);
+      if (!obj) return null;
+      obj.save = async () => {
+        objectives.set(id, obj);
+      };
+      return obj;
+    }),
+  },
+}));
+
+vi.mock('@/models/Task', () => ({
+  default: {
+    find: vi.fn(async (filter: any) => {
+      return Array.from(tasks.values()).filter((t) => {
+        const due =
+          t.dueAt >= filter.dueAt.$gte && t.dueAt < filter.dueAt.$lt;
+        const accessible = filter.$or.some((c: any) => {
+          if (c.participantIds) {
+            return t.participantIds.some(
+              (p: any) => p.toString() === c.participantIds.toString()
+            );
+          }
+          if (c.visibility) {
+            return (
+              t.visibility === c.visibility &&
+              t.teamId?.toString() === c.teamId.toString()
+            );
+          }
+          return false;
+        });
+        return due && accessible;
+      });
+    }),
+  },
+}));
+
+let session: any = {};
+vi.mock('@/lib/auth', () => ({ auth: vi.fn(async () => session) }));
+
+const { Types } = mongoose;
+
+describe('objectives api', () => {
+  beforeEach(() => {
+    objectives.clear();
+    tasks.clear();
+  });
+
+  it('create/complete objectives and dashboard', async () => {
+    const teamId = new Types.ObjectId();
+    const u1 = new Types.ObjectId();
+    const u2 = new Types.ObjectId();
+    session = { userId: u1.toString(), teamId: teamId.toString() };
+
+    let res = await upsertObjective(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({
+          date: '2023-01-01',
+          teamId: teamId.toString(),
+          title: 'obj1',
+          ownerId: u1.toString(),
+        }),
+      })
+    );
+    const obj1 = await res.json();
+
+    res = await upsertObjective(
+      new Request('http://test', {
+        method: 'POST',
+        body: JSON.stringify({
+          date: '2023-01-01',
+          teamId: teamId.toString(),
+          title: 'obj2',
+          ownerId: u2.toString(),
+        }),
+      })
+    );
+    const obj2 = await res.json();
+
+    res = await listObjectives(
+      new Request(
+        `http://test?date=2023-01-01&teamId=${teamId.toString()}`
+      )
+    );
+    const list = await res.json();
+    expect(list.length).toBe(2);
+
+    await toggleObjective(new Request('http://test', { method: 'PATCH' }), {
+      params: { id: obj1._id },
+    });
+
+    const task1 = {
+      _id: new Types.ObjectId(),
+      title: 't1',
+      ownerId: u1,
+      dueAt: new Date('2023-01-01T10:00:00Z'),
+      participantIds: [u1],
+    };
+    const task2 = {
+      _id: new Types.ObjectId(),
+      title: 't2',
+      ownerId: u2,
+      dueAt: new Date('2023-01-01T12:00:00Z'),
+      visibility: 'TEAM',
+      teamId,
+      participantIds: [],
+    };
+    tasks.set(task1._id.toString(), task1);
+    tasks.set(task2._id.toString(), task2);
+
+    res = await dailyDashboard(
+      new Request(
+        `http://test?date=2023-01-01&teamId=${teamId.toString()}`
+      )
+    );
+    const dash = await res.json();
+    const s1 = dash.summary.find((s: any) => s.ownerId === u1.toString());
+    const s2 = dash.summary.find((s: any) => s.ownerId === u2.toString());
+    expect(s1.completed).toBe(1);
+    expect(s1.total).toBe(1);
+    expect(s2.completed).toBe(0);
+    expect(s2.total).toBe(1);
+    expect(dash.pending.length).toBe(1);
+    expect(dash.tasks.length).toBe(2);
+  });
+});
+

--- a/src/app/api/objectives/route.ts
+++ b/src/app/api/objectives/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Objective from '@/models/Objective';
+import { auth } from '@/lib/auth';
+
+const upsertSchema = z.object({
+  id: z.string().optional(),
+  date: z.string(),
+  teamId: z.string(),
+  title: z.string(),
+  ownerId: z.string(),
+  linkedTaskIds: z.array(z.string()).optional(),
+  status: z.enum(['OPEN', 'DONE']).optional(),
+});
+
+function problem(status: number, title: string, detail: string) {
+  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  let body: z.infer<typeof upsertSchema>;
+  try {
+    body = upsertSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  if (session.teamId && session.teamId !== body.teamId) {
+    return problem(403, 'Forbidden', 'Wrong team');
+  }
+  await dbConnect();
+  if (body.id) {
+    const objective = await Objective.findById(body.id);
+    if (!objective) return problem(404, 'Not Found', 'Objective not found');
+    if (objective.teamId.toString() !== body.teamId) {
+      return problem(403, 'Forbidden', 'Wrong team');
+    }
+    Object.assign(objective, {
+      date: body.date,
+      teamId: new Types.ObjectId(body.teamId),
+      title: body.title,
+      ownerId: new Types.ObjectId(body.ownerId),
+      linkedTaskIds: body.linkedTaskIds?.map((id) => new Types.ObjectId(id)) ?? [],
+      status: body.status ?? objective.status,
+    });
+    await objective.save();
+    return NextResponse.json(objective);
+  }
+  const objective = await Objective.create({
+    date: body.date,
+    teamId: new Types.ObjectId(body.teamId),
+    title: body.title,
+    ownerId: new Types.ObjectId(body.ownerId),
+    linkedTaskIds: body.linkedTaskIds?.map((id) => new Types.ObjectId(id)) ?? [],
+    status: body.status ?? 'OPEN',
+  });
+  return NextResponse.json(objective, { status: 201 });
+}
+
+const listQuery = z.object({
+  date: z.string(),
+  teamId: z.string(),
+});
+
+export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  const url = new URL(req.url);
+  let query: z.infer<typeof listQuery>;
+  try {
+    query = listQuery.parse({
+      date: url.searchParams.get('date'),
+      teamId: url.searchParams.get('teamId'),
+    });
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  if (session.teamId && session.teamId !== query.teamId) {
+    return problem(403, 'Forbidden', 'Wrong team');
+  }
+  await dbConnect();
+  const objectives = await Objective.find({
+    date: query.date,
+    teamId: new Types.ObjectId(query.teamId),
+  }).sort({ ownerId: 1 });
+  return NextResponse.json(objectives);
+}
+

--- a/src/app/dashboard/daily/page.tsx
+++ b/src/app/dashboard/daily/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function DailyDashboardPage() {
+  const [date, setDate] = useState(
+    new Date().toISOString().split('T')[0]
+  );
+  const [teamId, setTeamId] = useState('');
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    if (!teamId) return;
+    fetch(`/api/dashboard/daily?date=${date}&teamId=${teamId}`)
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, [date, teamId]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Daily Dashboard</h1>
+      <div className="space-x-2">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="border px-2 py-1"
+        />
+        <input
+          placeholder="Team ID"
+          value={teamId}
+          onChange={(e) => setTeamId(e.target.value)}
+          className="border px-2 py-1"
+        />
+      </div>
+      {data && (
+        <div className="space-y-4">
+          <div>
+            <h2 className="font-semibold">Summary</h2>
+            <ul className="list-disc pl-6">
+              {data.summary.map((s: any) => (
+                <li key={s.ownerId}>
+                  {s.ownerId}: {s.completed}/{s.total}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h2 className="font-semibold">Pending Objectives</h2>
+            <ul className="list-disc pl-6">
+              {data.pending.map((o: any) => (
+                <li key={o._id}>{o.title}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h2 className="font-semibold">Tasks Due Today</h2>
+            {data.tasks.map((group: any) => (
+              <div key={group.ownerId} className="pl-4">
+                <h3 className="font-medium">{group.ownerId}</h3>
+                <ul className="list-disc pl-6">
+                  {group.tasks.map((t: any) => (
+                    <li key={t._id}>{t.title}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/objectives/page.tsx
+++ b/src/app/objectives/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ObjectivesPage() {
+  const [date, setDate] = useState(
+    new Date().toISOString().split('T')[0]
+  );
+  const [teamId, setTeamId] = useState('');
+  const [objectives, setObjectives] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!teamId) return;
+    fetch(`/api/objectives?date=${date}&teamId=${teamId}`)
+      .then((res) => res.json())
+      .then(setObjectives)
+      .catch(() => setObjectives([]));
+  }, [date, teamId]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Objectives</h1>
+      <div className="space-x-2">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="border px-2 py-1"
+        />
+        <input
+          placeholder="Team ID"
+          value={teamId}
+          onChange={(e) => setTeamId(e.target.value)}
+          className="border px-2 py-1"
+        />
+      </div>
+      <ul className="list-disc pl-6">
+        {objectives.map((o) => (
+          <li key={o._id}>
+            {o.title} - {o.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add CRUD endpoints for objectives with team access checks
- implement daily dashboard API aggregating objectives and tasks
- scaffold objectives and dashboard pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68aacceca4688328a451efa2e810012b