### PR TITLE
feat: type scheduleTaskJobs with ITask

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
+import type { ITask } from '@/models/Task';
 import ActivityLog from '@/models/ActivityLog';
 import User from '@/models/User';
 import { auth } from '@/lib/auth';
@@ -35,7 +36,7 @@ const patchSchema = z.object({
   currentStepIndex: z.number().int().optional(),
 });
 
-function computeParticipants(task: any) {
+function computeParticipants(task: ITask) {
   const ids = new Set<string>();
   ids.add(task.createdBy.toString());
   if (task.ownerId) ids.add(task.ownerId.toString());
@@ -51,7 +52,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   if (!session?.userId || !session.organizationId)
     return problem(401, 'Unauthorized', 'You must be signed in.');
   await dbConnect();
-  const task = await Task.findById(params.id);
+  const task: ITask | null = await Task.findById(params.id);
   if (
     !task ||
     !canReadTask(
@@ -75,7 +76,7 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     return problem(400, 'Invalid request', e.message);
   }
   await dbConnect();
-  const task = await Task.findById(params.id);
+  const task: ITask | null = await Task.findById(params.id);
   if (!task) return problem(404, 'Not Found', 'Task not found');
   if (
     !canWriteTask(

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
+import type { ITask } from '@/models/Task';
 import ActivityLog from '@/models/ActivityLog';
 import User from '@/models/User';
 import { auth } from '@/lib/auth';
@@ -87,7 +88,7 @@ export async function POST(req: Request) {
       return problem(400, 'Invalid request', 'Step owner must be in your organization');
     }
   }
-  const task = await Task.create({
+  const task: ITask = await Task.create({
     title: body.title,
     description: body.description,
     createdBy: new Types.ObjectId(createdBy),

--- a/src/lib/agenda.ts
+++ b/src/lib/agenda.ts
@@ -1,5 +1,6 @@
 import Agenda from 'agenda';
 import dbConnect from './db';
+import type { ITask } from '@/models/Task';
 
 export const DEFAULT_TZ = 'Asia/Kolkata';
 
@@ -17,7 +18,7 @@ export async function initAgenda(): Promise<Agenda> {
   return connected;
 }
 
-export async function scheduleTaskJobs(task: any) {
+export async function scheduleTaskJobs(task: ITask) {
   const ag = await initAgenda();
   const taskId = task._id.toString();
   await ag.cancel({ name: { $in: ['task.dueSoon', 'task.dueNow'] }, 'data.taskId': taskId });


### PR DESCRIPTION
## Summary
- type agenda scheduling utility with `ITask`
- ensure task API routes pass strongly typed `ITask` objects to scheduler

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b9041018148328ae6fa2b787cbe63e