### PR TITLE
feat: extend NextAuth session and JWT types

### DIFF
--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,22 @@
+import 'next-auth';
+import 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface Session {
+    userId: string;
+    email: string;
+    organizationId: string;
+    teamId: string;
+    role: string;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    userId: string;
+    email: string;
+    organizationId: string;
+    teamId: string;
+    role: string;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- extend NextAuth Session and JWT interfaces with userId, email, organizationId, teamId, and role
- add custom types directory to tsconfig include paths

## Testing
- `npm test` (fails: vitest not found)
- `npm install` (fails: 403 Forbidden)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')


------
https://chatgpt.com/codex/tasks/task_e_68b9078777e8832893823396da4b5ccd