### PR TITLE
feat: expand loop step statuses

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -20,13 +20,29 @@ const loopSchema = z.object({
   sequence: z.array(loopStepSchema).optional(),
 });
 
+const loopStepStatus = z
+  .enum([
+    'PENDING',
+    'ACTIVE',
+    'COMPLETED',
+    'BLOCKED',
+    'IN_PROGRESS',
+    'DONE',
+  ])
+  .transform((s) => {
+    if (s === 'IN_PROGRESS') return 'ACTIVE';
+    if (s === 'DONE') return 'COMPLETED';
+    return s;
+  })
+  .pipe(z.enum(['PENDING', 'ACTIVE', 'COMPLETED', 'BLOCKED']));
+
 const loopPatchSchema = z.object({
   sequence: z.array(
     z.object({
       index: z.number().int(),
       assignedTo: z.string().optional(),
       description: z.string().optional(),
-      status: z.enum(['PENDING', 'IN_PROGRESS', 'DONE']).optional(),
+      status: loopStepStatus.optional(),
     })
   ),
 });

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -215,7 +215,10 @@ export default function LoopBuilder() {
           </div>
         ) : (
           <div className="flex flex-col gap-4">
-            <LoopVisualizer steps={steps} users={users} />
+            <LoopVisualizer
+              steps={steps.map((s) => ({ ...s, status: 'PENDING' }))}
+              users={users}
+            />
             <div className="flex justify-end gap-2">
               <Button variant="outline" onClick={() => setMode('edit')}>
                 Edit

--- a/src/components/loop-visualizer.tsx
+++ b/src/components/loop-visualizer.tsx
@@ -10,7 +10,11 @@ interface User {
   avatar?: string;
 }
 
-export function LoopVisualizer({ steps, users }: { steps: LoopStep[]; users: User[] }) {
+export interface StepWithStatus extends LoopStep {
+  status?: 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
+}
+
+export function LoopVisualizer({ steps, users }: { steps: StepWithStatus[]; users: User[] }) {
   if (!steps.length) {
     return (
       <div className="text-sm text-gray-500">No steps defined yet.</div>
@@ -43,6 +47,9 @@ export function LoopVisualizer({ steps, users }: { steps: LoopStep[]; users: Use
               />
               <span className="text-sm text-center">
                 {step.description || 'Untitled Step'}
+              </span>
+              <span className="mt-1 text-xs font-medium">
+                {step.status ?? 'PENDING'}
               </span>
               {dependencyIndexes && (
                 <span className="mt-1 text-xs text-gray-500">

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -14,8 +14,18 @@ interface Task {
   status?: string;
 }
 
+interface LoopStep {
+  description: string;
+  status: 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
+}
+
+interface TaskLoop {
+  sequence: LoopStep[];
+}
+
 export default function TaskDetail({ id }: { id: string }) {
   const [task, setTask] = useState<Task | null>(null);
+  const [loop, setLoop] = useState<TaskLoop | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -25,6 +35,14 @@ export default function TaskDetail({ id }: { id: string }) {
       }
     };
     void load();
+  }, [id]);
+
+  useEffect(() => {
+    const loadLoop = async () => {
+      const res = await fetch(`/api/tasks/${id}/loop`);
+      if (res.ok) setLoop(await res.json());
+    };
+    void loadLoop();
   }, [id]);
 
   const updateField = async (field: keyof Task, value: string) => {
@@ -71,6 +89,18 @@ export default function TaskDetail({ id }: { id: string }) {
       <div>Owner: {task.ownerId}</div>
       <div>Tags: {task.tags?.join(", ")}</div>
       <div>Status: {task.status}</div>
+      {loop && (
+        <div className="flex flex-col gap-1">
+          <div className="font-semibold">Loop Steps</div>
+          <ul className="list-disc pl-4">
+            {loop.sequence.map((s, idx) => (
+              <li key={idx} className="text-sm">
+                {s.description} - {s.status}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <Button
         onClick={() => openLoopBuilder(id)}
         variant="outline"

--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -4,7 +4,7 @@ export interface ILoopStep {
   taskId: Types.ObjectId;
   assignedTo: Types.ObjectId;
   description: string;
-  status: 'PENDING' | 'IN_PROGRESS' | 'DONE';
+  status: 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
   estimatedTime?: number;
   actualTime?: number;
   completedAt?: Date;
@@ -28,8 +28,18 @@ const loopStepSchema = new Schema<ILoopStep>(
     description: { type: String, required: true },
     status: {
       type: String,
-      enum: ['PENDING', 'IN_PROGRESS', 'DONE'],
+      enum: ['PENDING', 'ACTIVE', 'COMPLETED', 'BLOCKED'],
       default: 'PENDING',
+      get: (v: string): ILoopStep['status'] => {
+        if (v === 'IN_PROGRESS') return 'ACTIVE';
+        if (v === 'DONE') return 'COMPLETED';
+        return v as ILoopStep['status'];
+      },
+      set: (v: string): ILoopStep['status'] => {
+        if (v === 'IN_PROGRESS') return 'ACTIVE';
+        if (v === 'DONE') return 'COMPLETED';
+        return v as ILoopStep['status'];
+      },
     },
     estimatedTime: { type: Number },
     actualTime: { type: Number },
@@ -37,7 +47,11 @@ const loopStepSchema = new Schema<ILoopStep>(
     comments: String,
     dependencies: [{ type: Schema.Types.ObjectId }],
   },
-  { _id: false }
+  {
+    _id: false,
+    toObject: { getters: true },
+    toJSON: { getters: true },
+  }
 );
 
 const taskLoopSchema = new Schema<ITaskLoop>(


### PR DESCRIPTION
## Summary
- support new loop step statuses PENDING, ACTIVE, COMPLETED and BLOCKED
- map legacy statuses to the new names for existing data
- show loop step statuses in builder preview and task detail view

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eab1b86883288412b92d4d767cb5