### PR TITLE
feat: add task loop endpoint

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Task from '@/models/Task';
+import TaskLoop from '@/models/TaskLoop';
+import { canWriteTask } from '@/lib/access';
+import { problem } from '@/lib/http';
+import { withOrganization } from '@/lib/middleware/withOrganization';
+
+const loopStepSchema = z.object({
+  assignedTo: z.string(),
+  description: z.string(),
+  estimatedTime: z.number().optional(),
+});
+
+const loopSchema = z.object({
+  sequence: z.array(loopStepSchema).optional(),
+});
+
+export const POST = withOrganization(
+  async (
+    req: Request,
+    { params }: { params: { id: string } },
+    session
+  ) => {
+    let body: z.infer<typeof loopSchema>;
+    try {
+      body = loopSchema.parse(await req.json().catch(() => ({})));
+    } catch (e: any) {
+      return problem(400, 'Invalid request', e.message);
+    }
+
+    await dbConnect();
+    const task = await Task.findById(params.id);
+    if (!task) return problem(404, 'Not Found', 'Task not found');
+    if (
+      !canWriteTask(
+        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        task
+      )
+    ) {
+      return problem(403, 'Forbidden', 'You cannot create a loop for this task');
+    }
+
+    const sequence =
+      body.sequence?.map((s) => ({
+        taskId: new Types.ObjectId(params.id),
+        assignedTo: new Types.ObjectId(s.assignedTo),
+        description: s.description,
+        estimatedTime: s.estimatedTime,
+      })) ?? [];
+
+    const loop = await TaskLoop.create({
+      taskId: new Types.ObjectId(params.id),
+      sequence,
+    });
+
+    return NextResponse.json(loop);
+  }
+);
+

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -47,6 +47,7 @@ export default function TaskCard({ task, onChange }: TaskCardProps) {
 
   const handleCreateLoop = async () => {
     await fetch(`/api/tasks/${task._id}/loop`, { method: 'POST' });
+    onChange?.();
   };
 
   return (


### PR DESCRIPTION
## Summary
- add POST handler to create task loops
- call loop creation endpoint from TaskCard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b60ab4e08328903e5d44e19c1045