### PR TITLE
feat: add animated draggable task cards

### DIFF
--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -12,7 +12,6 @@ import {
   useDroppable,
   DragOverlay,
 } from '@dnd-kit/core';
-import { SortableContext } from '@dnd-kit/sortable';
 import { motion } from 'framer-motion';
 import { springTransition } from '@/lib/motion';
 
@@ -82,13 +81,11 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
               >
                 {col.title}
               </motion.h2>
-              <SortableContext items={columnTasks.map((t) => t.id)}>
-                <div className="p-3 space-y-2 flex-1 overflow-auto">
-                  {columnTasks.map((t) => (
-                    <TaskCard key={t.id} task={t} />
-                  ))}
-                </div>
-              </SortableContext>
+              <div className="p-3 space-y-2 flex-1 overflow-auto">
+                {columnTasks.map((t) => (
+                  <TaskCard key={t.id} task={t} />
+                ))}
+              </div>
             </motion.div>
           );
         })}

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -1,8 +1,8 @@
 'use client';
+
 import { useMemo } from 'react';
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-import { motion } from 'framer-motion';
+import { useDraggable } from '@dnd-kit/core';
+import { motion, useReducedMotion, type MotionStyle } from 'framer-motion';
 import { springTransition } from '@/lib/motion';
 
 export interface Task {
@@ -17,10 +17,13 @@ export interface Task {
 
 interface TaskCardProps {
   task: Task;
+  /** When true the card is rendered inside a drag overlay ghost */
   dragOverlay?: boolean;
 }
 
 export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
+  const prefersReducedMotion = useReducedMotion();
+
   const priorityColor = useMemo(() => {
     switch (task.priority) {
       case 'High':
@@ -43,47 +46,41 @@ export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
     }
   }, [task.status]);
 
-  if (dragOverlay) {
-    return (
-      <motion.div
-        className="bg-[var(--color-surface)] rounded-md border border-[var(--color-border)] p-3 shadow-sm"
-        transition={springTransition}
-      >
-        <div className="text-sm font-medium text-[var(--color-text)]">{task.title}</div>
-        <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
-          <span>{task.assignee}</span>
-          <span
-            className="px-2 py-0.5 rounded-full text-white"
-            style={{ backgroundColor: priorityColor }}
-          >
-            {task.priority}
-          </span>
-          <span
-            className="px-2 py-0.5 rounded-full text-white"
-            style={{ backgroundColor: statusColor }}
-          >
-            {task.status === 'inprogress' ? 'In Progress' : task.status === 'todo' ? 'To Do' : 'Done'}
-          </span>
-        </div>
-      </motion.div>
-    );
-  }
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: task.id });
 
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: task.id });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  } as React.CSSProperties;
+  const style: MotionStyle | undefined = transform
+    ? { x: transform.x, y: transform.y }
+    : undefined;
+
+  const variants = {
+    initial: { scale: 1, rotateX: 0, rotateY: 0 },
+    hover: prefersReducedMotion
+      ? { scale: 1 }
+      : { scale: 1.03, rotateX: -2, rotateY: 2 },
+    press: prefersReducedMotion
+      ? { scale: 0.97 }
+      : { scale: 0.97, rotateX: 2, rotateY: -2 },
+    dragging: prefersReducedMotion
+      ? { scale: 1.02 }
+      : { scale: 1.05, rotateX: 0, rotateY: 0 },
+  } as const;
 
   return (
     <motion.div
-      ref={setNodeRef}
-      style={style}
-      className={`bg-[var(--color-surface)] rounded-md border border-[var(--color-border)] p-3 shadow-sm hover:shadow transition ${isDragging ? 'opacity-50' : ''}`}
-      {...attributes}
-      {...listeners}
+      ref={dragOverlay ? undefined : setNodeRef}
+      layoutId={`task-${task.id}`}
+      style={!dragOverlay ? style : undefined}
+      className={`bg-[var(--color-surface)] rounded-md border border-[var(--color-border)] p-3 shadow-sm transition
+ ${isDragging && !dragOverlay ? 'opacity-50' : ''}`}
+      variants={variants}
+      initial="initial"
+      animate={isDragging ? 'dragging' : 'initial'}
+      whileHover={dragOverlay ? undefined : 'hover'}
+      whileTap={dragOverlay ? undefined : 'press'}
       transition={springTransition}
+      {...(dragOverlay ? {} : attributes)}
+      {...(dragOverlay ? {} : listeners)}
     >
       <div className="text-sm font-medium text-[var(--color-text)]">{task.title}</div>
       <div className="mt-2 flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
@@ -104,3 +101,4 @@ export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
     </motion.div>
   );
 }
+


### PR DESCRIPTION
## Summary
- animate task cards with framer-motion and dnd-kit draggable
- simplify kanban board rendering without sortable context

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b0be77ebb0832891947f809170c080