### PR TITLE
feat: integrate dnd-kit for kanban drag-and-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "next-auth": "^4.24.7",
     "resend": "^2.0.0",
     "zod": "^3.23.8",
-    "agenda": "^5.0.0"
+    "agenda": "^5.0.0",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -1,5 +1,20 @@
 'use client';
+import { useState } from 'react';
 import TaskCard, { Task } from './task-card';
+import {
+  DndContext,
+  DragEndEvent,
+  DragStartEvent,
+  DragOverEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDroppable,
+  DragOverlay,
+} from '@dnd-kit/core';
+import { SortableContext } from '@dnd-kit/sortable';
+import { motion } from 'framer-motion';
+import { springTransition } from '@/lib/motion';
 
 interface KanbanBoardProps {
   tasks: Task[];
@@ -13,36 +28,74 @@ const columns: { key: Task['status']; title: string; color: string }[] = [
 ];
 
 export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>, status: Task['status']) => {
-    e.preventDefault();
-    const id = e.dataTransfer.getData('text/plain');
-    if (id) onMove(id, status);
+  const sensors = useSensors(useSensor(PointerSensor));
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [overId, setOverId] = useState<Task['status'] | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
   };
 
+  const handleDragOver = (event: DragOverEvent) => {
+    const status = event.over?.id as Task['status'] | undefined;
+    setOverId(status ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    setActiveId(null);
+    if (over) {
+      const status = over.id as Task['status'];
+      onMove(active.id as string, status);
+    }
+    setOverId(null);
+  };
+
+  const activeTask = tasks.find((t) => t.id === activeId) || null;
+
   return (
-    <div className="flex gap-4 h-full">
-      {columns.map((col) => (
-        <div
-          key={col.key}
-          className="flex-1 flex flex-col rounded-md bg-[var(--color-surface)] border border-[var(--color-border)]"
-          onDragOver={(e) => e.preventDefault()}
-          onDrop={(e) => handleDrop(e, col.key)}
-        >
-          <h2
-            className="p-3 text-sm font-medium border-b border-[var(--color-border)]"
-            style={{ backgroundColor: col.color, color: '#fff' }}
-          >
-            {col.title}
-          </h2>
-          <div className="p-3 space-y-2 flex-1 overflow-auto">
-            {tasks
-              .filter((t) => t.status === col.key)
-              .map((t) => (
-                <TaskCard key={t.id} task={t} />
-              ))}
-          </div>
-        </div>
-      ))}
-    </div>
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex gap-4 h-full">
+        {columns.map((col) => {
+          const { setNodeRef, isOver } = useDroppable({ id: col.key });
+          const columnTasks = tasks.filter((t) => t.status === col.key);
+          const highlight = isOver || overId === col.key;
+          return (
+            <motion.div
+              key={col.key}
+              ref={setNodeRef}
+              className="flex-1 flex flex-col rounded-md bg-[var(--color-surface)] border border-[var(--color-border)]"
+              animate={{ scale: highlight ? 1.02 : 1 }}
+              style={highlight ? { boxShadow: `0 0 0 2px ${col.color}` } : undefined}
+              transition={springTransition}
+            >
+              <motion.h2
+                className="p-3 text-sm font-medium border-b border-[var(--color-border)]"
+                style={{ backgroundColor: col.color, color: '#fff' }}
+                animate={{ scale: highlight ? 1.05 : 1 }}
+                transition={springTransition}
+              >
+                {col.title}
+              </motion.h2>
+              <SortableContext items={columnTasks.map((t) => t.id)}>
+                <div className="p-3 space-y-2 flex-1 overflow-auto">
+                  {columnTasks.map((t) => (
+                    <TaskCard key={t.id} task={t} />
+                  ))}
+                </div>
+              </SortableContext>
+            </motion.div>
+          );
+        })}
+      </div>
+      <DragOverlay dropAnimation={null}>
+        {activeTask ? <TaskCard task={activeTask} dragOverlay /> : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,8 @@
+export const springTransition = {
+  type: 'spring',
+  stiffness: 500,
+  damping: 30,
+  mass: 0.5,
+};
+
+export const overlayTransition = springTransition;


### PR DESCRIPTION
## Summary
- add drag-and-drop dependencies and centralized motion config
- refactor kanban board to use dnd-kit with framer-motion animations
- highlight drop zones and render spring-animated ghost card

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b0bd9877c88328a298f75fedd04bc8