### PR TITLE
feat: add invitation system

### DIFF
--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import crypto from 'crypto';
+import dbConnect from '@/lib/db';
+import Invitation from '@/models/Invitation';
+import User from '@/models/User';
+import { problem } from '@/lib/http';
+import { Types } from 'mongoose';
+
+const acceptSchema = z.object({
+  token: z.string(),
+  name: z.string(),
+  password: z.string(),
+});
+
+export async function POST(req: Request) {
+  let body: z.infer<typeof acceptSchema>;
+  try {
+    body = acceptSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+
+  const tokenHash = crypto.createHash('sha256').update(body.token).digest('hex');
+  await dbConnect();
+  const invite = await Invitation.findOne({ tokenHash }).lean();
+  if (!invite || invite.used || invite.expiresAt < new Date()) {
+    return problem(400, 'Invalid request', 'Invalid or expired token');
+  }
+
+  const username = invite.email.split('@')[0];
+  try {
+    const user = await User.create({
+      name: body.name,
+      email: invite.email,
+      username,
+      password: body.password,
+      organizationId: new Types.ObjectId(invite.organizationId),
+      role: invite.role,
+    });
+    await Invitation.updateOne({ _id: invite._id }, { $set: { used: true } });
+    return NextResponse.json({ id: user._id }, { status: 201 });
+  } catch (e: any) {
+    if (e.code === 11000) {
+      return problem(409, 'Conflict', 'User already exists');
+    }
+    if (e.name === 'ValidationError') {
+      return problem(400, 'Invalid request', e.message);
+    }
+    return problem(500, 'Internal Server Error', 'Unexpected error');
+  }
+}

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import crypto from 'crypto';
+import dbConnect from '@/lib/db';
+import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
+import Invitation from '@/models/Invitation';
+import { sendInvitationEmail } from '@/lib/email';
+import { Types } from 'mongoose';
+
+const inviteSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(['ADMIN', 'USER']).optional(),
+});
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.userId || !session.organizationId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  if (session.role !== 'ADMIN') {
+    return problem(403, 'Forbidden', 'Admin access required.');
+  }
+
+  let body: z.infer<typeof inviteSchema>;
+  try {
+    body = inviteSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+
+  const token = crypto.randomBytes(20).toString('hex');
+  const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  await dbConnect();
+  await Invitation.create({
+    email: body.email,
+    organizationId: new Types.ObjectId(session.organizationId),
+    tokenHash,
+    role: body.role || 'USER',
+    expiresAt,
+  });
+
+  const origin = req.headers.get('origin') || '';
+  const link = `${origin}/invite/${token}`;
+  await sendInvitationEmail(body.email, link);
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
+interface FormData {
+  name: string;
+  password: string;
+}
+
+export default function AcceptInvitePage({ params }: { params: { token: string } }) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<FormData>();
+  const router = useRouter();
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      const res = await fetch('/api/invitations/accept', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: params.token, ...data }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        setError('root', { message: err?.detail || 'Registration failed' });
+        return;
+      }
+      router.push('/login');
+    } catch {
+      setError('root', { message: 'Network error' });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 p-4">
+      <input
+        type="text"
+        placeholder="Name"
+        className="border p-2"
+        {...register('name', { required: 'Name is required' })}
+      />
+      {errors.name && <p className="text-red-500">{errors.name.message}</p>}
+      <input
+        type="password"
+        placeholder="Password"
+        className="border p-2"
+        {...register('password', { required: 'Password is required' })}
+      />
+      {errors.password && <p className="text-red-500">{errors.password.message}</p>}
+      {errors.root && <p className="text-red-500">{errors.root.message}</p>}
+      <button
+        type="submit"
+        className="bg-blue-500 text-white p-2"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? 'Registering...' : 'Register'}
+      </button>
+    </form>
+  );
+}

--- a/src/app/organization/invite/page.tsx
+++ b/src/app/organization/invite/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+interface FormData {
+  email: string;
+  role: 'ADMIN' | 'USER';
+}
+
+export default function InvitePage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+    clearErrors,
+    reset,
+  } = useForm<FormData>({ defaultValues: { role: 'USER' } });
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const onSubmit = async (data: FormData) => {
+    setSuccess(null);
+    clearErrors();
+    try {
+      const res = await fetch('/api/invitations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.detail || 'Failed to send');
+      }
+      setSuccess('Invitation sent');
+      reset({ email: '', role: data.role });
+    } catch (e: any) {
+      setError('root', { message: e.message || 'Failed to send' });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 p-4">
+      <input
+        type="email"
+        placeholder="Email"
+        className="border p-2"
+        {...register('email', { required: 'Email is required' })}
+      />
+      {errors.email && <p className="text-red-500">{errors.email.message}</p>}
+      <select className="border p-2" {...register('role')}>
+        <option value="USER">User</option>
+        <option value="ADMIN">Admin</option>
+      </select>
+      {errors.root && <p className="text-red-500">{errors.root.message}</p>}
+      {success && <p className="text-green-600">{success}</p>}
+      <button
+        type="submit"
+        className="bg-blue-500 text-white p-2"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? 'Sending...' : 'Send Invite'}
+      </button>
+    </form>
+  );
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -16,3 +16,16 @@ export async function sendOtpEmail(to: string, code: string) {
     console.log(`OTP for ${to}: ${code}`);
   }
 }
+
+export async function sendInvitationEmail(to: string, link: string) {
+  if (resend) {
+    await resend.emails.send({
+      from: 'invite@example.com',
+      to,
+      subject: 'You\'re invited',
+      text: `You have been invited. Accept the invitation here: ${link}`,
+    });
+  } else {
+    console.log(`Invitation for ${to}: ${link}`);
+  }
+}

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -1,0 +1,30 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface IInvitation extends Document {
+  email: string;
+  organizationId: Types.ObjectId;
+  tokenHash: string;
+  role: 'ADMIN' | 'USER';
+  expiresAt: Date;
+  used: boolean;
+}
+
+const invitationSchema = new Schema<IInvitation>(
+  {
+    email: { type: String, required: true, lowercase: true },
+    organizationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Organization',
+      required: true,
+    },
+    tokenHash: { type: String, required: true, unique: true },
+    role: { type: String, enum: ['ADMIN', 'USER'], default: 'USER' },
+    expiresAt: { type: Date, required: true },
+    used: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+invitationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export default models.Invitation || model<IInvitation>('Invitation', invitationSchema);


### PR DESCRIPTION
## Summary
- add mongoose model and email helper for invitations
- create API endpoints for sending and accepting invites
- add React pages for inviting members and accepting invitations

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @dnd-kit/core)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b921c30c2c83288e869c471e689d2b