### PR TITLE
feat: add task presence tracking

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -6,6 +6,8 @@ import { openLoopBuilder } from "@/lib/loopBuilder";
 import LoopVisualizer, { StepWithStatus, UserMap } from "@/components/loop-visualizer";
 import LoopProgress from "@/components/loop-progress";
 import useTaskChannel from "@/hooks/useTaskChannel";
+import usePresence from "@/hooks/usePresence";
+import { Avatar } from "@/components/ui/avatar";
 
 interface Task {
   title?: string;
@@ -36,6 +38,7 @@ export default function TaskDetail({ id }: { id: string }) {
   const [loop, setLoop] = useState<TaskLoop | null>(null);
   const [users, setUsers] = useState<UserMap>({});
   const [loopLoading, setLoopLoading] = useState(true);
+  const viewers = usePresence(id);
 
   const refreshTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${id}`);
@@ -112,12 +115,26 @@ export default function TaskDetail({ id }: { id: string }) {
 
   return (
     <div className="p-4 flex flex-col gap-4">
-      <input
-        className="border p-2"
-        value={task.title ?? ""}
-        onChange={(e) => setTask({ ...task, title: e.target.value })}
-        onBlur={(e) => void updateField("title", e.target.value)}
-      />
+      <div className="flex items-center justify-between gap-2">
+        <input
+          className="border p-2 flex-1"
+          value={task.title ?? ""}
+          onChange={(e) => setTask({ ...task, title: e.target.value })}
+          onBlur={(e) => void updateField("title", e.target.value)}
+        />
+        {viewers.length > 0 && (
+          <div className="flex -space-x-2 ml-2">
+            {viewers.map((u) => (
+              <Avatar
+                key={u._id}
+                src={u.avatar}
+                fallback={u.name?.[0] || "?"}
+                className="w-8 h-8 border-2 border-white"
+              />
+            ))}
+          </div>
+        )}
+      </div>
       <textarea
         className="border p-2"
         value={task.description ?? ""}

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Viewer {
+  _id: string;
+  name?: string;
+  avatar?: string;
+}
+
+export default function usePresence(taskId: string) {
+  const viewersRef = useRef<Record<string, Viewer>>({});
+  const [, setVersion] = useState(0);
+
+  useEffect(() => {
+    if (!taskId) return;
+    const url = `${window.location.origin.replace(/^http/, 'ws')}/api/ws?taskId=${taskId}`;
+    const ws = new WebSocket(url);
+
+    const update = () => setVersion((v) => v + 1);
+
+    ws.addEventListener('message', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.taskId !== taskId) return;
+        if (data.event === 'user.joined') {
+          const userId: string = data.userId;
+          if (!viewersRef.current[userId]) {
+            viewersRef.current[userId] = { _id: userId };
+            update();
+            fetch(`/api/users/${userId}`)
+              .then((res) => (res.ok ? res.json() : null))
+              .then((user) => {
+                if (user) {
+                  viewersRef.current[user._id] = user;
+                  update();
+                }
+              })
+              .catch(() => {});
+          }
+        } else if (data.event === 'user.left') {
+          const userId: string = data.userId;
+          if (viewersRef.current[userId]) {
+            delete viewersRef.current[userId];
+            update();
+          }
+        }
+      } catch {
+        // ignore
+      }
+    });
+
+    return () => {
+      ws.close();
+    };
+  }, [taskId]);
+
+  return Object.values(viewersRef.current);
+}


### PR DESCRIPTION
## Summary
- track WebSocket task presence and broadcast user.joined/user.left
- add usePresence hook for subscribing to presence updates
- show active task viewers in task header

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f4025dc8328a369cd28eaceafb0