### PR TITLE
feat: secure user api

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Types } from 'mongoose';
+import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 import { auth } from '@/lib/auth';
@@ -7,8 +8,11 @@ import { problem } from '@/lib/http';
 
 export async function GET(req: Request) {
   const session = await auth();
-  if (!session?.organizationId) {
+  if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  if (session.role !== 'ADMIN') {
+    return problem(403, 'Forbidden', 'Admin access required.');
   }
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q') || '';
@@ -27,9 +31,52 @@ export async function GET(req: Request) {
   return NextResponse.json(users);
 }
 
+const createUserSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  username: z.string(),
+  password: z.string(),
+  organizationId: z.string().optional(),
+  teamId: z.string().optional(),
+  timezone: z.string().optional(),
+  isActive: z.boolean().optional(),
+  role: z.enum(['ADMIN', 'USER']).optional(),
+  avatar: z.string().optional(),
+  permissions: z.array(z.string()).optional(),
+});
+
 export async function POST(req: Request) {
-  const data = await req.json();
+  const session = await auth();
+  if (!session?.userId || !session.organizationId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  if (session.role !== 'ADMIN') {
+    return problem(403, 'Forbidden', 'Admin access required.');
+  }
+  let body: z.infer<typeof createUserSchema>;
+  try {
+    body = createUserSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  if (body.organizationId && body.organizationId !== session.organizationId) {
+    return problem(400, 'Invalid request', 'organizationId mismatch');
+  }
   await dbConnect();
-  const user = await User.create(data);
-  return NextResponse.json(user, { status: 201 });
+  try {
+    const user = await User.create({
+      ...body,
+      organizationId: new Types.ObjectId(session.organizationId),
+      teamId: body.teamId ? new Types.ObjectId(body.teamId) : undefined,
+    });
+    return NextResponse.json(user, { status: 201 });
+  } catch (e: any) {
+    if (e.code === 11000) {
+      return problem(409, 'Conflict', 'User already exists');
+    }
+    if (e.name === 'ValidationError') {
+      return problem(400, 'Invalid request', e.message);
+    }
+    return problem(500, 'Internal Server Error', 'Unexpected error');
+  }
 }


### PR DESCRIPTION
## Summary
- enforce admin-only access for user list and creation
- validate email input and restrict organization
- handle duplicate or validation errors gracefully

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9083738f08328a6f54751d5f4840a