### PR TITLE
fix: use available agenda version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "next": "15.5.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "agenda": "^6.0.0"
+        "agenda": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "next-auth": "^5.0.0",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
-    "agenda": "^6.0.0"
+    "agenda": "^5.0.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- use published agenda version to resolve install failures

## Testing
- `npm install` *(fails: 403 Forbidden for packages)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68af762556108328a44599ab49b8ac0b