### PR TITLE
feat: add title to task steps

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -69,9 +69,9 @@ async function run() {
     teamId: team._id,
     status: 'FLOW_IN_PROGRESS',
     steps: [
-      { ownerId: user1._id, status: 'OPEN' },
-      { ownerId: user2._id, status: 'OPEN' },
-      { ownerId: user3._id, status: 'OPEN' }
+      { title: 'Step 1', ownerId: user1._id, status: 'OPEN' },
+      { title: 'Step 2', ownerId: user2._id, status: 'OPEN' },
+      { title: 'Step 3', ownerId: user3._id, status: 'OPEN' }
     ],
     currentStepIndex: 0,
   });

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -24,6 +24,7 @@ const patchSchema = z.object({
   dueAt: z.coerce.date().optional(),
   steps: z.array(
     z.object({
+      title: z.string(),
       ownerId: z.string(),
       description: z.string().optional(),
       dueAt: z.coerce.date().optional(),
@@ -111,6 +112,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     teamId: body.teamId ? new Types.ObjectId(body.teamId) : task.teamId,
     steps: body.steps
       ? body.steps.map((s) => ({
+          title: s.title,
           ownerId: new Types.ObjectId(s.ownerId),
           description: s.description,
           dueAt: s.dueAt,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -11,6 +11,7 @@ import { scheduleTaskJobs } from '@/lib/agenda';
 import { problem } from '@/lib/http';
 
 const stepSchema = z.object({
+  title: z.string(),
   ownerId: z.string(),
   description: z.string().optional(),
   dueAt: z.coerce.date().optional(),
@@ -32,7 +33,7 @@ const createTaskSchema = z.object({
   steps: z.array(stepSchema).optional(),
 });
 
-function computeParticipants(data: { creatorId: string; ownerId: string; helpers?: string[]; mentions?: string[]; steps?: { ownerId: string }[] }) {
+function computeParticipants(data: { creatorId: string; ownerId: string; helpers?: string[]; mentions?: string[]; steps?: { ownerId: string; title: string }[] }) {
   const ids = new Set<string>();
   ids.add(data.creatorId);
   ids.add(data.ownerId);
@@ -101,6 +102,7 @@ export async function POST(req: Request) {
     visibility: body.visibility ?? 'PRIVATE',
     dueAt: body.dueAt,
     steps: steps.map((s) => ({
+      title: s.title,
       ownerId: new Types.ObjectId(s.ownerId),
       description: s.description,
       dueAt: s.dueAt,

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -71,9 +71,9 @@ describe('task flow with steps', () => {
       organizationId: orgId,
       status: 'FLOW_IN_PROGRESS',
       steps: [
-        { ownerId: u1, status: 'OPEN' },
-        { ownerId: u2, status: 'OPEN' },
-        { ownerId: u3, status: 'OPEN' },
+        { title: 'Step 1', ownerId: u1, status: 'OPEN' },
+        { title: 'Step 2', ownerId: u2, status: 'OPEN' },
+        { title: 'Step 3', ownerId: u3, status: 'OPEN' },
       ],
       currentStepIndex: 0,
     });

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -11,6 +11,7 @@ export type TaskPriority = 'LOW' | 'MEDIUM' | 'HIGH';
 export type TaskVisibility = 'PRIVATE' | 'TEAM';
 
 export interface IStep {
+  title: string;
   ownerId: Types.ObjectId;
   description?: string;
   dueAt?: Date;
@@ -41,6 +42,7 @@ export interface ITask extends Document {
 
 const stepSchema = new Schema<IStep>(
   {
+    title: { type: String, required: true },
     ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     description: String,
     dueAt: Date,


### PR DESCRIPTION
## Summary
- add required `title` field for task steps in model and API schemas
- include titles when creating or updating task steps
- adjust seeds and tests for step titles

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b17f11692883289203299a635ba42c