### PR TITLE
refactor: centralize problem helper

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -11,6 +11,7 @@ import ActivityLog from '@/models/ActivityLog';
 import { parseMentions } from '@/lib/mentions';
 import { emitCommentCreated } from '@/lib/ws';
 import { notifyMention } from '@/lib/notify';
+import { problem } from '@/lib/http';
 
 const postSchema = z.object({
   taskId: z.string(),
@@ -22,10 +23,6 @@ const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 export async function POST(req: Request) {
   const session = await auth();

--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -5,15 +5,12 @@ import dbConnect from '@/lib/db';
 import Objective from '@/models/Objective';
 import Task from '@/models/Task';
 import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
 
 const querySchema = z.object({
   date: z.string(),
   teamId: z.string(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 export async function GET(req: Request) {
   const session = await auth();

--- a/src/app/api/objectives/[id]/route.ts
+++ b/src/app/api/objectives/[id]/route.ts
@@ -2,10 +2,7 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
 import Objective from '@/models/Objective';
 import { auth } from '@/lib/auth';
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
+import { problem } from '@/lib/http';
 
 export async function PATCH(
   req: Request,

--- a/src/app/api/objectives/route.ts
+++ b/src/app/api/objectives/route.ts
@@ -4,6 +4,7 @@ import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Objective from '@/models/Objective';
 import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
 
 const upsertSchema = z.object({
   id: z.string().optional(),
@@ -14,10 +15,6 @@ const upsertSchema = z.object({
   linkedTaskIds: z.array(z.string()).optional(),
   status: z.enum(['OPEN', 'DONE']).optional(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 export async function POST(req: Request) {
   const session = await auth();

--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -4,6 +4,7 @@ import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
 import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
 
 const querySchema = z.object({
   q: z.string().optional(),
@@ -23,10 +24,6 @@ const querySchema = z.object({
   visibility: z.enum(['PRIVATE', 'TEAM']).optional(),
   sort: z.enum(['relevance', 'updatedAt', 'dueAt']).optional(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 export async function GET(req: Request) {
   const session = await auth();

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -7,6 +7,7 @@ import ActivityLog from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { canReadTask, canWriteTask } from '@/lib/access';
 import { scheduleTaskJobs } from '@/lib/agenda';
+import { problem } from '@/lib/http';
 
 const patchSchema = z.object({
   title: z.string().optional(),
@@ -31,10 +32,6 @@ const patchSchema = z.object({
   ).optional(),
   currentStepIndex: z.number().int().optional(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 function computeParticipants(task: any) {
   const ids = new Set<string>();

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -11,14 +11,11 @@ import {
   notifyFlowAdvanced,
   notifyTaskClosed,
 } from '@/lib/notify';
+import { problem } from '@/lib/http';
 
 const bodySchema = z.object({
   action: z.enum(['START', 'SEND_FOR_REVIEW', 'REQUEST_CHANGES', 'DONE']),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 export async function POST(req: Request, { params }: { params: { id: string } }) {
   const session = await auth();

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -7,6 +7,7 @@ import ActivityLog from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { notifyAssignment, notifyMention } from '@/lib/notify';
 import { scheduleTaskJobs } from '@/lib/agenda';
+import { problem } from '@/lib/http';
 
 const stepSchema = z.object({
   ownerId: z.string(),
@@ -29,10 +30,6 @@ const createTaskSchema = z.object({
   dueAt: z.coerce.date().optional(),
   steps: z.array(stepSchema).optional(),
 });
-
-function problem(status: number, title: string, detail: string) {
-  return NextResponse.json({ type: 'about:blank', title, status, detail }, { status });
-}
 
 function computeParticipants(data: { creatorId: string; ownerId: string; helpers?: string[]; mentions?: string[]; steps?: { ownerId: string }[] }) {
   const ids = new Set<string>();

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+export function problem(status: number, title: string, detail: string) {
+  return NextResponse.json(
+    { type: 'about:blank', title, status, detail },
+    { status }
+  );
+}
+


### PR DESCRIPTION
## Summary
- add shared `problem` helper for JSON Problem responses
- use shared helper across API routes

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68ab651aaa1c8328873de2f4cb393685