### PR TITLE
feat: build tasks ui

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,12 +1,19 @@
 'use client';
-
 import { useEffect, useState } from 'react';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { StepsProgress } from '@/components/steps-progress';
 import useTaskChannel from '@/hooks/useTaskChannel';
 
 export default function TaskPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const [comments, setComments] = useState<any[]>([]);
   const [body, setBody] = useState('');
+  const [status, setStatus] = useState<
+    'OPEN' | 'IN_PROGRESS' | 'IN_REVIEW' | 'REVISIONS' | 'DONE'
+  >('OPEN');
 
   useEffect(() => {
     const load = async () => {
@@ -38,23 +45,80 @@ export default function TaskPage({ params }: { params: { id: string } }) {
   };
 
   return (
-    <div className="p-4 flex flex-col gap-2">
-      <h1>Task {id}</h1>
-      <ul className="flex flex-col gap-1">
-        {comments.map((c) => (
-          <li key={c._id}>{c.body}</li>
-        ))}
-      </ul>
-      <form onSubmit={submit} className="flex gap-2">
-        <input
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          className="border p-1 flex-1"
-        />
-        <button type="submit" className="bg-blue-500 text-white px-2">
-          Send
-        </button>
-      </form>
+    <div className="flex">
+      <main className="flex-1 p-4 space-y-4">
+        <header className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">Task {id}</h1>
+            <div className="flex items-center gap-2 text-sm text-gray-600 mt-1">
+              <Avatar fallback="A" />
+              <span>Alice</span>
+              <Badge>{new Date().toLocaleDateString()}</Badge>
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              disabled={status !== 'OPEN'}
+              onClick={() => setStatus('IN_PROGRESS')}
+            >
+              Start
+            </Button>
+            <Button
+              disabled={status !== 'IN_PROGRESS'}
+              onClick={() => setStatus('IN_REVIEW')}
+            >
+              Send for review
+            </Button>
+            <Button
+              disabled={status !== 'IN_REVIEW'}
+              onClick={() => setStatus('REVISIONS')}
+            >
+              Request changes
+            </Button>
+            <Button
+              disabled={!(status === 'IN_REVIEW' || status === 'REVISIONS')}
+              onClick={() => setStatus('DONE')}
+            >
+              Done
+            </Button>
+          </div>
+        </header>
+        <StepsProgress current={1} total={3} />
+        <section>
+          <h2 className="font-medium mb-2">Description</h2>
+          <p className="text-sm text-gray-600">Task description...</p>
+        </section>
+        <section>
+          <h2 className="font-medium mb-2">Attachments</h2>
+          <p className="text-sm text-gray-600">No attachments</p>
+        </section>
+        <section>
+          <h2 className="font-medium mb-2">Comments</h2>
+          <ul className="flex flex-col gap-1 mb-2">
+            {comments.map((c) => (
+              <li key={c._id}>{c.body}</li>
+            ))}
+          </ul>
+          <form onSubmit={submit} className="flex gap-2">
+            <Input
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Write a comment"
+            />
+            <Button type="submit">Send</Button>
+          </form>
+        </section>
+      </main>
+      <aside className="w-60 border-l p-4 space-y-4">
+        <div>
+          <h3 className="font-medium mb-2">Followers</h3>
+          <p className="text-sm text-gray-600">None</p>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">Tags</h3>
+          <p className="text-sm text-gray-600">-</p>
+        </div>
+      </aside>
     </div>
   );
 }

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -1,0 +1,119 @@
+'use client';
+import { useState } from 'react';
+import { Tabs } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { StepsProgress } from '@/components/steps-progress';
+import { z } from 'zod';
+
+const simpleSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  owner: z.string().min(1, 'Owner is required'),
+});
+
+const flowSchemas = [
+  z.object({ owner: z.string().min(1, 'Owner is required') }),
+  z.object({ description: z.string().min(1, 'Description is required') }),
+  z.object({ due: z.string().min(1, 'Due date is required') }),
+];
+
+export default function NewTaskPage() {
+  const [simple, setSimple] = useState({ title: '', owner: '' });
+  const [simpleError, setSimpleError] = useState<string | null>(null);
+
+  const submitSimple = (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = simpleSchema.safeParse(simple);
+    if (!res.success) {
+      setSimpleError(res.error.errors[0].message);
+      return;
+    }
+    alert('Submitted simple task');
+  };
+
+  const [step, setStep] = useState(1);
+  const [flow, setFlow] = useState({ owner: '', description: '', due: '' });
+  const [flowError, setFlowError] = useState<string | null>(null);
+
+  const next = () => {
+    const schema = flowSchemas[step - 1];
+    const key = ['owner', 'description', 'due'][step - 1] as 'owner' | 'description' | 'due';
+    const res = schema.safeParse({ [key]: flow[key] });
+    if (!res.success) {
+      setFlowError(res.error.errors[0].message);
+      return;
+    }
+    setFlowError(null);
+    if (step < 3) setStep(step + 1);
+    else alert('Flow complete');
+  };
+
+  const back = () => setStep((s) => Math.max(1, s - 1));
+
+  const flowContent = (
+    <div>
+      <StepsProgress current={step} total={3} />
+      {step === 1 && (
+        <div className="space-y-2">
+          <Input
+            placeholder="Owner"
+            value={flow.owner}
+            onChange={(e) => setFlow({ ...flow, owner: e.target.value })}
+          />
+        </div>
+      )}
+      {step === 2 && (
+        <Textarea
+          placeholder="Description"
+          value={flow.description}
+          onChange={(e) => setFlow({ ...flow, description: e.target.value })}
+        />
+      )}
+      {step === 3 && (
+        <Input
+          type="date"
+          value={flow.due}
+          onChange={(e) => setFlow({ ...flow, due: e.target.value })}
+        />
+      )}
+      {flowError && <p className="text-red-600 text-sm mt-2">{flowError}</p>}
+      <div className="flex gap-2 mt-4">
+        {step > 1 && <Button type="button" variant="outline" onClick={back}>Back</Button>}
+        <Button type="button" onClick={next}>{step < 3 ? 'Next' : 'Finish'}</Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="p-4">
+      <Tabs
+        items={[
+          {
+            value: 'simple',
+            label: 'Simple',
+            content: (
+              <form onSubmit={submitSimple} className="space-y-2">
+                <Input
+                  placeholder="Title"
+                  value={simple.title}
+                  onChange={(e) => setSimple({ ...simple, title: e.target.value })}
+                />
+                <Input
+                  placeholder="Owner"
+                  value={simple.owner}
+                  onChange={(e) => setSimple({ ...simple, owner: e.target.value })}
+                />
+                {simpleError && (
+                  <p className="text-red-600 text-sm">{simpleError}</p>
+                )}
+                <Button type="submit">Create</Button>
+              </form>
+            ),
+          },
+          { value: 'flow', label: 'Flow', content: flowContent },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -1,3 +1,73 @@
+'use client';
+import { useState } from 'react';
+import { TaskCard } from '@/components/task-card';
+import { Button } from '@/components/ui/button';
+
+const tasks = [
+  {
+    id: '1',
+    title: 'Design landing',
+    owner: 'Alice',
+    status: 'OPEN',
+    priority: 'HIGH',
+    due: '2024-06-01',
+    updatedAt: '2024-05-20',
+  },
+  {
+    id: '2',
+    title: 'Implement auth',
+    owner: 'Bob',
+    status: 'IN_PROGRESS',
+    priority: 'MEDIUM',
+    due: '2024-05-25',
+    updatedAt: '2024-05-23',
+  },
+];
+
 export default function TasksPage() {
-  return <h1 className="p-4">Tasks</h1>;
+  const [sort, setSort] = useState<'due' | 'updated'>('due');
+  const sorted = [...tasks].sort((a, b) =>
+    sort === 'due'
+      ? new Date(a.due).getTime() - new Date(b.due).getTime()
+      : new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
+  return (
+    <div className="flex">
+      <aside className="w-60 border-r p-4 space-y-6">
+        <div>
+          <div className="font-medium mb-2">Filters</div>
+          <div className="flex flex-col gap-1 text-sm">
+            <label className="flex items-center gap-2">
+              <input type="checkbox" /> Open
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" /> In Progress
+            </label>
+          </div>
+        </div>
+        <div>
+          <div className="font-medium mb-2">Sort</div>
+          <div className="flex flex-col gap-2">
+            <Button
+              variant={sort === 'due' ? 'default' : 'outline'}
+              onClick={() => setSort('due')}
+            >
+              Due (asc)
+            </Button>
+            <Button
+              variant={sort === 'updated' ? 'default' : 'outline'}
+              onClick={() => setSort('updated')}
+            >
+              Updated (desc)
+            </Button>
+          </div>
+        </div>
+      </aside>
+      <main className="flex-1 p-4 flex flex-col gap-2">
+        {sorted.map((t) => (
+          <TaskCard key={t.id} task={{ ...t, due: new Date(t.due).toLocaleDateString() }} />
+        ))}
+      </main>
+    </div>
+  );
 }

--- a/src/components/steps-progress.tsx
+++ b/src/components/steps-progress.tsx
@@ -1,0 +1,19 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export function StepsProgress({ current, total }: { current: number; total: number }) {
+  return (
+    <div className="flex items-center gap-2 mb-4">
+      {Array.from({ length: total }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            'h-2 flex-1 rounded-full',
+            i < current ? 'bg-blue-600' : 'bg-gray-200'
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -1,0 +1,33 @@
+'use client';
+import * as React from 'react';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+
+interface TaskCardProps {
+  task: {
+    id: string;
+    title: string;
+    owner: string;
+    ownerAvatar?: string;
+    status: string;
+    priority: string;
+    due: string;
+  };
+}
+
+export function TaskCard({ task }: TaskCardProps) {
+  return (
+    <div className="border rounded-md p-4 flex justify-between items-center">
+      <div>
+        <div className="font-medium mb-2">{task.title}</div>
+        <div className="flex items-center gap-2 text-sm text-gray-600">
+          <Avatar src={task.ownerAvatar} fallback={task.owner.charAt(0)} />
+          <span>{task.owner}</span>
+          <Badge>{task.status}</Badge>
+          <Badge variant="secondary">{task.priority}</Badge>
+          <Badge>{task.due}</Badge>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,27 @@
+'use client';
+import * as React from 'react';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+
+export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
+  src?: string;
+  fallback?: string;
+}
+
+export function Avatar({ src, fallback, className, ...props }: AvatarProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-gray-200 text-sm',
+        className
+      )}
+      {...props}
+    >
+      {src ? (
+        <Image src={src} alt={fallback || 'avatar'} width={32} height={32} />
+      ) : (
+        <span>{fallback}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,28 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: 'default' | 'secondary';
+}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={cn(
+          'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
+          variant === 'default'
+            ? 'bg-gray-100 text-gray-800'
+            : 'bg-blue-100 text-blue-800',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Badge.displayName = 'Badge';
+
+export { Badge };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,28 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'outline';
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none h-9 px-4 py-2',
+          variant === 'default'
+            ? 'bg-blue-600 text-white hover:bg-blue-600/90'
+            : 'border border-gray-300 hover:bg-gray-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,36 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TabItem {
+  value: string;
+  label: string;
+  content: React.ReactNode;
+}
+
+export function Tabs({ items, defaultValue }: { items: TabItem[]; defaultValue?: string }) {
+  const [value, setValue] = React.useState(defaultValue || items[0]?.value);
+  const active = items.find((i) => i.value === value);
+  return (
+    <div>
+      <div className="flex border-b mb-4">
+        {items.map((i) => (
+          <button
+            key={i.value}
+            type="button"
+            className={cn(
+              'px-3 py-2 text-sm',
+              value === i.value
+                ? 'border-b-2 border-blue-600 text-blue-600'
+                : 'text-gray-500'
+            )}
+            onClick={() => setValue(i.value)}
+          >
+            {i.label}
+          </button>
+        ))}
+      </div>
+      <div>{active?.content}</div>
+    </div>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+'use client';
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'flex w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add shadcn-style components for buttons, inputs, badges, tabs, avatar and progress
- implement task list with filter rail and sorting, plus card UI
- add new task creation tabs and flow with zod validation
- expand task detail with header, quick actions, and live comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f33b4608328b83d7225385153ba