### PR TITLE
feat: add notification filters and pagination

### DIFF
--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,19 +1,57 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import Notification from '@/models/Notification';
 import { auth } from '@/lib/auth';
 
-export async function GET() {
+const querySchema = z.object({
+  type: z.string().optional(),
+  read: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .optional(),
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export async function GET(req: Request) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  const url = new URL(req.url);
+  const raw: Record<string, any> = {};
+  url.searchParams.forEach((value, key) => {
+    raw[key] = value;
+  });
+  let query: z.infer<typeof querySchema>;
+  try {
+    query = querySchema.parse(raw);
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+
   await dbConnect();
-  const notifications = await Notification.find({
-    userId: session.userId,
-  })
+
+  const filter: Record<string, any> = { userId: session.userId };
+  if (query.type) filter.type = query.type;
+  if (typeof query.read === 'boolean') filter.read = query.read;
+  if (query.startDate || query.endDate) {
+    filter.createdAt = {};
+    if (query.startDate) filter.createdAt.$gte = query.startDate;
+    if (query.endDate) filter.createdAt.$lte = query.endDate;
+  }
+
+  const page = query.page ?? 1;
+  const limit = query.limit ?? 50;
+
+  const notifications = await Notification.find(filter)
     .sort({ createdAt: -1 })
-    .limit(50);
+    .skip((page - 1) * limit)
+    .limit(limit);
   return NextResponse.json(notifications);
 }
 

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,30 +1,84 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import useNotificationsChannel from '@/hooks/useNotificationsChannel';
 
+const PAGE_SIZE = 20;
+
 export default function NotificationsPage() {
+  const [filters, setFilters] = useState({
+    type: '',
+    read: '',
+    startDate: '',
+    endDate: '',
+  });
   const [items, setItems] = useState<any[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(
+    async (nextPage: number, replace = false) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (filters.type) params.append('type', filters.type);
+        if (filters.read) params.append('read', filters.read);
+        if (filters.startDate) params.append('startDate', filters.startDate);
+        if (filters.endDate) params.append('endDate', filters.endDate);
+        params.append('limit', PAGE_SIZE.toString());
+        params.append('page', nextPage.toString());
+        const res = await fetch(`/api/notifications?${params.toString()}`);
+        if (res.ok) {
+          const data = await res.json();
+          setItems((prev) => (replace ? data : [...prev, ...data]));
+          setHasMore(data.length === PAGE_SIZE);
+          setPage(nextPage);
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [filters]
+  );
 
   useEffect(() => {
-    const load = async () => {
-      const res = await fetch('/api/notifications');
-      if (res.ok) {
-        setItems(await res.json());
-      }
-    };
-    load();
-  }, []);
+    void load(1, true);
+  }, [filters, load]);
+
+  const loadMore = () => {
+    void load(page + 1);
+  };
 
   useNotificationsChannel({
-    onNotification: (n) => setItems((items) => [n, ...items]),
+    onNotification: (n) => {
+      const matchesType = !filters.type || filters.type === n.type;
+      const matchesRead =
+        !filters.read || (filters.read === 'true' ? n.read : !n.read);
+      const created = new Date(n.createdAt);
+      const matchesStart =
+        !filters.startDate || created >= new Date(filters.startDate);
+      const matchesEnd =
+        !filters.endDate || created <= new Date(filters.endDate);
+      if (matchesType && matchesRead && matchesStart && matchesEnd) {
+        setItems((items) => [n, ...items]);
+      }
+    },
   });
 
   const markRead = async (id: string) => {
     const res = await fetch(`/api/notifications/${id}/read`, { method: 'POST' });
     if (res.ok) {
-      setItems((items) =>
-        items.map((n) => (n._id === id ? { ...n, read: true, readAt: new Date().toISOString() } : n))
-      );
+      if (filters.read === 'false') {
+        setItems((items) => items.filter((n) => n._id !== id));
+      } else {
+        setItems((items) =>
+          items.map((n) =>
+            n._id === id
+              ? { ...n, read: true, readAt: new Date().toISOString() }
+              : n
+          )
+        );
+      }
       window.dispatchEvent(new CustomEvent('notification-read'));
     }
   };
@@ -35,9 +89,16 @@ export default function NotificationsPage() {
       unread.map((n) => fetch(`/api/notifications/${n._id}/read`, { method: 'POST' }))
     );
     if (unread.length > 0) {
-      setItems((items) =>
-        items.map((n) => (n.read ? n : { ...n, read: true, readAt: new Date().toISOString() }))
-      );
+      if (filters.read === 'false') {
+        setItems([]);
+        setHasMore(false);
+      } else {
+        setItems((items) =>
+          items.map((n) =>
+            n.read ? n : { ...n, read: true, readAt: new Date().toISOString() }
+          )
+        );
+      }
       window.dispatchEvent(
         new CustomEvent('notification-read', { detail: { count: unread.length } })
       );
@@ -54,6 +115,38 @@ export default function NotificationsPage() {
           </button>
         )}
       </div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          type="text"
+          placeholder="Type"
+          value={filters.type}
+          onChange={(e) => setFilters({ ...filters, type: e.target.value })}
+          className="border p-1 text-sm"
+        />
+        <select
+          value={filters.read}
+          onChange={(e) => setFilters({ ...filters, read: e.target.value })}
+          className="border p-1 text-sm"
+        >
+          <option value="">All</option>
+          <option value="false">Unread</option>
+          <option value="true">Read</option>
+        </select>
+        <input
+          type="date"
+          value={filters.startDate}
+          onChange={(e) => setFilters({ ...filters, startDate: e.target.value })}
+          className="border p-1 text-sm"
+        />
+        <input
+          type="date"
+          value={filters.endDate}
+          onChange={(e) => setFilters({ ...filters, endDate: e.target.value })}
+          className="border p-1 text-sm"
+        />
+      </div>
+
       <ul className="flex flex-col gap-1">
         {items.map((n) => (
           <li
@@ -65,6 +158,16 @@ export default function NotificationsPage() {
           </li>
         ))}
       </ul>
+
+      {hasMore && (
+        <button
+          onClick={loadMore}
+          className="mt-4 border px-4 py-2 text-sm"
+          disabled={loading}
+        >
+          Load more
+        </button>
+      )}
     </div>
   );
 }

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -23,5 +23,7 @@ const notificationSchema = new Schema<INotification>(
 );
 
 notificationSchema.index({ userId: 1, read: 1 });
+notificationSchema.index({ createdAt: -1 });
+notificationSchema.index({ type: 1 });
 
 export default models.Notification || model<INotification>('Notification', notificationSchema);


### PR DESCRIPTION
## Summary
- extend notifications API with filtering by type/read/status and pagination
- index notification model by createdAt and type for faster lookup
- add UI controls for filtering notifications and loading more results

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3ffd7c5c83288315f8c005fa130d