### PR TITLE
Ensure step owners are included as task participants

### DIFF
--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -89,6 +89,7 @@ taskSchema.pre('save', function (next) {
   ids.add(this.ownerId.toString());
   this.helpers?.forEach((h) => ids.add(h.toString()));
   this.mentions?.forEach((m) => ids.add(m.toString()));
+  this.steps?.forEach((s) => ids.add(s.ownerId.toString()));
   this.participantIds = Array.from(ids).map((id) => new Types.ObjectId(id));
   next();
 });


### PR DESCRIPTION
## Summary
- ensure `taskSchema` pre-save hook adds step owner IDs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8641f3c8328bd782a8c9f6b93c3