### PR TITLE
refactor auth hashing for edge runtime

### DIFF
--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { createHash } from 'crypto';
 import { verifyAndConsumeOtp } from '@/lib/otp';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 import { signIn } from '@/lib/auth';
+import { sha256 } from '@/lib/hash';
 
 export async function POST(req: Request) {
   const { email, code } = await req.json();
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
         name: email.split('@')[0],
         email,
         username: email,
-        password: createHash('sha256').update('changeme').digest('hex'),
+        password: await sha256('changeme'),
       },
     },
     { upsert: true }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
-import { createHash } from 'crypto';
+import { sha256 } from '@/lib/hash';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 
@@ -44,7 +44,7 @@ export const authOptions = {
         await dbConnect();
         const user = await User.findOne({ username: credentials.username });
         if (!user) return null;
-        const hashed = createHash('sha256').update(credentials.password).digest('hex');
+        const hashed = await sha256(credentials.password);
         if (user.password !== hashed) return null;
         return {
           id: user._id.toString(),

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,6 @@
+export async function sha256(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,5 +1,5 @@
 import { Schema, model, models, type Document, type Types } from 'mongoose';
-import { createHash } from 'crypto';
+import { sha256 } from '@/lib/hash';
 
 export interface IUser extends Document {
   name: string;
@@ -40,12 +40,11 @@ const userSchema = new Schema<IUser>(
   { timestamps: true }
 );
 
-userSchema.pre('save', async function (next) {
+userSchema.pre('save', async function () {
   if (this.isModified('password')) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (this as any).password = createHash('sha256').update((this as any).password).digest('hex');
+    (this as any).password = await sha256((this as any).password);
   }
-  next();
 });
 
 export default models.User || model<IUser>('User', userSchema);


### PR DESCRIPTION
## Summary
- use Web Crypto API for password hashing
- hash user passwords on save and OTP verification with Web Crypto helper

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a18acb2483288cead89ffee81f94