### PR TITLE
feat: add organization session middleware

### DIFF
--- a/src/lib/middleware/withOrganization.ts
+++ b/src/lib/middleware/withOrganization.ts
@@ -1,0 +1,22 @@
+import type { Session } from 'next-auth';
+import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
+
+export function withOrganization(
+  handler: (req: Request, session: Session) => Promise<Response>
+): (req: Request) => Promise<Response>;
+export function withOrganization<C>(
+  handler: (req: Request, ctx: C, session: Session) => Promise<Response>
+): (req: Request, ctx: C) => Promise<Response>;
+export function withOrganization(handler: any) {
+  return async (req: Request, ctx?: any) => {
+    const session = await auth();
+    if (!session?.userId || !session.organizationId) {
+      return problem(401, 'Unauthorized', 'You must be signed in.');
+    }
+    if (handler.length < 3) {
+      return handler(req, session);
+    }
+    return handler(req, ctx, session);
+  };
+}


### PR DESCRIPTION
## Summary
- add `withOrganization` middleware to enforce authenticated org-bound sessions
- wrap task API routes with new middleware and remove manual session checks

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*
- `npx tsc --noEmit` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b92ab065ec8328a10faaa5deca3525