### PR TITLE
feat: add responsive sizing to timeline components

### DIFF
--- a/src/components/loop-timeline.tsx
+++ b/src/components/loop-timeline.tsx
@@ -114,7 +114,7 @@ export default function LoopTimeline({
                   whileHover={{ scale: 1.05 }}
                   onClick={() => setSelected(step)}
                   className={cn(
-                    'relative flex flex-col items-center p-3 min-w-[120px] rounded border cursor-pointer z-10',
+                    'relative flex flex-col items-center p-2 sm:p-3 md:p-4 min-w-24 sm:min-w-28 md:min-w-32 rounded border cursor-pointer z-10',
                     statusStyles[step.status ?? 'PENDING']
                   )}
                   title={step.description}
@@ -123,7 +123,7 @@ export default function LoopTimeline({
                   <Avatar
                     src={user?.avatar}
                     fallback={user?.name?.[0] || '?'}
-                    className="w-10 h-10 mb-2"
+                    className="mb-2 sm:w-10 sm:h-10 md:w-12 md:h-12"
                   />
                   <span className="text-sm text-center">
                     {step.description || 'Untitled Step'}

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -24,7 +24,7 @@ export function Timeline({ events }: { events: TimelineEvent[] }) {
             key={index}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="relative pl-8 pb-8 text-gray-700"
+            className="relative pl-4 sm:pl-6 md:pl-8 pb-6 sm:pb-8 text-gray-700"
           >
             {index > 0 && (
               <motion.span
@@ -39,6 +39,7 @@ export function Timeline({ events }: { events: TimelineEvent[] }) {
               <Avatar
                 src={event.user.avatar}
                 fallback={event.user.name.charAt(0)}
+                className="sm:w-9 sm:h-9 md:w-10 md:h-10"
               />
               <div>
                 <div className="font-medium">{event.user.name}</div>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -12,13 +12,18 @@ export function Avatar({ src, fallback, className, ...props }: AvatarProps) {
   return (
     <div
       className={cn(
-        'inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-gray-200 text-sm',
+        'relative inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-gray-200 text-sm',
         className
       )}
       {...props}
     >
       {src ? (
-        <Image src={src} alt={fallback || 'avatar'} width={32} height={32} />
+        <Image
+          src={src}
+          alt={fallback || 'avatar'}
+          fill
+          className="object-cover"
+        />
       ) : (
         <span>{fallback}</span>
       )}


### PR DESCRIPTION
## Summary
- Allow Avatar images to resize with container
- Adjust LoopTimeline step sizes with responsive Tailwind classes
- Tune Timeline event spacing and avatars for small and medium screens

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e89c8cc8328982eb7c2765cdc99