### PR TITLE
feat(api): add task API types

### DIFF
--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -12,6 +12,7 @@ import {
   notifyTaskClosed,
 } from '@/lib/notify';
 import { problem } from '@/lib/http';
+import type { TaskResponse } from '@/types/api/task';
 
 const bodySchema = z.object({
   action: z.enum(['START', 'SEND_FOR_REVIEW', 'REQUEST_CHANGES', 'DONE']),
@@ -96,7 +97,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       }
     }
     emitTaskTransition(updated);
-    return NextResponse.json(updated);
+    return NextResponse.json<TaskResponse>(updated);
   } else {
     let newStatus = task.status;
     switch (body.action) {
@@ -139,7 +140,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       }
     }
     emitTaskTransition(task);
-    return NextResponse.json(task);
+    return NextResponse.json<TaskResponse>(task);
   }
 }
 

--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -1,0 +1,71 @@
+import type { TaskPriority, TaskStatus, TaskVisibility } from '@/models/Task';
+
+export interface TaskStepPayload {
+  title: string;
+  ownerId: string;
+  description?: string;
+  dueAt?: string;
+  status?: 'OPEN' | 'DONE';
+  completedAt?: string;
+}
+
+export interface TaskPayload {
+  title: string;
+  description?: string;
+  ownerId?: string;
+  helpers?: string[];
+  mentions?: string[];
+  teamId?: string;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  tags?: string[];
+  visibility?: TaskVisibility;
+  dueDate?: string;
+  steps?: TaskStepPayload[];
+  currentStepIndex?: number;
+}
+
+export interface TaskListQuery {
+  ownerId?: string;
+  createdBy?: string;
+  status?: TaskStatus[];
+  dueFrom?: string;
+  dueTo?: string;
+  tag?: string[];
+  visibility?: TaskVisibility;
+  teamId?: string;
+  q?: string;
+}
+
+export interface TaskStep {
+  title: string;
+  ownerId: string;
+  description?: string;
+  dueAt?: string;
+  status: 'OPEN' | 'DONE';
+  completedAt?: string;
+}
+
+export interface TaskResponse {
+  _id: string;
+  title: string;
+  description?: string;
+  createdBy: string;
+  ownerId?: string;
+  helpers?: string[];
+  mentions?: string[];
+  organizationId: string;
+  teamId?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  tags?: string[];
+  visibility: TaskVisibility;
+  dueDate?: string;
+  steps?: TaskStep[];
+  currentStepIndex?: number;
+  participantIds?: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type { TaskStatus, TaskPriority, TaskVisibility };


### PR DESCRIPTION
## Summary
- add shared TaskPayload, TaskListQuery, and TaskResponse types
- use new API types in task route handlers

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68b92bbb1b7c8328850a0606b6a6440a