### PR TITLE
feat: enhance websocket handling

### DIFF
--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,15 +1,43 @@
 import { addClient } from '@/lib/ws';
+import { auth } from '@/lib/auth';
 
 export async function GET(request: Request) {
   const upgrade = request.headers.get('upgrade');
   if (upgrade?.toLowerCase() !== 'websocket') {
     return new Response('Expected websocket', { status: 400 });
   }
+
+  const session = await auth();
+  if (!session?.userId || !session.organizationId) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const taskIds = searchParams.getAll('taskId');
+
   const { 0: client, 1: server } = Object.values(new WebSocketPair()) as unknown as [
     WebSocket,
     WebSocket
   ];
   server.accept();
-  addClient(server);
+  (server as any).userId = session.userId;
+  (server as any).organizationId = session.organizationId;
+  if (taskIds.length) (server as any).taskIds = taskIds;
+  addClient(server as any);
+
+  const interval = setInterval(() => {
+    try {
+      // @ts-ignore
+      server.ping();
+    } catch {
+      try {
+        server.close();
+      } catch {
+        // ignore
+      }
+    }
+  }, 30000);
+  server.addEventListener('close', () => clearInterval(interval));
+
   return new Response(null, { status: 101, webSocket: client });
 }

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -1,51 +1,114 @@
-const clients = new Set<WebSocket>();
+interface MetaWebSocket extends WebSocket {
+  userId?: string;
+  organizationId?: string;
+  taskIds?: string[];
+}
 
-export function addClient(ws: WebSocket) {
-  clients.add(ws);
-  ws.addEventListener('close', () => clients.delete(ws));
+const userClients = new Map<string, Set<WebSocket>>();
+const taskClients = new Map<string, Set<WebSocket>>();
+
+export function addClient(ws: MetaWebSocket) {
+  if (ws.userId) {
+    const set = userClients.get(ws.userId) ?? new Set<WebSocket>();
+    set.add(ws);
+    userClients.set(ws.userId, set);
+  }
+  if (ws.taskIds) {
+    ws.taskIds.forEach((taskId) => {
+      const set = taskClients.get(taskId) ?? new Set<WebSocket>();
+      set.add(ws);
+      taskClients.set(taskId, set);
+    });
+  }
+  ws.addEventListener('close', () => {
+    if (ws.userId) {
+      const set = userClients.get(ws.userId);
+      set?.delete(ws);
+      if (set && set.size === 0) userClients.delete(ws.userId);
+    }
+    if (ws.taskIds) {
+      ws.taskIds.forEach((taskId) => {
+        const set = taskClients.get(taskId);
+        set?.delete(ws);
+        if (set && set.size === 0) taskClients.delete(taskId);
+      });
+    }
+  });
+}
+
+function broadcast(set: Set<WebSocket> | undefined, message: string) {
+  if (!set) return;
+  set.forEach((ws) => {
+    try {
+      ws.send(message);
+    } catch {
+      set.delete(ws);
+    }
+  });
 }
 
 export function emitTaskTransition(task: any) {
+  const taskId = task._id?.toString();
   const message = JSON.stringify({
     event: 'task.transitioned',
-    taskId: task._id?.toString(),
+    taskId,
     task,
   });
-  clients.forEach((ws) => {
-    try {
-      ws.send(message);
-    } catch {
-      clients.delete(ws);
-    }
-  });
+  broadcast(taskClients.get(taskId), message);
 }
 
 export function emitTaskUpdated(task: any) {
+  const taskId = task._id?.toString();
   const message = JSON.stringify({
     event: 'task.updated',
-    taskId: task._id?.toString(),
+    taskId,
     task,
   });
-  clients.forEach((ws) => {
-    try {
-      ws.send(message);
-    } catch {
-      clients.delete(ws);
-    }
-  });
+  broadcast(taskClients.get(taskId), message);
 }
 
 export function emitCommentCreated(comment: any) {
+  const taskId = comment.taskId?.toString();
   const message = JSON.stringify({
     event: 'comment.created',
-    taskId: comment.taskId?.toString(),
+    taskId,
     comment,
   });
-  clients.forEach((ws) => {
-    try {
-      ws.send(message);
-    } catch {
-      clients.delete(ws);
-    }
+  broadcast(taskClients.get(taskId), message);
+}
+
+export function emitLoopUpdated(loop: any) {
+  const taskId = loop.taskId?.toString();
+  const message = JSON.stringify({
+    event: 'loop.updated',
+    taskId,
+    loop,
   });
+  broadcast(taskClients.get(taskId), message);
+}
+
+export function emitNotification(notification: any, userId: string) {
+  const message = JSON.stringify({
+    event: 'notification.created',
+    notification,
+  });
+  broadcast(userClients.get(userId), message);
+}
+
+export function emitPresence(payload: any) {
+  const taskId = payload.taskId?.toString();
+  const message = JSON.stringify({
+    event: 'presence',
+    ...payload,
+  });
+  if (taskId) broadcast(taskClients.get(taskId), message);
+}
+
+export function emitTyping(payload: any) {
+  const taskId = payload.taskId?.toString();
+  const message = JSON.stringify({
+    event: 'typing',
+    ...payload,
+  });
+  if (taskId) broadcast(taskClients.get(taskId), message);
 }


### PR DESCRIPTION
## Summary
- track websocket clients by user and task for targeted broadcasts
- add loop, notification, presence, and typing emit helpers
- authenticate ws connections and add heartbeat/cleanup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bb96339c108328936dfd33982dc4c5