### PR TITLE
refactor: centralize task participants

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -10,6 +10,7 @@ import { auth } from '@/lib/auth';
 import { canReadTask, canWriteTask } from '@/lib/access';
 import { scheduleTaskJobs } from '@/lib/agenda';
 import { problem } from '@/lib/http';
+import { computeParticipants } from '@/lib/taskParticipants';
 
 const patchSchema = z.object({
   title: z.string().optional(),
@@ -35,17 +36,6 @@ const patchSchema = z.object({
   ).optional(),
   currentStepIndex: z.number().int().optional(),
 });
-
-function computeParticipants(task: ITask) {
-  const ids = new Set<string>();
-  ids.add(task.createdBy.toString());
-  if (task.ownerId) ids.add(task.ownerId.toString());
-  task.helpers?.forEach((h: any) => ids.add(h.toString()));
-  task.mentions?.forEach((m: any) => ids.add(m.toString()));
-  task.steps?.forEach((s: any) => ids.add(s.ownerId.toString()));
-  task.participantIds = Array.from(ids).map((id) => new Types.ObjectId(id));
-}
-
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const session = await auth();
@@ -126,7 +116,13 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     task.status = 'FLOW_IN_PROGRESS';
     task.ownerId = task.steps[task.currentStepIndex ?? 0].ownerId;
   }
-  computeParticipants(task);
+  task.participantIds = computeParticipants({
+    createdBy: task.createdBy,
+    ownerId: task.ownerId,
+    helpers: task.helpers,
+    mentions: task.mentions,
+    steps: task.steps,
+  });
   await task.save();
   await ActivityLog.create({
     taskId: task._id,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -10,6 +10,7 @@ import { auth } from '@/lib/auth';
 import { notifyAssignment, notifyMention } from '@/lib/notify';
 import { scheduleTaskJobs } from '@/lib/agenda';
 import { problem } from '@/lib/http';
+import { computeParticipants } from '@/lib/taskParticipants';
 
 const stepSchema = z.object({
   title: z.string(),
@@ -33,17 +34,6 @@ const createTaskSchema = z.object({
   dueDate: z.coerce.date().optional(),
   steps: z.array(stepSchema).optional(),
 });
-
-function computeParticipants(data: { createdBy: string; ownerId: string; helpers?: string[]; mentions?: string[]; steps?: { ownerId: string; title: string }[] }) {
-  const ids = new Set<string>();
-  ids.add(data.createdBy);
-  ids.add(data.ownerId);
-  data.helpers?.forEach((h) => ids.add(h));
-  data.mentions?.forEach((m) => ids.add(m));
-  data.steps?.forEach((s) => ids.add(s.ownerId));
-  return Array.from(ids).map((id) => new Types.ObjectId(id));
-}
-
 
 export async function POST(req: Request) {
   const session = await auth();

--- a/src/lib/taskParticipants.ts
+++ b/src/lib/taskParticipants.ts
@@ -1,0 +1,22 @@
+import { Types } from 'mongoose';
+import type { IStep } from '@/models/Task';
+
+export type IdLike = Types.ObjectId | string;
+
+export interface TaskParticipantsPayload {
+  createdBy: IdLike;
+  ownerId?: IdLike;
+  helpers?: IdLike[];
+  mentions?: IdLike[];
+  steps?: (Pick<IStep, 'ownerId'> & { ownerId: IdLike })[];
+}
+
+export function computeParticipants(data: TaskParticipantsPayload): Types.ObjectId[] {
+  const ids = new Set<string>();
+  ids.add(data.createdBy.toString());
+  if (data.ownerId) ids.add(data.ownerId.toString());
+  data.helpers?.forEach((h) => ids.add(h.toString()));
+  data.mentions?.forEach((m) => ids.add(m.toString()));
+  data.steps?.forEach((s) => ids.add(s.ownerId.toString()));
+  return Array.from(ids).map((id) => new Types.ObjectId(id));
+}


### PR DESCRIPTION
## Summary
- centralize task participant calculation in `taskParticipants` util
- reuse participant utility in task creation and update routes

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b925bbd9348328bf9389229b239275