### PR TITLE
Add TaskLoop model

### DIFF
--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -1,0 +1,33 @@
+import { Schema, model, models, type Document, Types } from 'mongoose';
+
+export interface LoopStep {
+  taskId: Types.ObjectId;
+}
+
+export interface ITaskLoop extends Document {
+  taskId: Types.ObjectId;
+  sequence: LoopStep[];
+  currentStep: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const loopStepSchema = new Schema<LoopStep>(
+  {
+    taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
+  },
+  { _id: false }
+);
+
+const taskLoopSchema = new Schema<ITaskLoop>(
+  {
+    taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true, index: true },
+    sequence: [loopStepSchema],
+    currentStep: { type: Number, default: 0 },
+    isActive: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+export default models.TaskLoop || model<ITaskLoop>('TaskLoop', taskLoopSchema);


### PR DESCRIPTION
## Summary
- add TaskLoop schema for looping task sequences

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b8fdc9399c8328be58beddf8e9c3c8