### PR TITLE
handle missing sortable context in TaskCard

### DIFF
--- a/src/components/kanban/task-card.tsx
+++ b/src/components/kanban/task-card.tsx
@@ -46,13 +46,14 @@ export default function TaskCard({ task, dragOverlay = false }: TaskCardProps) {
     }
   }, [task.status]);
 
+  const sortable = useSortable({ id: task.id });
   const {
     attributes,
     listeners,
     setNodeRef,
     transform,
     isDragging,
-  } = useSortable({ id: task.id });
+  } = sortable ?? {};
 
   const style: MotionStyle | undefined = transform
     ? { x: transform.x, y: transform.y }


### PR DESCRIPTION
## Summary
- avoid destructuring from undefined when TaskCard is rendered outside a SortableContext

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b123a64b4c832880656d21aa162f7e