### PR TITLE
feat: improve login feedback

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,16 +7,30 @@ import { signIn } from 'next-auth/react';
 export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    if (username.trim().length < 3) {
+      setError('Username must be at least 3 characters long');
+      return;
+    }
+
     const res = await signIn('credentials', {
       redirect: false,
       username,
       password,
     });
-    if (!res?.error) {
+
+    if (res?.error) {
+      setError(res.error);
+    } else {
+      setSuccess('Login successful');
       router.push('/');
     }
   };
@@ -39,6 +53,8 @@ export default function LoginPage() {
         className="border p-2"
         required
       />
+      {error && <p className="text-red-500">{error}</p>}
+      {success && <p className="text-green-500">{success}</p>}
       <button type="submit" className="bg-blue-500 text-white p-2">
         Login
       </button>


### PR DESCRIPTION
## Summary
- handle error state when login fails and show error message
- add basic username length validation
- display success and failure messages for login attempts

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b908ce48588328a9d04652dd5f7f7b