### PR TITLE
fix: import Mongoose Types at runtime

### DIFF
--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,4 +1,4 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import { Schema, model, models, type Document, Types } from 'mongoose';
 
 export type TaskStatus =
   | 'OPEN'


### PR DESCRIPTION
## Summary
- import Mongoose `Types` as a runtime value so Task pre-save hook can instantiate ObjectIds

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b09fea7f1c8328b1b15ed4361fdc83