### PR TITLE
feat: add user registration

### DIFF
--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import Organization from '@/models/Organization';
+
+export async function GET() {
+  await dbConnect();
+  const organizations = await Organization.find({}, 'name').lean();
+  return NextResponse.json(organizations);
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Organization from '@/models/Organization';
+import User from '@/models/User';
+import { problem } from '@/lib/http';
+
+const registerSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  password: z.string(),
+  organizationId: z.string().optional(),
+  organizationName: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  let body: z.infer<typeof registerSchema>;
+  try {
+    body = registerSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+
+  await dbConnect();
+
+  let organizationId: Types.ObjectId;
+
+  if (body.organizationId) {
+    const org = await Organization.findById(body.organizationId).lean();
+    if (!org) {
+      return problem(400, 'Invalid request', 'Organization not found');
+    }
+    organizationId = new Types.ObjectId(body.organizationId);
+  } else if (body.organizationName) {
+    const domain = body.organizationName
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-');
+    try {
+      const org = await Organization.create({ name: body.organizationName, domain });
+      organizationId = org._id;
+    } catch (e: any) {
+      if (e.code === 11000) {
+        return problem(409, 'Conflict', 'Organization already exists');
+      }
+      if (e.name === 'ValidationError') {
+        return problem(400, 'Invalid request', e.message);
+      }
+      return problem(500, 'Internal Server Error', 'Unexpected error');
+    }
+  } else {
+    return problem(400, 'Invalid request', 'Organization is required');
+  }
+
+  const username = body.email.split('@')[0];
+
+  try {
+    const user = await User.create({
+      name: body.name,
+      email: body.email,
+      username,
+      password: body.password,
+      organizationId,
+    });
+    return NextResponse.json({ id: user._id }, { status: 201 });
+  } catch (e: any) {
+    if (e.code === 11000) {
+      return problem(409, 'Conflict', 'User already exists');
+    }
+    if (e.name === 'ValidationError') {
+      return problem(400, 'Invalid request', e.message);
+    }
+    return problem(500, 'Internal Server Error', 'Unexpected error');
+  }
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
+interface Organization {
+  _id: string;
+  name: string;
+}
+
+interface FormData {
+  name: string;
+  email: string;
+  password: string;
+  organizationId?: string;
+  organizationName?: string;
+}
+
+export default function RegisterPage() {
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [orgLoading, setOrgLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [newOrg, setNewOrg] = useState(false);
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<FormData>();
+
+  useEffect(() => {
+    const loadOrganizations = async () => {
+      setOrgLoading(true);
+      try {
+        const res = await fetch('/api/organizations');
+        if (!res.ok) throw new Error('Failed to load');
+        const data = await res.json();
+        setOrganizations(data);
+      } catch {
+        setFetchError('Failed to load organizations');
+      } finally {
+        setOrgLoading(false);
+      }
+    };
+    loadOrganizations();
+  }, []);
+
+  const onSubmit = async (data: FormData) => {
+    const payload: FormData = {
+      name: data.name,
+      email: data.email,
+      password: data.password,
+    };
+    if (newOrg) {
+      payload.organizationName = data.organizationName;
+    } else {
+      payload.organizationId = data.organizationId;
+    }
+    try {
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        setError('root', { message: err.detail || 'Registration failed' });
+        return;
+      }
+      router.push('/login');
+    } catch {
+      setError('root', { message: 'Network error' });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 p-4">
+      <input
+        type="text"
+        placeholder="Name"
+        className="border p-2"
+        {...register('name', { required: 'Name is required' })}
+      />
+      {errors.name && <p className="text-red-500">{errors.name.message}</p>}
+
+      <input
+        type="email"
+        placeholder="Email"
+        className="border p-2"
+        {...register('email', { required: 'Email is required' })}
+      />
+      {errors.email && <p className="text-red-500">{errors.email.message}</p>}
+
+      <input
+        type="password"
+        placeholder="Password"
+        className="border p-2"
+        {...register('password', { required: 'Password is required' })}
+      />
+      {errors.password && <p className="text-red-500">{errors.password.message}</p>}
+
+      {orgLoading ? (
+        <p>Loading organizations...</p>
+      ) : (
+        <>
+          {fetchError && <p className="text-red-500">{fetchError}</p>}
+          {!newOrg && (
+            <>
+              <select
+                className="border p-2"
+                {...register('organizationId', { required: 'Organization is required' })}
+              >
+                <option value="">Select organization</option>
+                {organizations.map((org) => (
+                  <option key={org._id} value={org._id}>
+                    {org.name}
+                  </option>
+                ))}
+              </select>
+              {errors.organizationId && (
+                <p className="text-red-500">{errors.organizationId.message}</p>
+              )}
+              <button
+                type="button"
+                className="text-blue-500 underline"
+                onClick={() => setNewOrg(true)}
+              >
+                Create new organization
+              </button>
+            </>
+          )}
+          {newOrg && (
+            <>
+              <input
+                type="text"
+                placeholder="Organization Name"
+                className="border p-2"
+                {...register('organizationName', { required: 'Organization name is required' })}
+              />
+              {errors.organizationName && (
+                <p className="text-red-500">{errors.organizationName.message}</p>
+              )}
+              <button
+                type="button"
+                className="text-blue-500 underline"
+                onClick={() => setNewOrg(false)}
+              >
+                Select existing organization
+              </button>
+            </>
+          )}
+        </>
+      )}
+
+      {errors.root && <p className="text-red-500">{errors.root.message}</p>}
+
+      <button
+        type="submit"
+        className="bg-blue-500 text-white p-2"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? 'Submitting...' : 'Register'}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- implement /api/organizations for listing organizations
- add /api/register to create user and optionally organization
- build registration page with organization selection and creation

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b91f29c7a48328affa46f35af9b363