### PR TITLE
feat: expand loop step schema

### DIFF
--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -1,21 +1,39 @@
 import { Schema, model, models, type Document, Types } from 'mongoose';
 
-export interface LoopStep {
+export interface ILoopStep {
   taskId: Types.ObjectId;
+  assignedTo: Types.ObjectId;
+  description: string;
+  status: 'PENDING' | 'IN_PROGRESS' | 'DONE';
+  estimatedTime?: number;
+  actualTime?: number;
+  completedAt?: Date;
+  comments?: string;
 }
 
 export interface ITaskLoop extends Document {
   taskId: Types.ObjectId;
-  sequence: LoopStep[];
+  sequence: ILoopStep[];
   currentStep: number;
   isActive: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
-const loopStepSchema = new Schema<LoopStep>(
+const loopStepSchema = new Schema<ILoopStep>(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
+    assignedTo: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    description: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ['PENDING', 'IN_PROGRESS', 'DONE'],
+      default: 'PENDING',
+    },
+    estimatedTime: { type: Number },
+    actualTime: { type: Number },
+    completedAt: Date,
+    comments: String,
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- add full ILoopStep interface with task assignment, status, and timing fields
- embed detailed loop step schema inside TaskLoop

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b8fe91087c83288f5e34c2d2f60885