### PR TITLE
Ensure step tasks close when all steps completed

### DIFF
--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -61,12 +61,15 @@ export async function POST(req: Request, { params }: { params: { id: string } })
       if (!step || step.status === 'DONE') return;
       step.status = 'DONE';
       step.completedAt = new Date();
-      if (idx + 1 < t.steps.length) {
-        t.currentStepIndex = idx + 1;
-        t.ownerId = t.steps[idx + 1].ownerId;
-        t.status = 'FLOW_IN_PROGRESS';
-      } else {
+
+      const allDone = t.steps.every((s) => s.status === 'DONE');
+      if (allDone) {
         t.status = 'DONE';
+      } else {
+        const nextIdx = t.steps.findIndex((s) => s.status !== 'DONE');
+        t.currentStepIndex = nextIdx;
+        t.ownerId = t.steps[nextIdx].ownerId;
+        t.status = 'FLOW_IN_PROGRESS';
       }
       await t.save({ session: mongoSession });
       await ActivityLog.create(


### PR DESCRIPTION
## Summary
- Update task step transition to mark task done when every step finished
- Test that completing last open step closes task and sends notification

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb7d89080c8328b9b18e3f88a699fe