### PR TITLE
Emit task update and comment events via WebSocket

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -8,6 +8,7 @@ import ActivityLog from '@/models/ActivityLog';
 import User from '@/models/User';
 import { canReadTask, canWriteTask } from '@/lib/access';
 import { scheduleTaskJobs } from '@/lib/agenda';
+import { emitTaskUpdated } from '@/lib/ws';
 import { problem } from '@/lib/http';
 import { computeParticipants } from '@/lib/taskParticipants';
 import { withOrganization } from '@/lib/middleware/withOrganization';
@@ -163,6 +164,7 @@ export const PATCH = withOrganization(
     payload: body,
   });
   await scheduleTaskJobs(task);
+  emitTaskUpdated(task);
   return NextResponse.json<TaskResponse>(task);
 });
 
@@ -265,6 +267,7 @@ export const PUT = withOrganization(
       payload: body,
     });
     await scheduleTaskJobs(task);
+    emitTaskUpdated(task);
     return NextResponse.json<TaskResponse>(task);
   }
 );

--- a/src/hooks/useTaskChannel.ts
+++ b/src/hooks/useTaskChannel.ts
@@ -1,8 +1,13 @@
 import { useEffect } from 'react';
 
+interface Options {
+  refreshTask?: () => void;
+  insertComment?: (comment: any) => void;
+}
+
 export default function useTaskChannel(
   taskId: string,
-  onMessage: (data: any) => void
+  { refreshTask, insertComment }: Options
 ) {
   useEffect(() => {
     if (!taskId) return;
@@ -12,7 +17,17 @@ export default function useTaskChannel(
       try {
         const data = JSON.parse(event.data);
         if (data.taskId === taskId) {
-          onMessage(data);
+          switch (data.event) {
+            case 'task.updated':
+            case 'task.transitioned':
+              refreshTask?.();
+              break;
+            case 'comment.created':
+              insertComment?.(data.comment);
+              break;
+            default:
+              break;
+          }
         }
       } catch {
         // ignore
@@ -21,5 +36,5 @@ export default function useTaskChannel(
     return () => {
       ws.close();
     };
-  }, [taskId, onMessage]);
+  }, [taskId, refreshTask, insertComment]);
 }

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -20,6 +20,21 @@ export function emitTaskTransition(task: any) {
   });
 }
 
+export function emitTaskUpdated(task: any) {
+  const message = JSON.stringify({
+    event: 'task.updated',
+    taskId: task._id?.toString(),
+    task,
+  });
+  clients.forEach((ws) => {
+    try {
+      ws.send(message);
+    } catch {
+      clients.delete(ws);
+    }
+  });
+}
+
 export function emitCommentCreated(comment: any) {
   const message = JSON.stringify({
     event: 'comment.created',


### PR DESCRIPTION
## Summary
- broadcast `task.updated` and `comment.created` events over WebSocket
- refresh task data or append new comments in `useTaskChannel`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9da99e2c48328a990bc8e02461e78