### PR TITLE
feat: add loop step completion service

### DIFF
--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Types } from 'mongoose';
+
+vi.mock('@/lib/db', () => ({ default: vi.fn() }));
+
+const notifyFlowAdvanced = vi.fn();
+vi.mock('@/lib/notify', () => ({ notifyFlowAdvanced }));
+
+const findOne = vi.fn();
+vi.mock('@/models/TaskLoop', () => ({ default: { findOne } }));
+
+const findTaskById = vi.fn();
+vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
+
+import { completeStep } from './loop';
+
+describe('completeStep', () => {
+  const taskId = new Types.ObjectId();
+  const userA = new Types.ObjectId();
+  const userB = new Types.ObjectId();
+  let loop: any;
+
+  beforeEach(() => {
+    notifyFlowAdvanced.mockReset();
+    findTaskById.mockReset();
+    loop = {
+      taskId,
+      sequence: [
+        { assignedTo: userA, status: 'ACTIVE', dependencies: [] },
+        { assignedTo: userB, status: 'PENDING', dependencies: [0] },
+      ],
+      currentStep: 0,
+      save: vi.fn().mockResolvedValue(null),
+    };
+    findOne.mockResolvedValue(loop);
+    findTaskById.mockResolvedValue({ _id: taskId });
+  });
+
+  it('completes step and activates next', async () => {
+    const res = await completeStep(taskId.toString(), 0);
+    expect(res).toBe(loop);
+    expect(loop.sequence[0].status).toBe('COMPLETED');
+    expect(loop.sequence[1].status).toBe('ACTIVE');
+    expect(loop.currentStep).toBe(1);
+    expect(notifyFlowAdvanced).toHaveBeenCalledWith([userB], { _id: taskId });
+  });
+});
+

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -1,0 +1,68 @@
+import { Types } from 'mongoose';
+import dbConnect from '@/lib/db';
+import Task from '@/models/Task';
+import TaskLoop from '@/models/TaskLoop';
+import { notifyFlowAdvanced } from '@/lib/notify';
+
+export async function completeStep(taskId: string, stepIndex: number) {
+  await dbConnect();
+  const loop = await TaskLoop.findOne({ taskId });
+  if (!loop) return null;
+  if (stepIndex < 0 || stepIndex >= loop.sequence.length) return loop;
+
+  const step = loop.sequence[stepIndex];
+  if (step.status === 'COMPLETED') return loop;
+
+  step.status = 'COMPLETED';
+  step.completedAt = new Date();
+
+  const newlyActiveIndexes: number[] = [];
+  loop.sequence.forEach((s, idx) => {
+    if (s.status !== 'PENDING') return;
+    const deps = (s.dependencies as any[]) || [];
+    const depsMet = deps.every((d) => {
+      if (typeof d === 'number') {
+        return loop.sequence[d]?.status === 'COMPLETED';
+      }
+      if (d instanceof Types.ObjectId) {
+        const depIdx = loop.sequence.findIndex((st: any) => st._id && st._id.equals(d));
+        return depIdx === -1 || loop.sequence[depIdx].status === 'COMPLETED';
+      }
+      return false;
+    });
+    if (depsMet) {
+      s.status = 'ACTIVE';
+      newlyActiveIndexes.push(idx);
+    }
+  });
+
+  if (newlyActiveIndexes.length) {
+    loop.currentStep = Math.min(...newlyActiveIndexes);
+  } else {
+    const activeIdx = loop.sequence.findIndex((s) => s.status === 'ACTIVE');
+    loop.currentStep = activeIdx; // -1 if none
+    if (activeIdx === -1 && loop.sequence.every((s) => s.status === 'COMPLETED')) {
+      loop.isActive = false;
+    }
+  }
+
+  await loop.save();
+
+  if (newlyActiveIndexes.length) {
+    const task = await Task.findById(taskId);
+    if (task) {
+      const recipients = newlyActiveIndexes.map((idx) => loop.sequence[idx].assignedTo);
+      const uniqueRecipients = Array.from(
+        new Set(recipients.map((r) => r.toString()))
+      ).map((id) => new Types.ObjectId(id));
+      if (uniqueRecipients.length) {
+        await notifyFlowAdvanced(uniqueRecipients, task);
+      }
+    }
+  }
+
+  return loop;
+}
+
+export default { completeStep };
+


### PR DESCRIPTION
## Summary
- add `completeStep` service to update loop progression and notify assignees
- cover loop step completion with unit test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ebe39b7883288d546f8378587a80