### PR TITLE
Add loop builder modal with drag and drop

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import LoopBuilder from '@/components/loop-builder';
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,7 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--color-background)]`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--color-background)]`}>
+        {children}
+        <LoopBuilder />
+      </body>
     </html>
   );
 }

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect } from 'react';
+import { DndContext, type DragEndEvent, closestCenter } from '@dnd-kit/core';
+import { SortableContext, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
+import useLoopBuilder, { type LoopStep } from '@/hooks/useLoopBuilder';
+import { registerLoopBuilder } from '@/lib/loopBuilder';
+
+export default function LoopBuilder() {
+  const {
+    open,
+    openBuilder,
+    closeBuilder,
+    taskId,
+    steps,
+    addStep,
+    updateStep,
+    removeStep,
+    reorderSteps,
+  } = useLoopBuilder();
+
+  useEffect(() => {
+    registerLoopBuilder(openBuilder);
+  }, [openBuilder]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = steps.findIndex((s) => s.id === active.id);
+    const newIndex = steps.findIndex((s) => s.id === over.id);
+    reorderSteps(oldIndex, newIndex);
+  };
+
+  const handleSave = async () => {
+    if (!taskId) return;
+    await fetch(`/api/tasks/${taskId}/loop`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sequence: steps.map(({ assignedTo, description, estimatedTime }) => ({
+          assignedTo,
+          description,
+          estimatedTime,
+        })),
+      }),
+    });
+    closeBuilder();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && closeBuilder()}>
+      <DialogContent>
+        <div className="flex flex-col gap-4">
+          <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={steps.map((s) => s.id)}>
+              {steps.map((step) => (
+                <StepItem
+                  key={step.id}
+                  step={step}
+                  onChange={updateStep}
+                  onRemove={removeStep}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+          <Button variant="outline" onClick={addStep}>
+            Add Step
+          </Button>
+          <div className="flex justify-end gap-2">
+            <DialogClose asChild>
+              <Button variant="outline" onClick={closeBuilder}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button onClick={handleSave}>Save</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StepItem({
+  step,
+  onChange,
+  onRemove,
+}: {
+  step: LoopStep;
+  onChange: (id: string, data: Partial<LoopStep>) => void;
+  onRemove: (id: string) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: step.id,
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border rounded p-2 flex items-start gap-2 bg-[var(--color-surface)]"
+    >
+      <div {...attributes} {...listeners} className="cursor-grab p-2 select-none">
+        ⋮⋮
+      </div>
+      <div className="flex-1 flex flex-col gap-2">
+        <Input
+          placeholder="Assigned To"
+          value={step.assignedTo}
+          onChange={(e) => onChange(step.id, { assignedTo: e.target.value })}
+        />
+        <Input
+          placeholder="Description"
+          value={step.description}
+          onChange={(e) => onChange(step.id, { description: e.target.value })}
+        />
+        <Input
+          placeholder="Estimated Time"
+          type="number"
+          value={step.estimatedTime ?? ''}
+          onChange={(e) =>
+            onChange(step.id, {
+              estimatedTime: e.target.value ? Number(e.target.value) : undefined,
+            })
+          }
+        />
+      </div>
+      <Button
+        variant="ghost"
+        className="text-red-600"
+        onClick={() => onRemove(step.id)}
+      >
+        Remove
+      </Button>
+    </div>
+  );
+}
+

--- a/src/hooks/useLoopBuilder.ts
+++ b/src/hooks/useLoopBuilder.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { arrayMove } from '@dnd-kit/sortable';
+
+export interface LoopStep {
+  id: string;
+  assignedTo: string;
+  description: string;
+  estimatedTime?: number;
+}
+
+export default function useLoopBuilder() {
+  const [open, setOpen] = useState(false);
+  const [taskId, setTaskId] = useState<string | null>(null);
+  const [steps, setSteps] = useState<LoopStep[]>([]);
+
+  const openBuilder = (id: string) => {
+    setTaskId(id);
+    setSteps([]);
+    setOpen(true);
+  };
+
+  const closeBuilder = () => setOpen(false);
+
+  const addStep = () => {
+    setSteps((s) => [
+      ...s,
+      { id: Math.random().toString(36).slice(2), assignedTo: '', description: '' },
+    ]);
+  };
+
+  const updateStep = (id: string, data: Partial<LoopStep>) => {
+    setSteps((s) => s.map((step) => (step.id === id ? { ...step, ...data } : step)));
+  };
+
+  const removeStep = (id: string) => {
+    setSteps((s) => s.filter((step) => step.id !== id));
+  };
+
+  const reorderSteps = (from: number, to: number) => {
+    setSteps((s) => arrayMove(s, from, to));
+  };
+
+  return {
+    open,
+    openBuilder,
+    closeBuilder,
+    taskId,
+    steps,
+    addStep,
+    updateStep,
+    removeStep,
+    reorderSteps,
+  };
+}
+

--- a/src/lib/loopBuilder.ts
+++ b/src/lib/loopBuilder.ts
@@ -1,5 +1,10 @@
-export function openLoopBuilder(taskId: string): void {
-  // Placeholder for loop builder modal integration
-  // eslint-disable-next-line no-console
-  console.log('Open loop builder for task', taskId);
+let listener: ((taskId: string) => void) | null = null;
+
+export function registerLoopBuilder(fn: (taskId: string) => void): void {
+  listener = fn;
 }
+
+export function openLoopBuilder(taskId: string): void {
+  listener?.(taskId);
+}
+


### PR DESCRIPTION
## Summary
- add LoopBuilder modal with step management and drag-and-drop ordering
- introduce useLoopBuilder hook and registration helper
- mount loop builder globally in app layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0851d188328a7a33c2b1f306f72