### PR TITLE
feat: display step metadata

### DIFF
--- a/src/components/loop-timeline.tsx
+++ b/src/components/loop-timeline.tsx
@@ -19,6 +19,7 @@ type StepStatus = 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
 
 export interface StepWithStatus extends LoopStep {
   status?: StepStatus;
+  comments?: string;
 }
 
 export default function LoopTimeline({
@@ -79,6 +80,9 @@ export default function LoopTimeline({
   const selectedUser = selected
     ? users.find((u) => u._id === selected.assignedTo)
     : null;
+  const selectedDependencies = selected?.dependencies?.map(
+    (d) => localSteps.find((s) => s.id === d)?.description || d
+  );
 
   const statusStyles: Record<StepStatus, string> = {
     PENDING: 'border-gray-300 bg-gray-100 text-gray-700',
@@ -181,6 +185,14 @@ export default function LoopTimeline({
               <p className="text-sm">Status: {selected.status ?? 'PENDING'}</p>
               {selected.estimatedTime && (
                 <p className="text-sm">Estimated: {selected.estimatedTime}h</p>
+              )}
+              {selectedDependencies && selectedDependencies.length > 0 && (
+                <p className="text-sm">
+                  Dependencies: {selectedDependencies.join(', ')}
+                </p>
+              )}
+              {selected.comments && (
+                <p className="text-sm">Comments: {selected.comments}</p>
               )}
               {selectedUser && (
                 <p className="text-sm">Assigned to: {selectedUser.name}</p>

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -17,7 +17,11 @@ interface Task {
 }
 
 interface LoopStep {
+  assignedTo?: string;
   description: string;
+  estimatedTime?: number;
+  dependencies?: string[];
+  comments?: string;
   status: 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
 }
 
@@ -104,9 +108,11 @@ export default function TaskDetail({ id }: { id: string }) {
             steps={
               loop.sequence.map((s, idx) => ({
                 id: String(idx),
-                assignedTo: "",
+                assignedTo: s.assignedTo ?? "",
                 description: s.description,
-                dependencies: [],
+                estimatedTime: s.estimatedTime,
+                dependencies: s.dependencies ?? [],
+                comments: s.comments,
                 index: idx,
                 status: s.status,
               })) as StepWithStatus[]


### PR DESCRIPTION
## Summary
- show estimated time, dependencies, and comments for loop steps in a dialog
- include comments field in step model
- forward step metadata from task detail to timeline

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bb8d85cc688328a5a0899a1ebef2fc