### PR TITLE
Display task timeline with status controls

### DIFF
--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -1,43 +1,50 @@
 import { NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Task from '@/models/Task';
+import ActivityLog from '@/models/ActivityLog';
+import { auth } from '@/lib/auth';
+import { canReadTask } from '@/lib/access';
+import { problem } from '@/lib/http';
 
 export async function GET(
   req: Request,
   { params }: { params: { id: string } }
 ) {
-  const { id } = params;
-  const now = Date.now();
-  const events = [
-    {
-      id: '1',
-      type: 'CREATED',
-      user: { name: 'Alice', avatar: '/avatars/alice.png' },
-      date: new Date(now - 1000 * 60 * 60 * 24).toISOString(),
-    },
-    {
-      id: '2',
-      type: 'ASSIGNED',
-      user: { name: 'Bob', avatar: '/avatars/bob.png' },
-      date: new Date(now - 1000 * 60 * 60 * 12).toISOString(),
-    },
-    {
-      id: '3',
-      type: 'ACCEPTED',
-      user: { name: 'Bob', avatar: '/avatars/bob.png' },
-      date: new Date(now - 1000 * 60 * 60 * 6).toISOString(),
-    },
-    {
-      id: '4',
-      type: 'REASSIGNED',
-      user: { name: 'Charlie', avatar: '/avatars/charlie.png' },
-      date: new Date(now - 1000 * 60 * 60 * 3).toISOString(),
-    },
-    {
-      id: '5',
-      type: 'COMPLETED',
-      user: { name: 'Charlie', avatar: '/avatars/charlie.png' },
-      date: new Date(now - 1000 * 60 * 30).toISOString(),
-    },
-  ];
-  // For now, return static events. In a real app, load events from database using id.
+  const session = await auth();
+  if (!session?.userId || !session.organizationId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+
+  await dbConnect();
+  const task = await Task.findById(params.id);
+  if (
+    !task ||
+    !canReadTask(
+      { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+      task
+    )
+  ) {
+    return problem(404, 'Not Found', 'Task not found');
+  }
+
+  const logs = await ActivityLog.find({ taskId: new Types.ObjectId(params.id) })
+    .sort({ createdAt: 1 })
+    .populate('actorId', 'name');
+
+  const events = logs.map((log) => {
+    let type = log.type;
+    if (log.type === 'TRANSITIONED' && (log as any).payload?.action) {
+      type = (log as any).payload.action;
+    }
+    return {
+      id: log._id.toString(),
+      type,
+      user: { name: (log.actorId as any)?.name || 'Unknown' },
+      date: log.createdAt,
+    };
+  });
+
   return NextResponse.json(events);
 }
+

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,63 +1,115 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import Timeline, { TimelineEvent } from '@/components/timeline/timeline';
-import useTaskChannel from '@/hooks/useTaskChannel';
+import { useCallback, useEffect, useState } from "react";
+import Timeline, { TimelineEvent } from "@/components/timeline/timeline";
+import useTaskChannel from "@/hooks/useTaskChannel";
 
 interface HistoryEvent {
   id: string;
-  type: 'CREATED' | 'ASSIGNED' | 'ACCEPTED' | 'COMPLETED' | 'REASSIGNED';
+  type:
+    | "CREATED"
+    | "START"
+    | "SEND_FOR_REVIEW"
+    | "REQUEST_CHANGES"
+    | "DONE"
+    | "UPDATED"
+    | "COMMENT";
   user: { name: string; avatar?: string };
   date: string;
 }
 
-const statusLabels: Record<HistoryEvent['type'], string> = {
-  CREATED: 'Created',
-  ASSIGNED: 'Assigned',
-  ACCEPTED: 'Accepted',
-  COMPLETED: 'Completed',
-  REASSIGNED: 'Reassigned',
+const statusLabels: Record<string, string> = {
+  CREATED: "Created",
+  START: "Started",
+  SEND_FOR_REVIEW: "Sent for review",
+  REQUEST_CHANGES: "Requested changes",
+  DONE: "Done",
+  UPDATED: "Updated",
+  COMMENT: "Commented",
+};
+
+interface Task {
+  _id: string;
+  status: string;
+  steps?: unknown[];
+}
+
+const actionButtons: Record<string, { action: string; label: string }[]> = {
+  OPEN: [{ action: "START", label: "Start" }],
+  IN_PROGRESS: [{ action: "SEND_FOR_REVIEW", label: "Send for review" }],
+  IN_REVIEW: [
+    { action: "REQUEST_CHANGES", label: "Request changes" },
+    { action: "DONE", label: "Done" },
+  ],
+  REVISIONS: [{ action: "SEND_FOR_REVIEW", label: "Send for review" }],
+  FLOW_IN_PROGRESS: [{ action: "DONE", label: "Complete step" }],
+  DONE: [],
 };
 
 export default function TaskPage({ params }: { params: { id: string } }) {
   const { id } = params;
   const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [task, setTask] = useState<Task | null>(null);
 
-  useEffect(() => {
-    const load = async () => {
-      const res = await fetch(`/api/tasks/${id}/history`);
-      if (res.ok) {
-        const data: HistoryEvent[] = await res.json();
-        setEvents(
-          data.map((e) => ({
-            user: e.user,
-            status: statusLabels[e.type],
-            date: e.date,
-          }))
-        );
-      }
-    };
-    load();
+  const load = useCallback(async () => {
+    const [taskRes, historyRes] = await Promise.all([
+      fetch(`/api/tasks/${id}`),
+      fetch(`/api/tasks/${id}/history`),
+    ]);
+    if (taskRes.ok) {
+      setTask(await taskRes.json());
+    }
+    if (historyRes.ok) {
+      const data: HistoryEvent[] = await historyRes.json();
+      setEvents(
+        data.map((e) => ({
+          user: e.user,
+          status: statusLabels[e.type] ?? e.type,
+          date: e.date,
+        }))
+      );
+    }
   }, [id]);
 
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleAction = async (action: string) => {
+    await fetch(`/api/tasks/${id}/transition`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action }),
+    });
+    await load();
+  };
+
   useTaskChannel(id, (data) => {
-    if (data.event === 'history.created') {
-      const e: HistoryEvent = data.history;
-      setEvents((prev) => [
-        ...prev,
-        {
-          user: e.user,
-          status: statusLabels[e.type],
-          date: e.date,
-        },
-      ]);
+    if (data.event === "task.transitioned") {
+      void load();
     }
   });
 
+  const buttons = task ? actionButtons[task.status] ?? [] : [];
+
   return (
     <div className="fixed inset-0 flex flex-col bg-white">
-      <header className="border-b border-gray-200 p-4">
-        <h1 className="text-lg font-semibold">Task {id} Timeline</h1>
+      <header className="border-b border-gray-200 p-4 flex items-center">
+        <h1 className="text-lg font-semibold flex-1">Task {id} Timeline</h1>
+        {task && (
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-600">{task.status}</span>
+            {buttons.map((b) => (
+              <button
+                key={b.action}
+                onClick={() => void handleAction(b.action)}
+                className="bg-blue-500 text-white px-2 py-1 rounded text-sm"
+              >
+                {b.label}
+              </button>
+            ))}
+          </div>
+        )}
       </header>
       <div className="flex-1 overflow-y-auto p-4">
         <Timeline events={events} />


### PR DESCRIPTION
## Summary
- add API endpoint to fetch task history events
- show task status and timeline on task page
- allow users to transition task status directly from detail page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef1416308328b20250ef4d616932