### PR TITLE
Use crypto.randomInt for OTP generation

### DIFF
--- a/src/lib/otp.test.ts
+++ b/src/lib/otp.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { hashOtp, verifyOtp, createOtpToken, verifyAndConsumeOtp } from './otp';
+import crypto from 'crypto';
+import {
+  generateOtp,
+  hashOtp,
+  verifyOtp,
+  createOtpToken,
+  verifyAndConsumeOtp,
+} from './otp';
 
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
@@ -41,6 +48,14 @@ describe('otp helpers', () => {
   beforeEach(() => {
     tokens.length = 0;
     rates.clear();
+  });
+
+  it('generates a 6-digit code using crypto.randomInt', () => {
+    const spy = vi.spyOn(crypto, 'randomInt').mockReturnValue(42);
+    const otp = generateOtp();
+    expect(spy).toHaveBeenCalledWith(0, 1_000_000);
+    expect(otp).toBe('000042');
+    spy.mockRestore();
   });
 
   it('hashes and verifies codes', () => {

--- a/src/lib/otp.ts
+++ b/src/lib/otp.ts
@@ -9,7 +9,7 @@ const MAX_REQUESTS_PER_HOUR = 5;
 const MAX_ATTEMPTS = 5;
 
 export function generateOtp(): string {
-  return Math.floor(100000 + Math.random() * 900000).toString();
+  return crypto.randomInt(0, 1_000_000).toString().padStart(6, '0');
 }
 
 export function hashOtp(code: string): string {


### PR DESCRIPTION
## Summary
- replace `Math.random` with `crypto.randomInt` and pad to 6 digits for OTP generation
- add unit test ensuring OTP generation uses `crypto.randomInt`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden for @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68ab63f1db5083289652a0edd8ecc3ab