### PR TITLE
Add DnD kit modifiers and sortable support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "agenda": "^5.0.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/modifiers": "^6.1.0",
     "framer-motion": "^11.0.0",
     "@radix-ui/react-dialog": "^1.0.5"
   },

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -12,6 +12,11 @@ import {
   useDroppable,
   DragOverlay,
 } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { motion, useReducedMotion } from 'framer-motion';
 import { spring, timing } from '@/lib/motion';
 
@@ -59,6 +64,7 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      modifiers={[restrictToVerticalAxis]}
     >
       <div className="flex gap-4 h-full">
         {columns.map((col) => {
@@ -95,9 +101,14 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
                 {col.title}
               </motion.h2>
               <div className="p-3 space-y-2 flex-1 overflow-auto">
-                {columnTasks.map((t) => (
-                  <TaskCard key={t.id} task={t} />
-                ))}
+                <SortableContext
+                  items={columnTasks.map((t) => t.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {columnTasks.map((t) => (
+                    <TaskCard key={t.id} task={t} />
+                  ))}
+                </SortableContext>
               </div>
             </motion.div>
           );

--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
-import { useDraggable } from '@dnd-kit/core';
+import { useSortable } from '@dnd-kit/sortable';
 import { motion, useReducedMotion, type MotionStyle } from 'framer-motion';
 import { spring, timing } from '@/lib/motion';
 
@@ -46,8 +46,13 @@ export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
     }
   }, [task.status]);
 
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({ id: task.id });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+  } = useSortable({ id: task.id });
 
   const style: MotionStyle | undefined = transform
     ? { x: transform.x, y: transform.y }


### PR DESCRIPTION
## Summary
- add @dnd-kit/modifiers dependency alongside existing DnD packages
- wire Kanban board with SortableContext and restrict drag to vertical axis
- switch task card to useSortable from @dnd-kit/sortable

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b11fce377c8328937c8760ff06dad4