### PR TITLE
Add loop builder stub and UI entry points

### DIFF
--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { openLoopBuilder } from '@/lib/loopBuilder';
 
 export interface TaskCardProps {
   task: {
@@ -45,11 +46,6 @@ export default function TaskCard({ task, onChange }: TaskCardProps) {
     onChange?.();
   };
 
-  const handleCreateLoop = async () => {
-    await fetch(`/api/tasks/${task._id}/loop`, { method: 'POST' });
-    onChange?.();
-  };
-
   return (
     <div className="rounded border p-4 flex flex-col gap-2 bg-white">
       <div className="flex items-center gap-3">
@@ -88,11 +84,11 @@ export default function TaskCard({ task, onChange }: TaskCardProps) {
           Delete
         </Button>
         <Button
-          onClick={() => void handleCreateLoop()}
+          onClick={() => openLoopBuilder(task._id)}
           variant="outline"
           className="text-xs"
         >
-          Create Loop
+          Add to Loop
         </Button>
       </div>
     </div>

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { openLoopBuilder } from "@/lib/loopBuilder";
 
 interface Task {
   title?: string;
@@ -69,6 +71,13 @@ export default function TaskDetail({ id }: { id: string }) {
       <div>Owner: {task.ownerId}</div>
       <div>Tags: {task.tags?.join(", ")}</div>
       <div>Status: {task.status}</div>
+      <Button
+        onClick={() => openLoopBuilder(id)}
+        variant="outline"
+        className="text-xs self-start"
+      >
+        Add to Loop
+      </Button>
     </div>
   );
 }

--- a/src/lib/loopBuilder.ts
+++ b/src/lib/loopBuilder.ts
@@ -1,0 +1,5 @@
+export function openLoopBuilder(taskId: string): void {
+  // Placeholder for loop builder modal integration
+  // eslint-disable-next-line no-console
+  console.log('Open loop builder for task', taskId);
+}


### PR DESCRIPTION
## Summary
- Add shared loop builder trigger for tasks
- Replace "Create Loop" with "Add to Loop" on task cards and task detail
- Provide loopBuilder stub for future modal integration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df2b8b5c8328b68d1effa23a04de