### PR TITLE
Emit loop update events and refresh client

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { openLoopBuilder } from "@/lib/loopBuilder";
 import LoopVisualizer, { StepWithStatus, UserMap } from "@/components/loop-visualizer";
 import LoopProgress from "@/components/loop-progress";
+import useTaskChannel from "@/hooks/useTaskChannel";
 
 interface Task {
   title?: string;
@@ -36,57 +37,64 @@ export default function TaskDetail({ id }: { id: string }) {
   const [users, setUsers] = useState<UserMap>({});
   const [loopLoading, setLoopLoading] = useState(true);
 
-  useEffect(() => {
-    const load = async () => {
-      const res = await fetch(`/api/tasks/${id}`);
-      if (res.ok) {
-        setTask(await res.json());
-      }
-    };
-    void load();
+  const refreshTask = useCallback(async () => {
+    const res = await fetch(`/api/tasks/${id}`);
+    if (res.ok) {
+      setTask(await res.json());
+    }
   }, [id]);
 
-  useEffect(() => {
-    const loadLoop = async () => {
-      try {
-        const res = await fetch(`/api/tasks/${id}/loop`);
-        if (res.ok) {
-          const loopData = await res.json();
-          setLoop(loopData);
+  const refreshLoop = useCallback(async () => {
+    setLoopLoading(true);
+    try {
+      const res = await fetch(`/api/tasks/${id}/loop`);
+      if (res.ok) {
+        const loopData = await res.json();
+        setLoop(loopData);
 
-          const ids = Array.from(
-            new Set(
-              (loopData.sequence || [])
-                .map((s: LoopStep) => s.assignedTo)
-                .filter((v: string | undefined): v is string => !!v)
-            )
+        const ids = Array.from(
+          new Set(
+            (loopData.sequence || [])
+              .map((s: LoopStep) => s.assignedTo)
+              .filter((v: string | undefined): v is string => !!v)
+          )
+        );
+        if (ids.length) {
+          const userRes = await fetch(
+            `/api/users?${ids.map((u) => `id=${u}`).join('&')}`,
+            { credentials: 'include' }
           );
-          if (ids.length) {
-            const userRes = await fetch(
-              `/api/users?${ids.map((u) => `id=${u}`).join('&')}`,
-              { credentials: 'include' }
-            );
-            if (userRes.ok) {
-              const data = await userRes.json();
-              const map: UserMap = Array.isArray(data)
-                ? data.reduce(
-                    (acc: UserMap, u: any) => {
-                      acc[u._id] = u;
-                      return acc;
-                    },
-                    {}
-                  )
-                : data;
-              setUsers(map);
-            }
+          if (userRes.ok) {
+            const data = await userRes.json();
+            const map: UserMap = Array.isArray(data)
+              ? data.reduce(
+                  (acc: UserMap, u: any) => {
+                    acc[u._id] = u;
+                    return acc;
+                  },
+                  {}
+                )
+              : data;
+            setUsers(map);
           }
         }
-      } finally {
-        setLoopLoading(false);
+      } else {
+        setLoop(null);
       }
-    };
-    void loadLoop();
+    } finally {
+      setLoopLoading(false);
+    }
   }, [id]);
+
+  useEffect(() => {
+    void refreshTask();
+  }, [refreshTask]);
+
+  useEffect(() => {
+    void refreshLoop();
+  }, [refreshLoop]);
+
+  useTaskChannel(id, { refreshTask, refreshLoop });
 
   const updateField = async (field: keyof Task, value: string) => {
     if (!task) return;

--- a/src/hooks/useTaskChannel.ts
+++ b/src/hooks/useTaskChannel.ts
@@ -3,11 +3,12 @@ import { useEffect } from 'react';
 interface Options {
   refreshTask?: () => void;
   insertComment?: (comment: any) => void;
+  refreshLoop?: () => void;
 }
 
 export default function useTaskChannel(
   taskId: string,
-  { refreshTask, insertComment }: Options
+  { refreshTask, insertComment, refreshLoop }: Options
 ) {
   useEffect(() => {
     if (!taskId) return;
@@ -25,6 +26,9 @@ export default function useTaskChannel(
             case 'comment.created':
               insertComment?.(data.comment);
               break;
+            case 'loop.updated':
+              refreshLoop?.();
+              break;
             default:
               break;
           }
@@ -36,5 +40,5 @@ export default function useTaskChannel(
     return () => {
       ws.close();
     };
-  }, [taskId, refreshTask, insertComment]);
+  }, [taskId, refreshTask, insertComment, refreshLoop]);
 }

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -77,12 +77,12 @@ export function emitCommentCreated(comment: any) {
   broadcast(taskClients.get(taskId), message);
 }
 
-export function emitLoopUpdated(loop: any) {
-  const taskId = loop.taskId?.toString();
+export function emitLoopUpdated(payload: { taskId: any; loop: any }) {
+  const taskId = payload.taskId?.toString();
   const message = JSON.stringify({
     event: 'loop.updated',
     taskId,
-    loop,
+    loop: payload.loop,
   });
   broadcast(taskClients.get(taskId), message);
 }


### PR DESCRIPTION
## Summary
- broadcast loop updates from loop API routes
- add realtime loop handling in useTaskChannel and TaskDetail

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: missing @eslint/eslintrc package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e16d4348328ab88cc837a9604a3