### PR TITLE
feat: link dashboard tasks to timeline view

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { SessionProvider, useSession } from 'next-auth/react';
+import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 
@@ -69,9 +70,14 @@ function DashboardInner() {
                   initial={{ opacity: 0, y: 4 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: 4 }}
-                  className="rounded border p-2"
+                  className="rounded border hover:bg-gray-50"
                 >
-                  {t.title}
+                  <Link
+                    href={`/tasks/${t._id}`}
+                    className="block p-2"
+                  >
+                    {t.title}
+                  </Link>
                 </motion.li>
               ))}
             </ul>


### PR DESCRIPTION
## Summary
- make dashboard tasks clickable with links to their timeline detail pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b1341aa6a083288096da16543548df