### PR TITLE
Add loop template model and builder integration

### DIFF
--- a/src/app/api/loop-templates/route.ts
+++ b/src/app/api/loop-templates/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import dbConnect from '@/lib/db';
+import LoopTemplate from '@/models/LoopTemplate';
+import { problem } from '@/lib/http';
+
+const stepSchema = z.object({
+  assignedTo: z.string(),
+  description: z.string(),
+  estimatedTime: z.number().optional(),
+  dependencies: z.array(z.number()).optional(),
+});
+
+const templateSchema = z.object({
+  name: z.string(),
+  steps: z.array(stepSchema),
+});
+
+export async function GET() {
+  await dbConnect();
+  const templates = await LoopTemplate.find();
+  return NextResponse.json(templates);
+}
+
+export async function POST(req: Request) {
+  let body: z.infer<typeof templateSchema>;
+  try {
+    body = templateSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  const template = await LoopTemplate.create(body);
+  return NextResponse.json(template, { status: 201 });
+}
+
+export async function PUT(req: Request) {
+  const schema = templateSchema.extend({ id: z.string() });
+  let body: z.infer<typeof schema>;
+  try {
+    body = schema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  const template = await LoopTemplate.findByIdAndUpdate(
+    body.id,
+    { name: body.name, steps: body.steps },
+    { new: true }
+  );
+  if (!template) {
+    return problem(404, 'Not Found', 'Template not found');
+  }
+  return NextResponse.json(template);
+}
+
+export async function DELETE(req: Request) {
+  const schema = z.object({ id: z.string() });
+  let body: z.infer<typeof schema>;
+  try {
+    body = schema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  const deleted = await LoopTemplate.findByIdAndDelete(body.id);
+  if (!deleted) {
+    return problem(404, 'Not Found', 'Template not found');
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -7,7 +7,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
-import useLoopBuilder, { type LoopStep } from '@/hooks/useLoopBuilder';
+import useLoopBuilder, { type LoopStep, type TemplateStep } from '@/hooks/useLoopBuilder';
 import { registerLoopBuilder } from '@/lib/loopBuilder';
 import LoopVisualizer from '@/components/loop-visualizer';
 
@@ -22,8 +22,12 @@ export default function LoopBuilder() {
     updateStep,
     removeStep,
     reorderSteps,
+    setFromTemplate,
   } = useLoopBuilder();
   const [users, setUsers] = useState<any[]>([]);
+  const [templates, setTemplates] = useState<any[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState('');
+  const [templateName, setTemplateName] = useState('');
 
   useEffect(() => {
     registerLoopBuilder(openBuilder);
@@ -32,10 +36,12 @@ export default function LoopBuilder() {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch('/api/users', { credentials: 'include' });
-        if (res.ok) {
-          setUsers(await res.json());
-        }
+        const [usersRes, tmplRes] = await Promise.all([
+          fetch('/api/users', { credentials: 'include' }),
+          fetch('/api/loop-templates', { credentials: 'include' }),
+        ]);
+        if (usersRes.ok) setUsers(await usersRes.json());
+        if (tmplRes.ok) setTemplates(await tmplRes.json());
       } catch {
         // ignore
       }
@@ -71,11 +77,76 @@ export default function LoopBuilder() {
     closeBuilder();
   };
 
+  const handleSaveTemplate = async () => {
+    const orderedSteps = [...steps].sort((a, b) => a.index - b.index);
+    await fetch('/api/loop-templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: templateName,
+        steps: orderedSteps.map((s) => ({
+          assignedTo: s.assignedTo,
+          description: s.description,
+          estimatedTime: s.estimatedTime,
+          dependencies: s.dependencies.map((d) =>
+            orderedSteps.findIndex((os) => os.id === d)
+          ),
+        })),
+      }),
+    });
+    setTemplateName('');
+    try {
+      const res = await fetch('/api/loop-templates', { credentials: 'include' });
+      if (res.ok) setTemplates(await res.json());
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleApplyTemplate = () => {
+    const tmpl = templates.find((t: any) => t._id === selectedTemplate);
+    if (!tmpl) return;
+    setFromTemplate(tmpl.steps as TemplateStep[]);
+  };
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && closeBuilder()}>
       <DialogContent>
         <div className="flex flex-col gap-4">
           <LoopVisualizer steps={steps} users={users} />
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={selectedTemplate}
+              onChange={(e) => setSelectedTemplate(e.target.value)}
+              className="flex h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm"
+            >
+              <option value="">Select template</option>
+              {templates.map((t) => (
+                <option key={t._id} value={t._id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+            <Button
+              variant="outline"
+              onClick={handleApplyTemplate}
+              disabled={!selectedTemplate}
+            >
+              Apply
+            </Button>
+            <Input
+              placeholder="Template name"
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+            />
+            <Button
+              variant="outline"
+              onClick={handleSaveTemplate}
+              disabled={!templateName || !steps.length}
+            >
+              Save Template
+            </Button>
+          </div>
           <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
             <SortableContext items={steps.map((s) => s.id)}>
               {steps.map((step) => (

--- a/src/hooks/useLoopBuilder.ts
+++ b/src/hooks/useLoopBuilder.ts
@@ -12,6 +12,13 @@ export interface LoopStep {
   index: number;
 }
 
+export interface TemplateStep {
+  assignedTo: string;
+  description: string;
+  estimatedTime?: number;
+  dependencies?: number[];
+}
+
 export default function useLoopBuilder() {
   const [open, setOpen] = useState(false);
   const [taskId, setTaskId] = useState<string | null>(null);
@@ -59,6 +66,20 @@ export default function useLoopBuilder() {
     );
   };
 
+  const setFromTemplate = (tmpl: TemplateStep[]) => {
+    setSteps(() => {
+      const ids = tmpl.map(() => Math.random().toString(36).slice(2));
+      return tmpl.map((s, idx) => ({
+        id: ids[idx],
+        assignedTo: s.assignedTo,
+        description: s.description,
+        estimatedTime: s.estimatedTime,
+        dependencies: s.dependencies?.map((d) => ids[d]) ?? [],
+        index: idx,
+      }));
+    });
+  };
+
   return {
     open,
     openBuilder,
@@ -69,6 +90,7 @@ export default function useLoopBuilder() {
     updateStep,
     removeStep,
     reorderSteps,
+    setFromTemplate,
   };
 }
 

--- a/src/models/LoopTemplate.ts
+++ b/src/models/LoopTemplate.ts
@@ -1,0 +1,35 @@
+import { Schema, model, models, type Document, Types } from 'mongoose';
+
+export interface ILoopStep {
+  assignedTo: Types.ObjectId;
+  description: string;
+  estimatedTime?: number;
+  dependencies?: number[];
+}
+
+export interface ILoopTemplate extends Document {
+  name: string;
+  steps: ILoopStep[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const loopStepSchema = new Schema<ILoopStep>(
+  {
+    assignedTo: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    description: { type: String, required: true },
+    estimatedTime: { type: Number },
+    dependencies: [{ type: Number }],
+  },
+  { _id: false }
+);
+
+const loopTemplateSchema = new Schema<ILoopTemplate>(
+  {
+    name: { type: String, required: true },
+    steps: [loopStepSchema],
+  },
+  { timestamps: true }
+);
+
+export default models.LoopTemplate || model<ILoopTemplate>('LoopTemplate', loopTemplateSchema);


### PR DESCRIPTION
## Summary
- Add LoopTemplate model for reusable step sequences
- Provide CRUD API for loop templates
- Allow users to save and apply templates in LoopBuilder

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e584aefc83289601e8f6231581c9