### PR TITLE
Auto-fill organization ID and validate email in admin user forms

### DIFF
--- a/src/app/admin/admin-users/new/page.tsx
+++ b/src/app/admin/admin-users/new/page.tsx
@@ -2,16 +2,18 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { SessionProvider, useSession } from 'next-auth/react';
 
-export default function NewAdminPage() {
+function NewAdminForm() {
+  const { data: session } = useSession();
   const [form, setForm] = useState({
     name: '',
     email: '',
     username: '',
     password: '',
-    organizationId: '',
     teamId: '',
   });
+  const [error, setError] = useState('');
   const router = useRouter();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -20,23 +22,42 @@ export default function NewAdminPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('/api/users', {
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+    setError('');
+    const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, role: 'ADMIN' }),
+      body: JSON.stringify({ ...form, organizationId: session?.organizationId, role: 'ADMIN' }),
     });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.detail || 'Failed to create user');
+      return;
+    }
     router.push('/admin/users');
   };
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      {error && <p className="text-red-500">{error}</p>}
       <input name="name" value={form.name} onChange={handleChange} placeholder="Name" className="border p-2" required />
-      <input name="email" value={form.email} onChange={handleChange} placeholder="Email" className="border p-2" required />
+      <input type="email" name="email" value={form.email} onChange={handleChange} placeholder="Email" className="border p-2" required />
       <input name="username" value={form.username} onChange={handleChange} placeholder="Username" className="border p-2" required />
       <input name="password" type="password" value={form.password} onChange={handleChange} placeholder="Password" className="border p-2" required />
-      <input name="organizationId" value={form.organizationId} onChange={handleChange} placeholder="Organization ID" className="border p-2" required />
       <input name="teamId" value={form.teamId} onChange={handleChange} placeholder="Team ID" className="border p-2" />
       <button type="submit" className="bg-blue-500 text-white p-2">Save Admin</button>
     </form>
   );
 }
+
+export default function NewAdminPage() {
+  return (
+    <SessionProvider>
+      <NewAdminForm />
+    </SessionProvider>
+  );
+}
+

--- a/src/app/admin/users/new/page.tsx
+++ b/src/app/admin/users/new/page.tsx
@@ -2,16 +2,18 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { SessionProvider, useSession } from 'next-auth/react';
 
-export default function NewUserPage() {
+function NewUserForm() {
+  const { data: session } = useSession();
   const [form, setForm] = useState({
     name: '',
     email: '',
     username: '',
     password: '',
-    organizationId: '',
     teamId: '',
   });
+  const [error, setError] = useState('');
   const router = useRouter();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -20,23 +22,42 @@ export default function NewUserPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('/api/users', {
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(form.email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+    setError('');
+    const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
+      body: JSON.stringify({ ...form, organizationId: session?.organizationId }),
     });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setError(data.detail || 'Failed to create user');
+      return;
+    }
     router.push('/admin/users');
   };
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      {error && <p className="text-red-500">{error}</p>}
       <input name="name" value={form.name} onChange={handleChange} placeholder="Name" className="border p-2" required />
-      <input name="email" value={form.email} onChange={handleChange} placeholder="Email" className="border p-2" required />
+      <input type="email" name="email" value={form.email} onChange={handleChange} placeholder="Email" className="border p-2" required />
       <input name="username" value={form.username} onChange={handleChange} placeholder="Username" className="border p-2" required />
       <input name="password" type="password" value={form.password} onChange={handleChange} placeholder="Password" className="border p-2" required />
-      <input name="organizationId" value={form.organizationId} onChange={handleChange} placeholder="Organization ID" className="border p-2" required />
       <input name="teamId" value={form.teamId} onChange={handleChange} placeholder="Team ID" className="border p-2" />
       <button type="submit" className="bg-blue-500 text-white p-2">Save</button>
     </form>
   );
 }
+
+export default function NewUserPage() {
+  return (
+    <SessionProvider>
+      <NewUserForm />
+    </SessionProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Validate email addresses and surface server errors when creating users
- Automatically use admin session organization ID instead of manual entry

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b909682cec83289549416bf03f07f8