### PR TITLE
chore: upgrade dnd-kit modifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "agenda": "^5.0.0",
-        "next-auth": "^4.24.7"
+        "next-auth": "^4.24.7",
+        "@dnd-kit/modifiers": "^9.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "agenda": "^5.0.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/modifiers": "^6.1.0",
+    "@dnd-kit/modifiers": "^9.0.0",
     "framer-motion": "^11.0.0",
     "@radix-ui/react-dialog": "^1.0.5"
   },

--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -81,7 +81,7 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
-        modifiers={isKeyboard ? undefined : [restrictToVerticalAxis]}
+        modifiers={isKeyboard ? undefined : [restrictToVerticalAxis()]}
       >
       <div className="flex gap-4 h-full">
         {columns.map((col) => {


### PR DESCRIPTION
## Summary
- upgrade `@dnd-kit/modifiers` to `^9.0.0`
- invoke `restrictToVerticalAxis()` when applying drag modifiers

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b1222f959483288b0799fb3c69d8a6