### PR TITLE
fix dnd modifier error in KanbanBoard

### DIFF
--- a/src/components/kanban/kanban-board.tsx
+++ b/src/components/kanban/kanban-board.tsx
@@ -81,7 +81,7 @@ export default function KanbanBoard({ tasks, onMove }: KanbanBoardProps) {
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDragEnd={handleDragEnd}
-        modifiers={isKeyboard ? undefined : [restrictToVerticalAxis()]}
+        modifiers={isKeyboard ? undefined : [restrictToVerticalAxis]}
       >
       <div className="flex gap-4 h-full">
         {columns.map((col) => {


### PR DESCRIPTION
## Summary
- fix drag modifier usage so restrictToVerticalAxis is passed correctly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b1249aadfc83288b9c0043f382e11c