### PR TITLE
Refactor comment model and API to use userId/content

### DIFF
--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -91,12 +91,12 @@ export async function GET(req: Request) {
               {
                 text: {
                   query: query.q!,
-                  path: 'comments.body',
+                  path: 'comments.content',
                 },
               },
             ],
           },
-          highlight: { path: ['title', 'description', 'comments.body'] },
+          highlight: { path: ['title', 'description', 'comments.content'] },
         },
       },
       {

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -2,21 +2,19 @@ import { Schema, model, models, type Document, type Types } from 'mongoose';
 
 export interface IComment extends Document {
   taskId: Types.ObjectId;
-  authorId: Types.ObjectId;
-  body: string;
-  mentions: Types.ObjectId[];
-  attachments: string[];
+  userId: Types.ObjectId;
+  content: string;
 }
 
 const commentSchema = new Schema<IComment>(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
-    authorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-    body: { type: String, required: true },
-    mentions: [{ type: Schema.Types.ObjectId, ref: 'User' }],
-    attachments: [String],
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    content: { type: String, required: true },
   },
   { timestamps: true }
 );
+
+commentSchema.index({ taskId: 1, createdAt: -1 });
 
 export default models.Comment || model<IComment>('Comment', commentSchema);


### PR DESCRIPTION
## Summary
- rename Comment authorId -> userId and body -> content
- drop mentions/attachments fields and add index on {taskId, createdAt}
- update comments API and task search to new field names

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b8ffb80ac48328bb9372017f78b114