### PR TITLE
chore: downgrade next-auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0",
     "next": "15.5.0",
     "mongoose": "^8.0.0",
-    "next-auth": "^5.0.0",
+    "next-auth": "^4.24.5",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
     "agenda": "^5.0.0"


### PR DESCRIPTION
## Summary
- downgrade next-auth to stable 4.x release

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a6825f048328b65cb449dc633866