### PR TITLE
feat: extend user model with roles

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -47,7 +47,7 @@ async function run() {
       password: 'admin',
       organizationId: org._id,
       teamId: team._id,
-      isAdmin: true,
+      role: 'ADMIN',
     },
   ]);
 

--- a/src/app/admin/admin-users/new/page.tsx
+++ b/src/app/admin/admin-users/new/page.tsx
@@ -23,7 +23,7 @@ export default function NewAdminPage() {
     await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, isAdmin: true }),
+      body: JSON.stringify({ ...form, role: 'ADMIN' }),
     });
     router.push('/admin/users');
   };

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -13,7 +13,7 @@ export default function EditUserPage() {
     password: '',
     organizationId: '',
     teamId: '',
-    isAdmin: false,
+    role: 'USER',
   });
   const router = useRouter();
 
@@ -28,7 +28,7 @@ export default function EditUserPage() {
         password: '',
         organizationId: data.organizationId || '',
         teamId: data.teamId || '',
-        isAdmin: data.isAdmin || false,
+        role: data.role || 'USER',
       });
     };
     if (id) void load();
@@ -36,7 +36,11 @@ export default function EditUserPage() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, type, checked, value } = e.target;
-    setForm({ ...form, [name]: type === 'checkbox' ? checked : value });
+    if (name === 'role' && type === 'checkbox') {
+      setForm({ ...form, role: checked ? 'ADMIN' : 'USER' });
+    } else {
+      setForm({ ...form, [name]: type === 'checkbox' ? checked : value });
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -60,7 +64,7 @@ export default function EditUserPage() {
       <input name="organizationId" value={form.organizationId} onChange={handleChange} placeholder="Organization ID" className="border p-2" required />
       <input name="teamId" value={form.teamId} onChange={handleChange} placeholder="Team ID" className="border p-2" />
       <label className="flex items-center gap-2">
-        <input type="checkbox" name="isAdmin" checked={form.isAdmin} onChange={handleChange} /> Admin
+        <input type="checkbox" name="role" checked={form.role === 'ADMIN'} onChange={handleChange} /> Admin
       </label>
       <button type="submit" className="bg-blue-500 text-white p-2">Save</button>
     </form>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -65,7 +65,7 @@ export default function UsersPage() {
               <td className="border p-2">{u.name}</td>
               <td className="border p-2">{u.email}</td>
               <td className="border p-2">{u.username}</td>
-              <td className="border p-2">{u.isAdmin ? 'Yes' : 'No'}</td>
+              <td className="border p-2">{u.role === 'ADMIN' ? 'Yes' : 'No'}</td>
               <td className="border p-2 flex gap-2">
                 <Link
                   href={`/admin/users/${u._id}`}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,7 +12,7 @@ interface AuthUser {
   email: string;
   organizationId?: string;
   teamId?: string;
-  isAdmin?: boolean;
+  role?: string;
 }
 
 export const authOptions: NextAuthOptions = {
@@ -36,7 +36,7 @@ export const authOptions: NextAuthOptions = {
           email: user.email,
           organizationId: user.organizationId?.toString(),
           teamId: user.teamId?.toString(),
-          isAdmin: user.isAdmin,
+          role: user.role,
         };
       },
     }),
@@ -48,7 +48,7 @@ export const authOptions: NextAuthOptions = {
         token.email = user.email;
         token.organizationId = user.organizationId;
         token.teamId = user.teamId;
-        token.isAdmin = user.isAdmin;
+        token.role = user.role;
       }
       return token;
     },
@@ -57,7 +57,7 @@ export const authOptions: NextAuthOptions = {
       session.email = token.email;
       session.organizationId = token.organizationId;
       session.teamId = token.teamId;
-      session.isAdmin = token.isAdmin;
+      session.role = token.role;
       return session;
     },
   },

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -10,7 +10,9 @@ export interface IUser extends Document {
   teamId?: Types.ObjectId;
   timezone: string;
   isActive: boolean;
-  isAdmin: boolean;
+  role: 'ADMIN' | 'USER';
+  avatar?: string;
+  permissions: string[];
 }
 
 const userSchema = new Schema<IUser>(
@@ -19,7 +21,6 @@ const userSchema = new Schema<IUser>(
     email: {
       type: String,
       required: true,
-      unique: true,
       lowercase: true,
       index: true,
     },
@@ -35,10 +36,14 @@ const userSchema = new Schema<IUser>(
     teamId: { type: Schema.Types.ObjectId, ref: 'Team' },
     timezone: { type: String, default: 'Asia/Kolkata' },
     isActive: { type: Boolean, default: true },
-    isAdmin: { type: Boolean, default: false },
+    role: { type: String, enum: ['ADMIN', 'USER'], default: 'USER' },
+    avatar: { type: String },
+    permissions: { type: [String], default: [] },
   },
   { timestamps: true }
 );
+
+userSchema.index({ email: 1, organizationId: 1 }, { unique: true });
 
 userSchema.pre('save', async function () {
   if (this.isModified('password')) {


### PR DESCRIPTION
## Summary
- switch user model from `isAdmin` to role-based system and add avatar and permissions
- enforce unique emails per organization
- update auth, seeding, and admin UI to use roles

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b8fb10553c8328bb0b20e15a787345