### PR TITLE
feat: add loop progress component

### DIFF
--- a/src/components/loop-progress.tsx
+++ b/src/components/loop-progress.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { StepsProgress } from './steps-progress';
+
+export function LoopProgress({ total, completed }: { total: number; completed: number }) {
+  const percent = total ? Math.round((completed / total) * 100) : 0;
+  return (
+    <div className="flex flex-col gap-1">
+      <StepsProgress current={completed} total={total} />
+      <span className="text-xs text-gray-600">{percent}% complete</span>
+    </div>
+  );
+}
+
+export default LoopProgress;

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { openLoopBuilder } from "@/lib/loopBuilder";
+import LoopTimeline, { StepWithStatus } from "@/components/loop-timeline";
+import LoopProgress from "@/components/loop-progress";
 
 interface Task {
   title?: string;
@@ -90,15 +92,23 @@ export default function TaskDetail({ id }: { id: string }) {
       <div>Tags: {task.tags?.join(", ")}</div>
       <div>Status: {task.status}</div>
       {loop && (
-        <div className="flex flex-col gap-1">
+        <div className="flex flex-col gap-2">
+          <LoopProgress
+            total={loop.sequence.length}
+            completed={loop.sequence.filter((s) => s.status === "COMPLETED").length}
+          />
           <div className="font-semibold">Loop Steps</div>
-          <ul className="list-disc pl-4">
-            {loop.sequence.map((s, idx) => (
-              <li key={idx} className="text-sm">
-                {s.description} - {s.status}
-              </li>
-            ))}
-          </ul>
+          <LoopTimeline
+            steps={loop.sequence.map((s, idx) => ({
+              id: String(idx),
+              assignedTo: "",
+              description: s.description,
+              dependencies: [],
+              index: idx,
+              status: s.status,
+            })) as StepWithStatus[]}
+            users={[]}
+          />
         </div>
       )}
       <Button


### PR DESCRIPTION
## Summary
- add LoopProgress component showing percent completion
- display loop progress above loop timeline

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb89d094f883288fc71b48132e2233