### PR TITLE
refactor task model fields

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -54,16 +54,16 @@ async function run() {
   const simpleDue = new Date(Date.now() + 2 * 60 * 60 * 1000);
   await Task.create({
     title: 'Simple task',
-    creatorId: user1._id,
+    createdBy: user1._id,
     ownerId: user1._id,
     organizationId: org._id,
     teamId: team._id,
-    dueAt: simpleDue,
+    dueDate: simpleDue,
   });
 
   await Task.create({
     title: 'Flow task',
-    creatorId: user1._id,
+    createdBy: user1._id,
     ownerId: user1._id,
     organizationId: org._id,
     teamId: team._id,

--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -61,7 +61,7 @@ export async function GET(req: Request) {
     access.push({ visibility: 'TEAM', teamId: new Types.ObjectId(session.teamId) });
   }
   const tasks = await Task.find({
-    dueAt: { $gte: start, $lt: end },
+    dueDate: { $gte: start, $lt: end },
     $or: access,
   });
   const taskMap = new Map<string, any[]>();

--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -43,7 +43,7 @@ vi.mock('@/models/Task', () => ({
     find: vi.fn(async (filter: any) => {
       return Array.from(tasks.values()).filter((t) => {
         const due =
-          t.dueAt >= filter.dueAt.$gte && t.dueAt < filter.dueAt.$lt;
+          t.dueDate >= filter.dueDate.$gte && t.dueDate < filter.dueDate.$lt;
         const accessible = filter.$or.some((c: any) => {
           if (c.participantIds) {
             return t.participantIds.some(
@@ -123,14 +123,14 @@ describe('objectives api', () => {
       _id: new Types.ObjectId(),
       title: 't1',
       ownerId: u1,
-      dueAt: new Date('2023-01-01T10:00:00Z'),
+      dueDate: new Date('2023-01-01T10:00:00Z'),
       participantIds: [u1],
     };
     const task2 = {
       _id: new Types.ObjectId(),
       title: 't2',
       ownerId: u2,
-      dueAt: new Date('2023-01-01T12:00:00Z'),
+      dueDate: new Date('2023-01-01T12:00:00Z'),
       visibility: 'TEAM',
       teamId,
       participantIds: [],

--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -19,10 +19,10 @@ const querySchema = z.object({
   dueFrom: z.coerce.date().optional(),
   dueTo: z.coerce.date().optional(),
   ownerId: z.string().optional(),
-  creatorId: z.string().optional(),
+  createdBy: z.string().optional(),
   teamId: z.string().optional(),
   visibility: z.enum(['PRIVATE', 'TEAM']).optional(),
-  sort: z.enum(['relevance', 'updatedAt', 'dueAt']).optional(),
+  sort: z.enum(['relevance', 'updatedAt', 'dueDate']).optional(),
 });
 
 export async function GET(req: Request) {
@@ -54,12 +54,12 @@ export async function GET(req: Request) {
 
   const filter: any = {};
   if (query.ownerId) filter.ownerId = new Types.ObjectId(query.ownerId);
-  if (query.creatorId) filter.creatorId = new Types.ObjectId(query.creatorId);
+  if (query.createdBy) filter.createdBy = new Types.ObjectId(query.createdBy);
   if (query.status && query.status.length) filter.status = { $in: query.status };
   if (query.dueFrom || query.dueTo) {
-    filter.dueAt = {};
-    if (query.dueFrom) filter.dueAt.$gte = query.dueFrom;
-    if (query.dueTo) filter.dueAt.$lte = query.dueTo;
+    filter.dueDate = {};
+    if (query.dueFrom) filter.dueDate.$gte = query.dueFrom;
+    if (query.dueTo) filter.dueDate.$lte = query.dueTo;
   }
   if (query.tag && query.tag.length) filter.tags = { $in: query.tag };
   if (query.visibility) filter.visibility = query.visibility;
@@ -115,10 +115,10 @@ export async function GET(req: Request) {
           status: 1,
           tags: 1,
           ownerId: 1,
-          creatorId: 1,
+          createdBy: 1,
           teamId: 1,
           visibility: 1,
-          dueAt: 1,
+          dueDate: 1,
           highlights: { $meta: 'searchHighlights' },
           score: { $meta: 'searchScore' },
         },
@@ -126,8 +126,8 @@ export async function GET(req: Request) {
     ];
     if (query.sort === 'updatedAt') {
       pipeline.push({ $sort: { updatedAt: -1 } });
-    } else if (query.sort === 'dueAt') {
-      pipeline.push({ $sort: { dueAt: 1 } });
+    } else if (query.sort === 'dueDate') {
+      pipeline.push({ $sort: { dueDate: 1 } });
     } else {
       pipeline.push({ $sort: { score: { $meta: 'searchScore' } } });
     }
@@ -138,7 +138,7 @@ export async function GET(req: Request) {
     const sort: any = {};
     if (query.q) sort.score = { $meta: 'textScore' };
     if (query.sort === 'updatedAt') sort.updatedAt = -1;
-    if (query.sort === 'dueAt') sort.dueAt = 1;
+    if (query.sort === 'dueDate') sort.dueDate = 1;
     results = await Task.find(
       { $and: [mongoFilter, { $or: access }] },
       query.q ? { score: { $meta: 'textScore' } } : undefined
@@ -167,7 +167,7 @@ export async function GET(req: Request) {
         dueFrom: query.dueFrom,
         dueTo: query.dueTo,
         ownerId: query.ownerId,
-        creatorId: query.creatorId,
+        createdBy: query.createdBy,
         teamId: query.teamId,
         visibility: query.visibility,
         sort: query.sort,

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -21,7 +21,7 @@ const patchSchema = z.object({
   priority: z.enum(['LOW','MEDIUM','HIGH']).optional(),
   tags: z.array(z.string()).optional(),
   visibility: z.enum(['PRIVATE','TEAM']).optional(),
-  dueAt: z.coerce.date().optional(),
+  dueDate: z.coerce.date().optional(),
   steps: z.array(
     z.object({
       title: z.string(),
@@ -37,8 +37,8 @@ const patchSchema = z.object({
 
 function computeParticipants(task: any) {
   const ids = new Set<string>();
-  ids.add(task.creatorId.toString());
-  ids.add(task.ownerId.toString());
+  ids.add(task.createdBy.toString());
+  if (task.ownerId) ids.add(task.ownerId.toString());
   task.helpers?.forEach((h: any) => ids.add(h.toString()));
   task.mentions?.forEach((m: any) => ids.add(m.toString()));
   task.steps?.forEach((s: any) => ids.add(s.ownerId.toString()));

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -35,8 +35,8 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     return problem(404, 'Not Found', 'Task not found');
 
   const actorId = session.userId;
-  const isCreator = task.creatorId.toString() === actorId;
-  const isOwner = task.ownerId.toString() === actorId;
+  const isCreator = task.createdBy.toString() === actorId;
+  const isOwner = task.ownerId?.toString() === actorId;
   if (!isCreator && !isOwner) {
     return problem(403, 'Forbidden', 'You cannot transition this task');
   }

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -66,7 +66,7 @@ describe('task flow with steps', () => {
     tasks.set(taskId.toString(), {
       _id: taskId,
       title: 'Test',
-      creatorId: u1,
+      createdBy: u1,
       ownerId: u1,
       organizationId: orgId,
       status: 'FLOW_IN_PROGRESS',
@@ -129,7 +129,7 @@ describe('simple task status transitions', () => {
     tasks.set(taskId.toString(), {
       _id: taskId,
       title: 'Test',
-      creatorId: u1,
+      createdBy: u1,
       ownerId: u1,
       organizationId: orgId,
       status: 'OPEN',

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -71,9 +71,9 @@ export default function TaskSearchPage() {
         />
         <input
           type="text"
-          name="creatorId"
-          defaultValue={params.get('creatorId') ?? ''}
-          placeholder="creatorId"
+          name="createdBy"
+          defaultValue={params.get('createdBy') ?? ''}
+          placeholder="createdBy"
           className="border rounded px-2 py-1"
         />
         <input
@@ -99,7 +99,7 @@ export default function TaskSearchPage() {
         >
           <option value="relevance">Relevance</option>
           <option value="updatedAt">Updated</option>
-          <option value="dueAt">Due date</option>
+          <option value="dueDate">Due date</option>
         </select>
         <button type="submit" className="border rounded px-2 py-1">
           Apply

--- a/src/lib/access.test.ts
+++ b/src/lib/access.test.ts
@@ -4,7 +4,7 @@ import type { ITask } from '../models/Task';
 import { canReadTask, canWriteTask } from './access';
 
 describe('task access', () => {
-  const creatorId = new Types.ObjectId();
+  const createdBy = new Types.ObjectId();
   const ownerId = new Types.ObjectId();
   const helperId = new Types.ObjectId();
   const mentionId = new Types.ObjectId();
@@ -15,7 +15,7 @@ describe('task access', () => {
   const otherOrgId = new Types.ObjectId();
 
   const baseTask = {
-    creatorId,
+    createdBy,
     ownerId,
     helpers: [],
     mentions: [],
@@ -26,7 +26,7 @@ describe('task access', () => {
 
   it('creator can read and write', () => {
     const task = { ...baseTask };
-    const user = { _id: creatorId, teamId, organizationId: orgId };
+    const user = { _id: createdBy, teamId, organizationId: orgId };
     expect(canReadTask(user, task)).toBe(true);
     expect(canWriteTask(user, task)).toBe(true);
   });

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -13,8 +13,8 @@ export function canReadTask(user: UserLike, task: ITask): boolean {
   if (!userId) return false;
   if (!orgId || task.organizationId.toString() !== orgId) return false;
 
-  if (task.creatorId.toString() === userId) return true;
-  if (task.ownerId.toString() === userId) return true;
+  if (task.createdBy.toString() === userId) return true;
+  if (task.ownerId?.toString() === userId) return true;
   if (task.helpers?.some((h) => h.toString() === userId)) return true;
   if (task.mentions?.some((m) => m.toString() === userId)) return true;
 
@@ -34,5 +34,7 @@ export function canWriteTask(user: UserLike, task: ITask): boolean {
   const userId = user?._id?.toString();
   const orgId = user.organizationId?.toString();
   if (!userId || !orgId || task.organizationId.toString() !== orgId) return false;
-  return task.creatorId.toString() === userId || task.ownerId.toString() === userId;
+  return (
+    task.createdBy.toString() === userId || task.ownerId?.toString() === userId
+  );
 }

--- a/src/lib/agenda.ts
+++ b/src/lib/agenda.ts
@@ -21,8 +21,8 @@ export async function scheduleTaskJobs(task: any) {
   const ag = await initAgenda();
   const taskId = task._id.toString();
   await ag.cancel({ name: { $in: ['task.dueSoon', 'task.dueNow'] }, 'data.taskId': taskId });
-  if (task.dueAt) {
-    const due = new Date(task.dueAt);
+  if (task.dueDate) {
+    const due = new Date(task.dueDate);
     const soon = new Date(due.getTime() - 24 * 60 * 60 * 1000);
     if (soon > new Date()) {
       await ag.schedule(soon, 'task.dueSoon', { taskId });


### PR DESCRIPTION
## Summary
- rename Task model fields `creatorId` -> `createdBy` and `dueAt` -> `dueDate`
- allow non-specified task fields to be optional and add composite index for `organizationId`, `status`, `dueDate`
- update APIs, tests, and utilities to use new field names

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b8fc334054832892251767fb3561db