### PR TITLE
Expand in-progress tasks fetch

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -12,10 +12,23 @@ interface Task {
   status: string;
 }
 
+const statusLabels: Record<string, string> = {
+  OPEN: 'Open',
+  IN_PROGRESS: 'In Progress',
+  IN_REVIEW: 'In Review',
+  REVISIONS: 'Revisions',
+  FLOW_IN_PROGRESS: 'Flow In Progress',
+  DONE: 'Done',
+};
+
 const statusTabs = [
-  { value: 'OPEN', label: 'Open' },
-  { value: 'IN_PROGRESS', label: 'In Progress' },
-  { value: 'DONE', label: 'Done' },
+  { value: 'OPEN', label: 'Open', query: ['OPEN'] },
+  {
+    value: 'IN_PROGRESS',
+    label: 'In Progress',
+    query: ['IN_PROGRESS', 'IN_REVIEW', 'REVISIONS', 'FLOW_IN_PROGRESS'],
+  },
+  { value: 'DONE', label: 'Done', query: ['DONE'] },
 ];
 
 function DashboardInner() {
@@ -30,7 +43,9 @@ function DashboardInner() {
     async function loadTasks() {
       const results = await Promise.all(
         statusTabs.map((s) =>
-          fetch(`/api/tasks?status=${s.value}`)
+          fetch(
+            `/api/tasks?${s.query.map((st) => `status=${st}`).join('&')}`
+          )
             .then((res) => res.json())
             .catch(() => [])
         )
@@ -77,6 +92,11 @@ function DashboardInner() {
                     className="block p-2"
                   >
                     {t.title}
+                    {s.query.length > 1 && (
+                      <span className="ml-2 text-xs text-gray-500">
+                        {statusLabels[t.status] ?? t.status}
+                      </span>
+                    )}
                   </Link>
                 </motion.li>
               ))}


### PR DESCRIPTION
## Summary
- group related in-progress statuses and fetch them together
- show each task's precise status label when multiple statuses are merged under a tab

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b135a3b5948328be3f49f2dd03937b