### PR TITLE
Add back link on task detail page

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState, type ChangeEvent } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import TaskDetail from "@/components/task-detail";
 import StatusBadge from "@/components/status-badge";
 import CommentThread from "@/components/comment-thread";
@@ -164,13 +165,20 @@ export default function TaskPage({ params }: { params: { id: string } }) {
   const actions = ACTIONS[task.status];
 
   return (
-    <div className="p-4 flex gap-8">
-      <div className="flex-1 flex flex-col gap-4">
-        <div className="flex items-center gap-2">
-          <h1 className="text-xl font-semibold">{task.title}</h1>
-          <StatusBadge status={task.status} />
-        </div>
-        <div className="flex gap-2">
+    <div className="p-4">
+      <Link
+        href="/tasks"
+        className="text-blue-500 underline mb-4 inline-block"
+      >
+        &larr; Back to Tasks
+      </Link>
+        <div className="flex gap-8">
+          <div className="flex-1 flex flex-col gap-4">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl font-semibold">{task.title}</h1>
+              <StatusBadge status={task.status} />
+            </div>
+            <div className="flex gap-2">
           {actions.map((a) => (
             <button
               key={a.action}
@@ -236,6 +244,7 @@ export default function TaskPage({ params }: { params: { id: string } }) {
         <Timeline events={history} />
       </aside>
     </div>
+  </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add breadcrumb link to return to tasks list from task detail page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d9a1af1083288333b1dbd33a909e