### PR TITLE
feat: improve database logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The application configures Mongoose's connection pool with the following default
 
 You can override these values with the environment variables `MONGODB_MAX_POOL_SIZE`, `MONGODB_MIN_POOL_SIZE`, and `MONGODB_SOCKET_TIMEOUT_MS`.
 
+Set `DB_DEBUG` to any value to enable verbose logging of connection attempts and failures.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- add DB_DEBUG flag and helper for verbose database connection logs
- log retries, backoff timing and permanent failures during MongoDB connection attempts
- document DB_DEBUG environment variable

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b902f7e82c8328a6d11fd703db5e86