### PR TITLE
Refactor login form with react-hook-form and email validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "framer-motion": "^11.0.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-tabs": "^1.0.5",
-    "bcrypt": "^5.1.1"
+    "bcrypt": "^5.1.1",
+    "react-hook-form": "^7.51.5"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- replace state-driven login form with react-hook-form for validation and submission tracking
- switch credential field to email and require password with basic client validation
- display server errors and loading indicator
- add react-hook-form dependency

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b91cfe9d048328895e0d28ed0de926