### PR TITLE
feat: centralize motion constants and reduce motion

### DIFF
--- a/src/components/create-task-modal.tsx
+++ b/src/components/create-task-modal.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
+import { spring, timing } from '@/lib/motion';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -76,7 +77,7 @@ export default function CreateTaskModal({ open, onClose, onCreate }: CreateTaskM
         <motion.div
           initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
-          transition={prefersReducedMotion ? { duration: 0 } : { type: 'spring', duration: 0.3 }}
+          transition={prefersReducedMotion ? timing.settle : spring.ghost}
         >
           <h2 className="mb-4 text-lg font-medium text-[var(--color-text)]">Create Task</h2>
           <form className="space-y-4" onSubmit={handleSubmit}>

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -12,8 +12,8 @@ import {
   useDroppable,
   DragOverlay,
 } from '@dnd-kit/core';
-import { motion } from 'framer-motion';
-import { springTransition } from '@/lib/motion';
+import { motion, useReducedMotion } from 'framer-motion';
+import { spring, timing } from '@/lib/motion';
 
 interface KanbanBoardProps {
   tasks: Task[];
@@ -30,6 +30,7 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
   const sensors = useSensors(useSensor(PointerSensor));
   const [activeId, setActiveId] = useState<string | null>(null);
   const [overId, setOverId] = useState<Task['status'] | null>(null);
+  const prefersReducedMotion = useReducedMotion();
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);
@@ -69,15 +70,27 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
               key={col.key}
               ref={setNodeRef}
               className="flex-1 flex flex-col rounded-md bg-[var(--color-surface)] border border-[var(--color-border)]"
-              animate={{ scale: highlight ? 1.02 : 1 }}
+              animate={
+                highlight
+                  ? prefersReducedMotion
+                    ? { opacity: 0.95 }
+                    : { scale: 1.02 }
+                  : { opacity: 1, scale: 1 }
+              }
               style={highlight ? { boxShadow: `0 0 0 2px ${col.color}` } : undefined}
-              transition={springTransition}
+              transition={prefersReducedMotion ? timing.settle : spring.lift}
             >
               <motion.h2
                 className="p-3 text-sm font-medium border-b border-[var(--color-border)]"
                 style={{ backgroundColor: col.color, color: '#fff' }}
-                animate={{ scale: highlight ? 1.05 : 1 }}
-                transition={springTransition}
+                animate={
+                  highlight
+                    ? prefersReducedMotion
+                      ? { opacity: 1 }
+                      : { scale: 1.05 }
+                    : { opacity: 1, scale: 1 }
+                }
+                transition={prefersReducedMotion ? timing.settle : spring.lift}
               >
                 {col.title}
               </motion.h2>

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { motion, useReducedMotion, type MotionStyle } from 'framer-motion';
-import { springTransition } from '@/lib/motion';
+import { spring, timing } from '@/lib/motion';
 
 export interface Task {
   id: string;
@@ -78,7 +78,7 @@ export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
       animate={isDragging ? 'dragging' : 'initial'}
       whileHover={dragOverlay ? undefined : 'hover'}
       whileTap={dragOverlay ? undefined : 'press'}
-      transition={springTransition}
+      transition={prefersReducedMotion ? timing.settle : dragOverlay ? spring.ghost : spring.lift}
       {...(dragOverlay ? {} : attributes)}
       {...(dragOverlay ? {} : listeners)}
     >

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
+import { timing } from '@/lib/motion';
 
 interface TopbarProps {
   onNewTask?: () => void;
@@ -9,6 +10,7 @@ interface TopbarProps {
 
 export default function Topbar({ onNewTask }: TopbarProps) {
   const [ripples, setRipples] = useState<{ id: number; x: number; y: number }[]>([]);
+  const prefersReducedMotion = useReducedMotion();
   const MotionButton = motion(Button);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -38,8 +40,8 @@ export default function Topbar({ onNewTask }: TopbarProps) {
               className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/30"
               style={{ left: r.x, top: r.y, width: 20, height: 20 }}
               initial={{ opacity: 0.5, scale: 0 }}
-              animate={{ opacity: 0, scale: 8 }}
-              transition={{ duration: 0.6, ease: 'easeOut' }}
+              animate={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 8 }}
+              transition={timing.settle}
             />
           ))}
         </MotionButton>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -3,7 +3,8 @@
 import * as React from 'react'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
 import { cn } from '@/lib/utils'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
+import { timing } from '@/lib/motion'
 
 const TabsContext = React.createContext<{ value: string }>({ value: '' })
 
@@ -57,7 +58,7 @@ const TabsTrigger = React.forwardRef<
         <motion.span
           layoutId="tab-indicator"
           className="absolute bottom-0 left-0 right-0 h-0.5 bg-current"
-          transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+          transition={timing.inkBar}
         />
       )}
       <span className="pointer-events-none absolute left-1/2 bottom-0 h-0.5 w-0 -translate-x-1/2 bg-current transition-[width] duration-300 ease-out group-hover:w-full group-data-[state=active]:opacity-0" />
@@ -72,6 +73,7 @@ const TabsContent = React.forwardRef<
 >(({ className, children, value, ...props }, ref) => {
   const { value: current } = React.useContext(TabsContext)
   const active = current === value
+  const prefersReducedMotion = useReducedMotion()
   return (
     <TabsPrimitive.Content
       ref={ref}
@@ -84,11 +86,11 @@ const TabsContent = React.forwardRef<
         {active && (
           <motion.div
             key={value}
-            layout
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 8 }}
-            transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+            layout={!prefersReducedMotion}
+            initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+            animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
+            transition={timing.inkBar}
           >
             {children}
           </motion.div>

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,8 +1,9 @@
-export const springTransition = {
-  type: 'spring',
-  stiffness: 500,
-  damping: 30,
-  mass: 0.5,
-};
+export const spring = {
+  lift: { type: 'spring', stiffness: 500, damping: 30, mass: 0.5 },
+  ghost: { type: 'spring', stiffness: 350, damping: 25, mass: 0.8 },
+} as const;
 
-export const overlayTransition = springTransition;
+export const timing = {
+  settle: { duration: 0.3, ease: 'easeOut' },
+  inkBar: { duration: 0.55, ease: [0.22, 1, 0.36, 1] },
+} as const;


### PR DESCRIPTION
## Summary
- add shared motion constants for lift, ghost, settle and ink-bar
- standardize animations across components and support reduced motion

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b11bdd06608328918380c5ea96b306