### PR TITLE
feat: paginate tasks API and UI

### DIFF
--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -37,6 +37,8 @@ export interface TaskListQuery {
   teamId?: string;
   q?: string;
   sort?: 'dueDate' | 'priority' | 'createdAt' | 'title';
+  limit?: number;
+  page?: number;
 }
 
 export interface TaskStep {


### PR DESCRIPTION
## Summary
- add optional `limit` and `page` parameters to tasks API endpoint
- implement pagination state with "Load more" button on Tasks page
- extend shared task query types with pagination fields

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9364935788328a380edb0aba44630