### PR TITLE
Use bcrypt for password hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "framer-motion": "^11.0.0",
     "@radix-ui/react-dialog": "^1.0.5",
-    "@radix-ui/react-tabs": "^1.0.5"
+    "@radix-ui/react-tabs": "^1.0.5",
+    "bcrypt": "^5.1.1"
   },
   "devDependencies": {
     "typescript": "^5",

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -3,7 +3,9 @@ import { verifyAndConsumeOtp } from '@/lib/otp';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 import { signIn } from '@/lib/auth';
-import { sha256 } from '@/lib/hash';
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 10;
 
 export async function POST(req: Request) {
   const { email, code } = await req.json();
@@ -44,7 +46,7 @@ export async function POST(req: Request) {
         name: email.split('@')[0],
         email,
         username: email,
-        password: await sha256('changeme'),
+        password: await bcrypt.hash('changeme', SALT_ROUNDS),
       },
     },
     { upsert: true }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import type { NextAuthOptions } from 'next-auth';
 import { getServerSession } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import { signIn as signInBase } from 'next-auth/react';
-import { sha256 } from '@/lib/hash';
+import bcrypt from 'bcrypt';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 
@@ -29,8 +29,8 @@ export const authOptions: NextAuthOptions = {
         await dbConnect();
         const user = await User.findOne({ username: credentials.username });
         if (!user) return null;
-        const hashed = await sha256(credentials.password);
-        if (user.password !== hashed) return null;
+        const match = await bcrypt.compare(credentials.password, user.password);
+        if (!match) return null;
         return {
           id: user._id.toString(),
           email: user.email,

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,6 +1,0 @@
-export async function sha256(input: string): Promise<string> {
-  const data = new TextEncoder().encode(input);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,5 +1,7 @@
 import { Schema, model, models, type Document, type Types } from 'mongoose';
-import { sha256 } from '@/lib/hash';
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 10;
 
 export interface IUser extends Document {
   name: string;
@@ -48,7 +50,11 @@ userSchema.index({ email: 1, organizationId: 1 }, { unique: true });
 userSchema.pre('save', async function () {
   if (this.isModified('password')) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (this as any).password = await sha256((this as any).password);
+    (this as any).password = await bcrypt.hash(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (this as any).password,
+      SALT_ROUNDS
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- hash user passwords with bcrypt before saving
- verify credentials using bcrypt instead of sha256
- create bcrypt-hashed default password during OTP verification
- add bcrypt dependency and remove old hash helper

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b906a7145c83288994f6806211b99f