### PR TITLE
Configure mongoose connection pool settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 
 Run `npm run seed` to populate the database with sample accounts. The script creates three regular users (`user1`, `user2`, `user3`) whose passwords match their usernames and an admin user (`admin`) with password `admin`.
 
+## Database connection
+
+The application configures Mongoose's connection pool with the following defaults:
+
+- `maxPoolSize`: 10
+- `minPoolSize`: 1
+- `socketTimeoutMS`: 45000
+
+You can override these values with the environment variables `MONGODB_MAX_POOL_SIZE`, `MONGODB_MIN_POOL_SIZE`, and `MONGODB_SOCKET_TIMEOUT_MS`.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6,6 +6,16 @@ if (!MONGODB_URI) {
   throw new Error('MONGODB_URI is not defined');
 }
 
+const {
+  MONGODB_MAX_POOL_SIZE = '10',
+  MONGODB_MIN_POOL_SIZE = '1',
+  MONGODB_SOCKET_TIMEOUT_MS = '45000',
+} = process.env;
+
+const maxPoolSize = parseInt(MONGODB_MAX_POOL_SIZE, 10);
+const minPoolSize = parseInt(MONGODB_MIN_POOL_SIZE, 10);
+const socketTimeoutMS = parseInt(MONGODB_SOCKET_TIMEOUT_MS, 10);
+
 declare global {
   var mongooseCache:
     | {
@@ -24,7 +34,12 @@ if (!cached) {
 export default async function dbConnect(): Promise<typeof mongoose> {
   if (cached.conn) return cached.conn;
   if (!cached.promise) {
-    cached.promise = mongoose.connect(MONGODB_URI, { bufferCommands: false });
+    cached.promise = mongoose.connect(MONGODB_URI, {
+      bufferCommands: false,
+      maxPoolSize,
+      minPoolSize,
+      socketTimeoutMS,
+    });
   }
   cached.conn = await cached.promise;
   return cached.conn;


### PR DESCRIPTION
## Summary
- add pool options (maxPoolSize, minPoolSize, socketTimeoutMS) with environment-controlled defaults
- document default pool settings and environment variables in README

## Testing
- ⚠️ `npm test` (fails: vitest not found)
- ⚠️ `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68b9018649d883289e04e569ca698196