### PR TITLE
add radix tabs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react-dom": "19.1.0",
         "agenda": "^5.0.0",
         "next-auth": "^4.24.7",
-        "@dnd-kit/modifiers": "^9.0.0"
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@radix-ui/react-tabs": "^1.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/modifiers": "^9.0.0",
     "framer-motion": "^11.0.0",
-    "@radix-ui/react-dialog": "^1.0.5"
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-tabs": "^1.0.5"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- add @radix-ui/react-tabs dependency to resolve missing module

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b13272d3ec832880efc92932adc01c