### PR TITLE
feat: add nested comment threads

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -13,10 +13,12 @@ import { problem } from '@/lib/http';
 const postSchema = z.object({
   taskId: z.string(),
   content: z.string(),
+  parentId: z.string().optional(),
 });
 
 const listQuerySchema = z.object({
   taskId: z.string(),
+  parentId: z.string().optional(),
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
@@ -47,6 +49,7 @@ export async function POST(req: Request) {
     taskId: new Types.ObjectId(body.taskId),
     userId: new Types.ObjectId(session.userId),
     content: body.content,
+    parentId: body.parentId ? new Types.ObjectId(body.parentId) : null,
   });
   await ActivityLog.create({
     taskId: comment.taskId,
@@ -87,7 +90,11 @@ export async function GET(req: Request) {
   }
   const page = query.page ?? 1;
   const limit = query.limit ?? 20;
-  const comments = await Comment.find({ taskId: new Types.ObjectId(query.taskId) })
+  const filter: any = {
+    taskId: new Types.ObjectId(query.taskId),
+    parentId: query.parentId ? new Types.ObjectId(query.parentId) : null,
+  };
+  const comments = await Comment.find(filter)
     .sort({ createdAt: -1 })
     .skip((page - 1) * limit)
     .limit(limit);

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import TaskDetail from "@/components/task-detail";
 import StatusBadge from "@/components/status-badge";
+import CommentThread from "@/components/comment-thread";
 import type { TaskStatus } from '@/models/Task';
 
 interface Task {
@@ -71,6 +72,7 @@ export default function TaskPage({ params }: { params: { id: string } }) {
         </div>
       ) : null}
       <TaskDetail id={id} />
+      <CommentThread taskId={id} />
     </div>
   );
 }

--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface Comment {
+  _id: string;
+  content: string;
+  taskId: string;
+  parentId?: string | null;
+}
+
+export default function CommentThread({
+  taskId,
+  parentId,
+}: {
+  taskId: string;
+  parentId?: string;
+}) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [newContent, setNewContent] = useState('');
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyContent, setReplyContent] = useState('');
+
+  const load = useCallback(async () => {
+    const params = new URLSearchParams({ taskId });
+    if (parentId) params.set('parentId', parentId);
+    const res = await fetch(`/api/comments?${params.toString()}`);
+    if (res.ok) setComments(await res.json());
+  }, [taskId, parentId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleCreate = async (pid?: string | null) => {
+    const content = pid ? replyContent : newContent;
+    const res = await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ taskId, content, parentId: pid ?? undefined }),
+    });
+    if (res.ok) {
+      if (pid) {
+        setReplyContent('');
+        setReplyingTo(null);
+      } else {
+        setNewContent('');
+      }
+      await load();
+    }
+  };
+
+  return (
+    <div className={parentId ? 'ml-4 mt-2' : 'mt-4'}>
+      {!parentId && (
+        <div className="mb-4">
+          <Textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="Add a comment..."
+          />
+          <Button className="mt-1 text-xs" onClick={() => void handleCreate(null)}>
+            Comment
+          </Button>
+        </div>
+      )}
+      {comments.map((c) => (
+        <div key={c._id} className="mb-2">
+          <div className="p-2 border rounded">
+            <p className="text-sm">{c.content}</p>
+            <button
+              className="text-xs text-blue-500"
+              onClick={() => setReplyingTo(c._id)}
+            >
+              Reply
+            </button>
+          </div>
+          {replyingTo === c._id && (
+            <div className="ml-4 mt-2">
+              <Textarea
+                value={replyContent}
+                onChange={(e) => setReplyContent(e.target.value)}
+              />
+              <Button
+                className="mt-1 text-xs"
+                onClick={() => void handleCreate(c._id)}
+              >
+                Submit
+              </Button>
+            </div>
+          )}
+          <CommentThread taskId={taskId} parentId={c._id} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -4,6 +4,7 @@ export interface IComment extends Document {
   taskId: Types.ObjectId;
   userId: Types.ObjectId;
   content: string;
+  parentId?: Types.ObjectId;
 }
 
 const commentSchema = new Schema<IComment>(
@@ -11,10 +12,11 @@ const commentSchema = new Schema<IComment>(
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     content: { type: String, required: true },
+    parentId: { type: Schema.Types.ObjectId, ref: 'Comment', default: null },
   },
   { timestamps: true }
 );
 
-commentSchema.index({ taskId: 1, createdAt: -1 });
+commentSchema.index({ taskId: 1, parentId: 1, createdAt: -1 });
 
 export default models.Comment || model<IComment>('Comment', commentSchema);


### PR DESCRIPTION
## Summary
- support hierarchical comments with optional parentId field and indexed queries
- allow comment APIs to send and receive threaded replies
- add recursive comment thread component and embed in task page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b9d4b233fc8328a80ed288a8f88e68