### PR TITLE
Improve offline WebSocket handling and queuing

### DIFF
--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -55,13 +55,15 @@ export default function CommentThread({
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ taskId, content, parentId: pid ?? undefined }),
     });
-    if (res?.ok) {
+    if (res?.ok || res?.offline) {
       if (pid) {
         setReplyContent('');
         setReplyingTo(null);
       } else {
         setNewContent('');
       }
+    }
+    if (res?.ok) {
       await load();
     }
   };

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -60,9 +60,14 @@ export default function useTyping(
     if (!userId) return;
     const ws = wsRef.current;
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(
-        JSON.stringify({ event: 'comment.typing', taskId, userId })
-      );
+      try {
+        ws.send(
+          JSON.stringify({ event: 'comment.typing', taskId, userId })
+        );
+      } catch (err) {
+        console.error('WebSocket send failed', err);
+        ws.dispatchEvent(new Event('error'));
+      }
     }
   }, [taskId, userId]);
 


### PR DESCRIPTION
## Summary
- Safely handle WebSocket send failures and broadcast errors back to clients
- Detect browser online/offline to retry queued requests and update status
- Queue unsent comments when offline and clear form after queuing

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc3c4dd9248328ada9159d29989ff2