### PR TITLE
chore: pin next-auth to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0",
     "next": "15.5.0",
     "mongoose": "^8.0.0",
-    "next-auth": "^5.0.0",
+    "next-auth": "^4.24.5",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
     "agenda": "^5.0.0"


### PR DESCRIPTION
## Summary
- pin next-auth to the latest v4 release to avoid requesting nonexistent v5

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b09b4853688328b14431194e7dbfa5