### PR TITLE
chore: use stable next-auth v4

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-export { auth as middleware } from './src/lib/auth';
+export { default } from 'next-auth/middleware';
 
 export const config = {
   matcher: ['/((?!api/auth|signin).*)'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "next": "15.5.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "agenda": "^5.0.0"
+        "agenda": "^5.0.0",
+        "next-auth": "^4.24.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-dom": "19.1.0",
     "next": "15.5.0",
     "mongoose": "^8.0.0",
-    "next-auth": "^4.24.5",
+    "next-auth": "^4.24.7",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
     "agenda": "^5.0.0"

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -49,5 +49,6 @@ export async function POST(req: Request) {
     },
     { upsert: true }
   );
-  return signIn('credentials', { email, otpVerified: true, redirectTo: '/tasks' });
-}
+    await signIn('credentials', { email, otpVerified: true, callbackUrl: '/tasks', redirect: false });
+    return NextResponse.redirect(new URL('/tasks', req.url));
+  }


### PR DESCRIPTION
## Summary
- revert NextAuth dependency to latest stable v4 release
- rework auth config for NextAuth v4 and use built-in middleware
- adjust OTP verification flow to use callbackUrl and redirect

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a95b99e08328a6122374b905fcfc