### PR TITLE
Exclude login route from middleware and set custom sign-in page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 export { default } from 'next-auth/middleware';
 
 export const config = {
-  matcher: ['/((?!api/auth|signin).*)'],
+  matcher: ['/((?!api/auth|signin|login).*)'],
 };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -41,6 +41,9 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  pages: {
+    signIn: '/login',
+  },
   callbacks: {
     async jwt({ token, user }) {
       if (user) {


### PR DESCRIPTION
## Summary
- Exclude `/login` from NextAuth middleware matcher
- Configure NextAuth to redirect unauthenticated users to `/login`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b9060680548328b86b2814dd02430a