### PR TITLE
feat: add status badge for tasks

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,8 +1,77 @@
 "use client";
 
+import { useCallback, useEffect, useState } from 'react';
 import TaskDetail from "@/components/task-detail";
+import StatusBadge from "@/components/status-badge";
+import type { TaskStatus } from '@/models/Task';
+
+interface Task {
+  _id: string;
+  title: string;
+  status: TaskStatus;
+}
+
+const ACTIONS: Record<TaskStatus, { action: string; label: string }[]> = {
+  OPEN: [{ action: 'START', label: 'Start' }],
+  IN_PROGRESS: [{ action: 'SEND_FOR_REVIEW', label: 'Send for Review' }],
+  IN_REVIEW: [
+    { action: 'REQUEST_CHANGES', label: 'Request Changes' },
+    { action: 'DONE', label: 'Mark Done' },
+  ],
+  REVISIONS: [{ action: 'SEND_FOR_REVIEW', label: 'Send for Review' }],
+  FLOW_IN_PROGRESS: [{ action: 'DONE', label: 'Mark Done' }],
+  DONE: [],
+};
 
 export default function TaskPage({ params }: { params: { id: string } }) {
-  return <TaskDetail id={params.id} />;
+  const { id } = params;
+  const [task, setTask] = useState<Task | null>(null);
+
+  const load = useCallback(async () => {
+    const res = await fetch(`/api/tasks/${id}`);
+    if (res.ok) setTask(await res.json());
+  }, [id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleTransition = async (action: string) => {
+    const res = await fetch(`/api/tasks/${id}/transition`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    });
+    if (res.ok) {
+      const updated = await res.json();
+      setTask(updated);
+    }
+  };
+
+  if (!task) return <div>Loading...</div>;
+  const actions = ACTIONS[task.status];
+
+  return (
+    <div className="p-4 flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <h1 className="text-xl font-semibold">{task.title}</h1>
+        <StatusBadge status={task.status} />
+      </div>
+      {actions.length ? (
+        <div className="flex gap-2">
+          {actions.map((a) => (
+            <button
+              key={a.action}
+              onClick={() => void handleTransition(a.action)}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <TaskDetail id={id} />
+    </div>
+  );
 }
 

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -1,0 +1,28 @@
+import { Badge } from '@/components/ui/badge';
+import type { TaskStatus } from '@/models/Task';
+
+const STATUS_STYLES: Record<TaskStatus, { label: string; icon: string; className: string }> = {
+  OPEN: { label: 'Open', icon: '📝', className: 'bg-gray-100 text-gray-800' },
+  IN_PROGRESS: { label: 'In Progress', icon: '⏳', className: 'bg-blue-100 text-blue-800' },
+  IN_REVIEW: { label: 'In Review', icon: '👀', className: 'bg-purple-100 text-purple-800' },
+  REVISIONS: { label: 'Revisions', icon: '✏️', className: 'bg-yellow-100 text-yellow-800' },
+  FLOW_IN_PROGRESS: {
+    label: 'Flow In Progress',
+    icon: '🔄',
+    className: 'bg-indigo-100 text-indigo-800',
+  },
+  DONE: { label: 'Done', icon: '✅', className: 'bg-green-100 text-green-800' },
+};
+
+export function StatusBadge({ status }: { status: TaskStatus }) {
+  const { label, icon, className } = STATUS_STYLES[status];
+  return (
+    <Badge className={`gap-1 ${className}`}>
+      <span>{icon}</span>
+      {label}
+    </Badge>
+  );
+}
+
+export default StatusBadge;
+


### PR DESCRIPTION
## Summary
- add `StatusBadge` component showing task status with colors and icons
- display and update status badge on task page during status transitions

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8d5927083289bbf6b3f894fc1b8