### PR TITLE
feat: add notification settings with digest frequency

### DIFF
--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import dbConnect from '@/lib/db';
+import User from '@/models/User';
+import { auth } from '@/lib/auth';
+import { problem } from '@/lib/http';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  await dbConnect();
+  const user = await User.findById(session.userId)
+    .select('notificationSettings')
+    .lean();
+  if (!user) {
+    return problem(404, 'Not found', 'User not found.');
+  }
+  const prefs =
+    user.notificationSettings ||
+    { email: true, push: true, digestFrequency: 'daily' };
+  return NextResponse.json(prefs);
+}
+
+const updateSchema = z.object({
+  email: z.boolean().optional(),
+  push: z.boolean().optional(),
+  digestFrequency: z.enum(['daily', 'weekly']).optional(),
+});
+
+export async function PUT(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return problem(401, 'Unauthorized', 'You must be signed in.');
+  }
+  let body: z.infer<typeof updateSchema>;
+  try {
+    body = updateSchema.parse(await req.json());
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+  await dbConnect();
+  try {
+    const user = await User.findByIdAndUpdate(
+      session.userId,
+      { notificationSettings: body },
+      { new: true, runValidators: true }
+    )
+      .select('notificationSettings')
+      .lean();
+    if (!user) {
+      return problem(404, 'Not found', 'User not found.');
+    }
+    return NextResponse.json(user.notificationSettings);
+  } catch (e: any) {
+    return problem(400, 'Invalid request', e.message);
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -12,6 +12,7 @@ interface PasswordFormData {
 interface NotificationsFormData {
   email: boolean;
   push: boolean;
+  digestFrequency: 'daily' | 'weekly';
 }
 
 interface TimezoneFormData {
@@ -64,7 +65,11 @@ export default function SettingsPage() {
         const user = await userRes.json();
         const prefs = await notifRes.json();
         resetTimezone({ timezone: user.timezone || '' });
-        resetNotifications({ email: prefs.email ?? true, push: prefs.push ?? true });
+        resetNotifications({
+          email: prefs.email ?? true,
+          push: prefs.push ?? true,
+          digestFrequency: prefs.digestFrequency || 'daily',
+        });
       } catch {
         setLoadError('Failed to load settings');
       } finally {
@@ -208,6 +213,16 @@ export default function SettingsPage() {
           <label className="flex items-center gap-2">
             <input type="checkbox" {...registerNotifications('push')} />
             <span>Push Notifications</span>
+          </label>
+          <label className="flex items-center gap-2">
+            <span>Digest Frequency</span>
+            <select
+              className="border p-2"
+              {...registerNotifications('digestFrequency')}
+            >
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+            </select>
           </label>
           {notificationsError && <p className="text-red-500">{notificationsError}</p>}
           {notificationsSuccess && <p className="text-green-500">{notificationsSuccess}</p>}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -15,6 +15,11 @@ export interface IUser extends Document {
   role: 'ADMIN' | 'USER';
   avatar?: string;
   permissions: string[];
+  notificationSettings: {
+    email: boolean;
+    push: boolean;
+    digestFrequency: 'daily' | 'weekly';
+  };
 }
 
 const userSchema = new Schema<IUser>(
@@ -41,6 +46,15 @@ const userSchema = new Schema<IUser>(
     role: { type: String, enum: ['ADMIN', 'USER'], default: 'USER' },
     avatar: { type: String },
     permissions: { type: [String], default: [] },
+    notificationSettings: {
+      email: { type: Boolean, default: true },
+      push: { type: Boolean, default: true },
+      digestFrequency: {
+        type: String,
+        enum: ['daily', 'weekly'],
+        default: 'daily',
+      },
+    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- add `notificationSettings` subdocument to user model
- implement `/api/users/me/notifications` GET & PUT routes
- allow users to manage digest frequency on settings page

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc415825d48328a63f2024dc604010