### PR TITLE
Highlight current loop step in visualizer

### DIFF
--- a/src/components/loop-timeline.tsx
+++ b/src/components/loop-timeline.tsx
@@ -22,9 +22,11 @@ export interface StepWithStatus extends LoopStep {
 export default function LoopTimeline({
   steps,
   users,
+  currentStep,
 }: {
   steps: StepWithStatus[];
   users: User[];
+  currentStep?: number;
 }) {
   const [selected, setSelected] = useState<StepWithStatus | null>(null);
 
@@ -49,32 +51,43 @@ export default function LoopTimeline({
       <div className="flex flex-col md:flex-row items-stretch md:items-center overflow-auto py-2">
         {ordered.map((step, idx) => {
           const user = users.find((u) => u._id === step.assignedTo);
+          const isCurrent = idx === currentStep;
           return (
             <div key={step.id} className="flex flex-col md:flex-row items-center">
-              <motion.button
-                layout
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={{ opacity: 1, scale: 1 }}
-                whileHover={{ scale: 1.05 }}
-                onClick={() => setSelected(step)}
-                className={cn(
-                  'flex flex-col items-center p-3 min-w-[120px] rounded border cursor-pointer',
-                  statusStyles[step.status ?? 'PENDING']
+              <div className="relative">
+                {isCurrent && (
+                  <motion.span
+                    layoutId="current-step"
+                    className="absolute -inset-1 rounded ring-2 ring-blue-500 shadow-md pointer-events-none"
+                    transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                  />
                 )}
-                title={step.description}
-              >
-                <Avatar
-                  src={user?.avatar}
-                  fallback={user?.name?.[0] || '?'}
-                  className="w-10 h-10 mb-2"
-                />
-                <span className="text-sm text-center">
-                  {step.description || 'Untitled Step'}
-                </span>
-                <span className="mt-1 text-xs font-medium">
-                  {step.status ?? 'PENDING'}
-                </span>
-              </motion.button>
+                <motion.button
+                  layout
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: isCurrent ? 1.05 : 1 }}
+                  whileHover={{ scale: 1.05 }}
+                  onClick={() => setSelected(step)}
+                  className={cn(
+                    'relative flex flex-col items-center p-3 min-w-[120px] rounded border cursor-pointer z-10',
+                    statusStyles[step.status ?? 'PENDING']
+                  )}
+                  title={step.description}
+                  transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                >
+                  <Avatar
+                    src={user?.avatar}
+                    fallback={user?.name?.[0] || '?'}
+                    className="w-10 h-10 mb-2"
+                  />
+                  <span className="text-sm text-center">
+                    {step.description || 'Untitled Step'}
+                  </span>
+                  <span className="mt-1 text-xs font-medium">
+                    {step.status ?? 'PENDING'}
+                  </span>
+                </motion.button>
+              </div>
               {idx < ordered.length - 1 && (
                 <>
                   <div className="hidden md:block mx-2 h-0.5 w-8 bg-gray-300" />

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -23,6 +23,7 @@ interface LoopStep {
 
 interface TaskLoop {
   sequence: LoopStep[];
+  currentStep: number;
 }
 
 export default function TaskDetail({ id }: { id: string }) {
@@ -99,14 +100,17 @@ export default function TaskDetail({ id }: { id: string }) {
           />
           <div className="font-semibold">Loop Steps</div>
           <LoopTimeline
-            steps={loop.sequence.map((s, idx) => ({
-              id: String(idx),
-              assignedTo: "",
-              description: s.description,
-              dependencies: [],
-              index: idx,
-              status: s.status,
-            })) as StepWithStatus[]}
+            currentStep={loop.currentStep}
+            steps={
+              loop.sequence.map((s, idx) => ({
+                id: String(idx),
+                assignedTo: "",
+                description: s.description,
+                dependencies: [],
+                index: idx,
+                status: s.status,
+              })) as StepWithStatus[]
+            }
             users={[]}
           />
         </div>


### PR DESCRIPTION
## Summary
- forward TaskLoop currentStep to LoopTimeline
- highlight and animate current loop step in LoopTimeline using framer-motion

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8b1174ac8328a831a2223b5a72f9