### PR TITLE
chore: update next-auth dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0",
     "next": "15.5.0",
     "mongoose": "^8.0.0",
-    "next-auth": "^4.24.5",
+    "next-auth": "^5.0.0",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
     "agenda": "^5.0.0"


### PR DESCRIPTION
## Summary
- update next-auth to v5 so NextAuth handlers are available

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)
- `npm test` (fails: sh: 1: vitest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b0a3688ba483288cc9a392c146c859