### PR TITLE
Validate step owners belong to organization

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -92,6 +92,17 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
       return problem(400, 'Invalid request', 'Owner must be in your organization');
     }
   }
+  if (body.steps) {
+    for (const s of body.steps) {
+      const stepOwner = await User.findOne({
+        _id: new Types.ObjectId(s.ownerId),
+        organizationId: new Types.ObjectId(session.organizationId),
+      });
+      if (!stepOwner) {
+        return problem(400, 'Invalid request', 'Step owner must be in your organization');
+      }
+    }
+  }
   Object.assign(task, {
     ...body,
     ownerId: body.ownerId ? new Types.ObjectId(body.ownerId) : task.ownerId,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -76,6 +76,16 @@ export async function POST(req: Request) {
   if (!owner) {
     return problem(400, 'Invalid request', 'Owner must be in your organization');
   }
+  // ensure each step owner is from same organization
+  for (const s of steps) {
+    const stepOwner = await User.findOne({
+      _id: new Types.ObjectId(s.ownerId),
+      organizationId: new Types.ObjectId(session.organizationId),
+    });
+    if (!stepOwner) {
+      return problem(400, 'Invalid request', 'Step owner must be in your organization');
+    }
+  }
   const task = await Task.create({
     title: body.title,
     description: body.description,


### PR DESCRIPTION
## Summary
- check that each step owner exists in the same organization when creating tasks
- mirror step owner validation when updating tasks

## Testing
- `npm test` *(fails: vitest not found and dependencies forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b0b93934f08328bbc1001f07c9f0da