### PR TITLE
Add action controls for loop steps

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -112,6 +112,7 @@ export default function TaskDetail({ id }: { id: string }) {
               })) as StepWithStatus[]
             }
             users={[]}
+            taskId={id}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- add Complete, Reassign, and Comment controls to loop timeline steps
- patch API for step completion and reassignment
- expose taskId in task detail for loop actions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bb8c4546b483288258fe1505223ce9