### PR TITLE
feat: add task search API and UI

### DIFF
--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Task from '@/models/Task';
+import { auth } from '@/lib/auth';
+
+const querySchema = z.object({
+  q: z.string().optional(),
+  status: z
+    .union([z.string(), z.array(z.string())])
+    .transform((val) => (Array.isArray(val) ? val : val ? [val] : []))
+    .optional(),
+  tag: z
+    .union([z.string(), z.array(z.string())])
+    .transform((val) => (Array.isArray(val) ? val : val ? [val] : []))
+    .optional(),
+  dueFrom: z.coerce.date().optional(),
+  dueTo: z.coerce.date().optional(),
+  ownerId: z.string().optional(),
+  creatorId: z.string().optional(),
+  teamId: z.string().optional(),
+  visibility: z.enum(['PRIVATE', 'TEAM']).optional(),
+  sort: z.enum(['relevance', 'updatedAt', 'dueAt']).optional(),
+});
+
+function problem(status: number, title: string, detail: string) {
+  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
+}
+
+export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+
+  const url = new URL(req.url);
+  const raw: Record<string, string | string[]> = {};
+  url.searchParams.forEach((value, key) => {
+    if (raw[key]) {
+      raw[key] = Array.isArray(raw[key])
+        ? [...(raw[key] as string[]), value]
+        : [raw[key] as string, value];
+    } else {
+      raw[key] = value;
+    }
+  });
+
+  let query: z.infer<typeof querySchema>;
+  try {
+    query = querySchema.parse(raw);
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+
+  await dbConnect();
+
+  const filter: any = {};
+  if (query.ownerId) filter.ownerId = new Types.ObjectId(query.ownerId);
+  if (query.creatorId) filter.creatorId = new Types.ObjectId(query.creatorId);
+  if (query.status && query.status.length) filter.status = { $in: query.status };
+  if (query.dueFrom || query.dueTo) {
+    filter.dueAt = {};
+    if (query.dueFrom) filter.dueAt.$gte = query.dueFrom;
+    if (query.dueTo) filter.dueAt.$lte = query.dueTo;
+  }
+  if (query.tag && query.tag.length) filter.tags = { $in: query.tag };
+  if (query.visibility) filter.visibility = query.visibility;
+  if (query.teamId) filter.teamId = new Types.ObjectId(query.teamId);
+
+  const access: any[] = [
+    { participantIds: new Types.ObjectId(session.userId) },
+  ];
+  if (session.teamId) {
+    access.push({ visibility: 'TEAM', teamId: new Types.ObjectId(session.teamId) });
+  }
+
+  const useAtlas = process.env.ATLAS_SEARCH === 'true';
+
+  let results: any[] = [];
+  if (useAtlas && query.q) {
+    const pipeline: any[] = [
+      {
+        $search: {
+          index: 'tasks',
+          compound: {
+            should: [
+              {
+                text: {
+                  query: query.q!,
+                  path: ['title', 'description'],
+                },
+              },
+              {
+                text: {
+                  query: query.q!,
+                  path: 'comments.body',
+                },
+              },
+            ],
+          },
+          highlight: { path: ['title', 'description', 'comments.body'] },
+        },
+      },
+      {
+        $lookup: {
+          from: 'comments',
+          localField: '_id',
+          foreignField: 'taskId',
+          as: 'comments',
+        },
+      },
+      { $match: { $and: [filter, { $or: access }] } },
+      {
+        $project: {
+          title: 1,
+          description: 1,
+          status: 1,
+          tags: 1,
+          ownerId: 1,
+          creatorId: 1,
+          teamId: 1,
+          visibility: 1,
+          dueAt: 1,
+          highlights: { $meta: 'searchHighlights' },
+          score: { $meta: 'searchScore' },
+        },
+      },
+    ];
+    if (query.sort === 'updatedAt') {
+      pipeline.push({ $sort: { updatedAt: -1 } });
+    } else if (query.sort === 'dueAt') {
+      pipeline.push({ $sort: { dueAt: 1 } });
+    } else {
+      pipeline.push({ $sort: { score: { $meta: 'searchScore' } } });
+    }
+    results = await Task.aggregate(pipeline);
+  } else {
+    const mongoFilter: any = { ...filter };
+    if (query.q) mongoFilter.$text = { $search: query.q };
+    const sort: any = {};
+    if (query.q) sort.score = { $meta: 'textScore' };
+    if (query.sort === 'updatedAt') sort.updatedAt = -1;
+    if (query.sort === 'dueAt') sort.dueAt = 1;
+    results = await Task.find(
+      { $and: [mongoFilter, { $or: access }] },
+      query.q ? { score: { $meta: 'textScore' } } : undefined
+    ).sort(Object.keys(sort).length ? sort : { updatedAt: -1 });
+  }
+
+  const output = results.map((t: any) => {
+    let excerpt = '';
+    if (useAtlas && t.highlights) {
+      excerpt = t.highlights
+        .map((h: any) => h.texts.map((x: any) => x.value).join(''))
+        .join(' ... ');
+    } else {
+      excerpt = t.description ? t.description.slice(0, 120) : '';
+    }
+    return { ...t, excerpt };
+  });
+
+  return NextResponse.json({
+    results: output,
+    verification: {
+      q: query.q,
+      filters: {
+        status: query.status,
+        tag: query.tag,
+        dueFrom: query.dueFrom,
+        dueTo: query.dueTo,
+        ownerId: query.ownerId,
+        creatorId: query.creatorId,
+        teamId: query.teamId,
+        visibility: query.visibility,
+        sort: query.sort,
+      },
+    },
+  });
+}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,9 +27,17 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <nav className="p-2 border-b flex gap-4">
+        <nav className="p-2 border-b flex gap-4 items-center">
           <a href="/">Home</a>
           <a href="/notifications">🔔</a>
+          <form action="/search/tasks" method="GET" className="ml-auto">
+            <input
+              type="text"
+              name="q"
+              placeholder="Search tasks..."
+              className="border rounded px-2 py-1 text-sm"
+            />
+          </form>
         </nav>
         {children}
       </body>

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+interface SearchResult {
+  _id: string;
+  title: string;
+  excerpt: string;
+}
+
+export default function TaskSearchPage() {
+  const params = useSearchParams();
+  const [data, setData] = useState<{ results: SearchResult[]; verification: any }>();
+
+  useEffect(() => {
+    const qs = params.toString();
+    fetch(`/api/search/tasks?${qs}`).then((res) => res.json()).then(setData);
+  }, [params]);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lg mb-4">Task Search</h1>
+      <form method="GET" className="flex flex-wrap gap-2 mb-4">
+        <input
+          type="text"
+          name="q"
+          defaultValue={params.get('q') ?? ''}
+          placeholder="Search"
+          className="border rounded px-2 py-1"
+        />
+        <select
+          name="status"
+          multiple
+          defaultValue={params.getAll('status')}
+          className="border rounded px-2 py-1"
+        >
+          {['OPEN', 'IN_PROGRESS', 'IN_REVIEW', 'REVISIONS', 'FLOW_IN_PROGRESS', 'DONE'].map(
+            (s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            )
+          )}
+        </select>
+        <input
+          type="text"
+          name="tag"
+          defaultValue={params.get('tag') ?? ''}
+          placeholder="tag"
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          name="dueFrom"
+          defaultValue={params.get('dueFrom') ?? ''}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="date"
+          name="dueTo"
+          defaultValue={params.get('dueTo') ?? ''}
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          name="ownerId"
+          defaultValue={params.get('ownerId') ?? ''}
+          placeholder="ownerId"
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          name="creatorId"
+          defaultValue={params.get('creatorId') ?? ''}
+          placeholder="creatorId"
+          className="border rounded px-2 py-1"
+        />
+        <input
+          type="text"
+          name="teamId"
+          defaultValue={params.get('teamId') ?? ''}
+          placeholder="teamId"
+          className="border rounded px-2 py-1"
+        />
+        <select
+          name="visibility"
+          defaultValue={params.get('visibility') ?? ''}
+          className="border rounded px-2 py-1"
+        >
+          <option value="">Any visibility</option>
+          <option value="PRIVATE">PRIVATE</option>
+          <option value="TEAM">TEAM</option>
+        </select>
+        <select
+          name="sort"
+          defaultValue={params.get('sort') ?? 'relevance'}
+          className="border rounded px-2 py-1"
+        >
+          <option value="relevance">Relevance</option>
+          <option value="updatedAt">Updated</option>
+          <option value="dueAt">Due date</option>
+        </select>
+        <button type="submit" className="border rounded px-2 py-1">
+          Apply
+        </button>
+      </form>
+      {data?.verification && (
+        <p className="mb-2 text-sm text-gray-600">
+          Search for "{data.verification.q}" with filters applied
+        </p>
+      )}
+      <ul>
+        {data?.results?.map((t) => (
+          <li key={t._id} className="mb-4">
+            <div className="font-semibold">{t.title}</div>
+            {t.excerpt && (
+              <div
+                className="text-sm text-gray-700"
+                dangerouslySetInnerHTML={{ __html: t.excerpt }}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add GET /api/search/tasks with Atlas Search and text fallback
- enable header search box directing to task search results
- create task search page with filters, sorting, excerpts, and verification output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d155ec883289472d3710e1a4b66