### PR TITLE
feat: allow reassigning loop steps

### DIFF
--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Types } from 'mongoose';
+
+vi.mock('@/lib/db', () => ({ default: vi.fn() }));
+
+const auth = vi.fn();
+vi.mock('@/lib/auth', () => ({ auth }));
+
+const notifyAssignment = vi.fn();
+vi.mock('@/lib/notify', () => ({ notifyAssignment }));
+
+const findTaskById = vi.fn();
+vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
+
+const findLoop = vi.fn();
+vi.mock('@/models/TaskLoop', () => ({ default: { findOne: findLoop } }));
+
+const findUsers = vi.fn();
+vi.mock('@/models/User', () => ({ default: { find: findUsers } }));
+
+vi.mock('@/lib/access', () => ({ canWriteTask: () => true }));
+
+const startSession = vi.fn();
+vi.mock('mongoose', async () => {
+  const actual: any = await vi.importActual('mongoose');
+  return { ...actual, startSession };
+});
+
+import { PATCH } from './route';
+
+describe('PATCH /tasks/:id/loop assignedTo updates', () => {
+  const taskId = new Types.ObjectId();
+  const oldUser = new Types.ObjectId();
+  const newUser = new Types.ObjectId();
+  const orgId = new Types.ObjectId();
+  const sessionData = {
+    userId: new Types.ObjectId().toString(),
+    teamId: null,
+    organizationId: orgId.toString(),
+  } as any;
+
+  let loop: any;
+
+  beforeEach(() => {
+    auth.mockResolvedValue(sessionData);
+    findTaskById.mockReset();
+    findTaskById.mockResolvedValue({ _id: taskId, organizationId: orgId });
+    findUsers.mockReset();
+    findUsers.mockResolvedValue([{ _id: newUser, organizationId: orgId }]);
+
+    loop = {
+      taskId,
+      sequence: [{ assignedTo: oldUser, status: 'COMPLETED', description: 'step' }],
+      currentStep: 1,
+      isActive: false,
+      save: vi.fn().mockResolvedValue(null),
+    };
+
+    findLoop.mockReset();
+    findLoop.mockReturnValue({
+      session: vi.fn().mockReturnThis(),
+      then: (resolve: any) => resolve(loop),
+    });
+
+    const withTransaction = vi.fn(async (fn: any) => {
+      await fn();
+    });
+    startSession.mockReset();
+    startSession.mockResolvedValue({ withTransaction, endSession: vi.fn() });
+    notifyAssignment.mockReset();
+  });
+
+  it('updates assignee, resets status, and notifies users', async () => {
+    const req = new Request('http://localhost', {
+      method: 'PATCH',
+      body: JSON.stringify({ sequence: [{ index: 0, assignedTo: newUser.toString() }] }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: { id: taskId.toString() } });
+    expect(res.status).toBe(200);
+    expect(loop.sequence[0].assignedTo).toEqual(newUser);
+    expect(loop.sequence[0].status).toBe('PENDING');
+    expect(loop.currentStep).toBe(0);
+    expect(loop.isActive).toBe(true);
+    expect(notifyAssignment).toHaveBeenCalledTimes(2);
+    expect(notifyAssignment).toHaveBeenCalledWith([newUser], { _id: taskId, organizationId: orgId });
+    expect(notifyAssignment).toHaveBeenCalledWith([oldUser], { _id: taskId, organizationId: orgId });
+  });
+});


### PR DESCRIPTION
## Summary
- support updating loop step assignees with transaction safety
- notify new and previous assignees when a step is reassigned
- test reassignment resets status and triggers notifications

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7f81b8208328aa28f4f0db5cf3d0