### PR TITLE
feat: add organization members page

### DIFF
--- a/src/app/organization/members/page.tsx
+++ b/src/app/organization/members/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+interface User {
+  _id: string;
+  name: string;
+  email: string;
+  role: 'ADMIN' | 'USER';
+}
+
+function Spinner() {
+  return (
+    <div className="animate-spin h-5 w-5 border-2 border-gray-300 border-t-transparent rounded-full" />
+  );
+}
+
+interface MemberRowProps {
+  user: User;
+  onUpdated: (user: User) => void;
+}
+
+function MemberRow({ user, onUpdated }: MemberRowProps) {
+  const { register, handleSubmit, formState: { isSubmitting } } = useForm<{ role: User['role'] }>({
+    defaultValues: { role: user.role },
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (data: { role: User['role'] }) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/users/${user._id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: data.role }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || 'Failed to update');
+      }
+      const updated = await res.json();
+      onUpdated(updated);
+    } catch (e: any) {
+      setError(e.message || 'Failed to update');
+    }
+  };
+
+  return (
+    <tr className="border-b">
+      <td className="p-2">{user.name}</td>
+      <td className="p-2">{user.email}</td>
+      <td className="p-2">
+        <form onChange={handleSubmit(onSubmit)} className="flex items-center gap-2">
+          <select
+            {...register('role')}
+            className="border p-1 rounded"
+            defaultValue={user.role}
+          >
+            <option value="USER">User</option>
+            <option value="ADMIN">Admin</option>
+          </select>
+          {isSubmitting && <Spinner />}
+        </form>
+        {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
+      </td>
+    </tr>
+  );
+}
+
+export default function MembersPage() {
+  const [members, setMembers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setError(null);
+      try {
+        const res = await fetch('/api/users');
+        if (!res.ok) {
+          const err = await res.json().catch(() => null);
+          throw new Error(err?.detail || 'Failed to load');
+        }
+        const data = await res.json();
+        setMembers(data);
+      } catch (e: any) {
+        setError(e.message || 'Failed to load');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const handleUpdated = (updated: User) => {
+    setMembers((prev) => prev.map((m) => (m._id === updated._id ? updated : m)));
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center p-4">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="p-4 text-red-500">{error}</div>;
+  }
+
+  return (
+    <div className="p-4">
+      <table className="min-w-full bg-white">
+        <thead>
+          <tr className="text-left border-b">
+            <th className="p-2">Name</th>
+            <th className="p-2">Email</th>
+            <th className="p-2">Role</th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((m) => (
+            <MemberRow key={m._id} user={m} onUpdated={handleUpdated} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add organization members page to fetch and manage user roles
- display users in table with role select and spinner handling

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b92097b8688328adbe9549292fdf35