### PR TITLE
feat: replace task modal with dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "agenda": "^5.0.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
-    "framer-motion": "^11.0.0"
+    "framer-motion": "^11.0.0",
+    "@radix-ui/react-dialog": "^1.0.5"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/components/create-task-modal.tsx
+++ b/src/components/create-task-modal.tsx
@@ -1,8 +1,10 @@
 'use client';
 import { useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
 import type { Task } from './kanban/task-card';
 
 interface CreateTaskModalProps {
@@ -19,6 +21,7 @@ export default function CreateTaskModal({ open, onClose, onCreate }: CreateTaskM
     assignee: '',
     due: '',
   });
+  const prefersReducedMotion = useReducedMotion();
   const [steps, setSteps] = useState<
     { assignee: string; description: string; due: string }[]
   >([]);
@@ -67,13 +70,16 @@ export default function CreateTaskModal({ open, onClose, onCreate }: CreateTaskM
     onClose();
   };
 
-  if (!open) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
-      <div className="w-full max-w-md rounded-md bg-[var(--color-surface)] p-6 shadow-lg">
-        <h2 className="mb-4 text-lg font-medium text-[var(--color-text)]">Create Task</h2>
-        <form className="space-y-4" onSubmit={handleSubmit}>
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent>
+        <motion.div
+          initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={prefersReducedMotion ? { duration: 0 } : { type: 'spring', duration: 0.3 }}
+        >
+          <h2 className="mb-4 text-lg font-medium text-[var(--color-text)]">Create Task</h2>
+          <form className="space-y-4" onSubmit={handleSubmit}>
           <Input
             placeholder="Title"
             value={form.title}
@@ -155,7 +161,8 @@ export default function CreateTaskModal({ open, onClose, onCreate }: CreateTaskM
             <Button type="submit">Create</Button>
           </div>
         </form>
-      </div>
-    </div>
+      </motion.div>
+    </DialogContent>
+  </Dialog>
   );
 }

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 
 interface TopbarProps {
@@ -6,11 +8,41 @@ interface TopbarProps {
 }
 
 export default function Topbar({ onNewTask }: TopbarProps) {
+  const [ripples, setRipples] = useState<{ id: number; x: number; y: number }[]>([]);
+  const MotionButton = motion(Button);
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (!onNewTask) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const id = Date.now();
+    setRipples((r) => [...r, { id, x, y }]);
+    setTimeout(() => setRipples((r) => r.filter((rip) => rip.id !== id)), 600);
+    onNewTask();
+  };
+
   return (
     <header className="h-14 flex items-center justify-between px-4 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
       <h1 className="font-semibold text-lg text-[var(--color-text)]">Tasks</h1>
       {onNewTask && (
-        <Button onClick={onNewTask}>New Task</Button>
+        <MotionButton
+          onClick={handleClick}
+          whileTap={{ scale: 0.95 }}
+          className="relative overflow-hidden"
+        >
+          New Task
+          {ripples.map((r) => (
+            <motion.span
+              key={r.id}
+              className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/30"
+              style={{ left: r.x, top: r.y, width: 20, height: 20 }}
+              initial={{ opacity: 0.5, scale: 0 }}
+              animate={{ opacity: 0, scale: 8 }}
+              transition={{ duration: 0.6, ease: 'easeOut' }}
+            />
+          ))}
+        </MotionButton>
       )}
     </header>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 z-50 bg-black/30', className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-md bg-[var(--color-surface)] p-6 shadow-lg focus:outline-none',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogTrigger, DialogContent, DialogClose };


### PR DESCRIPTION
## Summary
- replace manual create-task modal with shadcn Dialog and framer-motion entrance animation
- add ripple/scale feedback to "New Task" trigger button
- expose reusable Dialog UI primitive

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b11ac24cb08328967dcfab3d8c3af5