### PR TITLE
Add loop visualizer preview to builder

### DIFF
--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
 import useLoopBuilder, { type LoopStep } from '@/hooks/useLoopBuilder';
 import { registerLoopBuilder } from '@/lib/loopBuilder';
+import LoopVisualizer from '@/components/loop-visualizer';
 
 export default function LoopBuilder() {
   const {
@@ -73,6 +74,7 @@ export default function LoopBuilder() {
     <Dialog open={open} onOpenChange={(o) => !o && closeBuilder()}>
       <DialogContent>
         <div className="flex flex-col gap-4">
+          <LoopVisualizer steps={steps} users={users} />
           <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={steps.map((s) => s.id)}>
               {steps.map((step) => (

--- a/src/components/loop-visualizer.tsx
+++ b/src/components/loop-visualizer.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { LoopStep } from '@/hooks/useLoopBuilder';
+import { Avatar } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+interface User {
+  _id: string;
+  name: string;
+  avatar?: string;
+}
+
+export function LoopVisualizer({ steps, users }: { steps: LoopStep[]; users: User[] }) {
+  if (!steps.length) {
+    return (
+      <div className="text-sm text-gray-500">No steps defined yet.</div>
+    );
+  }
+
+  return (
+    <div className="flex items-center overflow-x-auto py-2">
+      {steps.map((step, idx) => {
+        const user = users.find((u) => u._id === step.assignedTo);
+        const invalid = !step.assignedTo || !step.description;
+        const dependencyIndexes = step.dependencies
+          .map((id) => steps.findIndex((s) => s.id === id) + 1)
+          .filter((n) => n > 0)
+          .join(', ');
+        return (
+          <div key={step.id} className="flex items-center">
+            <div
+              className={cn(
+                'flex flex-col items-center p-2 min-w-[120px] rounded border bg-white',
+                invalid && 'border-red-500 bg-red-50'
+              )}
+            >
+              <Avatar
+                src={user?.avatar}
+                fallback={user?.name?.[0] || '?'}
+                className="w-10 h-10 mb-2"
+              />
+              <span className="text-sm text-center">
+                {step.description || 'Untitled Step'}
+              </span>
+              {dependencyIndexes && (
+                <span className="mt-1 text-xs text-gray-500">
+                  Depends on: {dependencyIndexes}
+                </span>
+              )}
+            </div>
+            {idx < steps.length - 1 && (
+              <div className="mx-2 h-0.5 w-8 bg-gray-300" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default LoopVisualizer;
+


### PR DESCRIPTION
## Summary
- add LoopVisualizer component to render loop steps with avatars, dependencies, and validation highlights
- embed LoopVisualizer preview into LoopBuilder for immediate step feedback

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden on @dnd-kit/core)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e326dcfc8328a3b4f82e2836f064