### PR TITLE
Introduce notification enum and loop step alerts

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,13 +1,41 @@
 import agenda, { initAgenda, DEFAULT_TZ } from '@/lib/agenda';
 import User from '@/models/User';
 import Team from '@/models/Team';
+import Task from '@/models/Task';
+import { notifyDueSoon, notifyDueNow, notifyOverdue } from '@/lib/notify';
+import { Types } from 'mongoose';
 
 agenda.define('task.dueSoon', async (job) => {
-  console.log('task.dueSoon', job.attrs.data);
+  const { taskId, stepId } = job.attrs.data as { taskId: string; stepId?: string };
+  const task = await Task.findById(taskId).lean();
+  if (!task) return;
+  let recipients: Types.ObjectId[] = [];
+  if (stepId) {
+    const idx = parseInt(stepId.split(':')[1] || '0', 10);
+    const step = task.steps?.[idx];
+    if (step?.ownerId) recipients = [step.ownerId];
+  } else {
+    recipients = (task.participantIds || []) as Types.ObjectId[];
+  }
+  if (recipients.length) await notifyDueSoon(recipients, task);
 });
 
 agenda.define('task.dueNow', async (job) => {
-  console.log('task.dueNow', job.attrs.data);
+  const { taskId, stepId } = job.attrs.data as { taskId: string; stepId?: string };
+  const task = await Task.findById(taskId).lean();
+  if (!task) return;
+  let recipients: Types.ObjectId[] = [];
+  if (stepId) {
+    const idx = parseInt(stepId.split(':')[1] || '0', 10);
+    const step = task.steps?.[idx];
+    if (step?.ownerId) recipients = [step.ownerId];
+  } else {
+    recipients = (task.participantIds || []) as Types.ObjectId[];
+  }
+  if (recipients.length) {
+    await notifyDueNow(recipients, task);
+    await notifyOverdue(recipients, task);
+  }
 });
 
 agenda.define('task.overdueDigest', async (job) => {

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -7,8 +7,8 @@ const auth = vi.fn();
 vi.mock('@/lib/auth', () => ({ auth }));
 
 const notifyAssignment = vi.fn();
-const notifyFlowAdvanced = vi.fn();
-vi.mock('@/lib/notify', () => ({ notifyAssignment, notifyFlowAdvanced }));
+const notifyLoopStepReady = vi.fn();
+vi.mock('@/lib/notify', () => ({ notifyAssignment, notifyLoopStepReady }));
 
 const findTaskById = vi.fn();
 vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
@@ -69,7 +69,7 @@ describe('PATCH /tasks/:id/loop assignedTo updates', () => {
     startSession.mockReset();
     startSession.mockResolvedValue({ withTransaction, endSession: vi.fn() });
     notifyAssignment.mockReset();
-    notifyFlowAdvanced.mockReset();
+    notifyLoopStepReady.mockReset();
   });
 
   it('updates assignee, resets status, and notifies users', async () => {
@@ -96,7 +96,7 @@ describe('PATCH /tasks/:id/loop assignedTo updates', () => {
       { _id: taskId, organizationId: orgId },
       'step'
     );
-    expect(notifyFlowAdvanced).toHaveBeenCalledWith(
+    expect(notifyLoopStepReady).toHaveBeenCalledWith(
       [newUser],
       { _id: taskId, organizationId: orgId },
       'step'

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -9,7 +9,7 @@ import User from '@/models/User';
 import { canWriteTask } from '@/lib/access';
 import { problem } from '@/lib/http';
 import { withOrganization } from '@/lib/middleware/withOrganization';
-import { notifyAssignment, notifyFlowAdvanced } from '@/lib/notify';
+import { notifyAssignment, notifyLoopStepReady } from '@/lib/notify';
 import { emitLoopUpdated } from '@/lib/ws';
 
 const loopStepSchema = z.object({
@@ -304,7 +304,7 @@ export const PATCH = withOrganization(
     for (const a of newAssignments) {
       const uid = new Types.ObjectId(a.userId);
       await notifyAssignment([uid], task, a.description);
-      await notifyFlowAdvanced([uid], task, a.description);
+      await notifyLoopStepReady([uid], task, a.description);
     }
   for (const a of oldAssignments) {
     const uid = new Types.ObjectId(a.userId);

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -9,7 +9,7 @@ import { emitTaskTransition } from '@/lib/ws';
 import { diff } from '@/lib/diff';
 import {
   notifyStatusChange,
-  notifyFlowAdvanced,
+  notifyLoopStepReady,
   notifyTaskClosed,
   notifyAssignment,
 } from '@/lib/notify';
@@ -101,7 +101,7 @@ export async function POST(req: Request, { params }: { params: { id: string } })
         const step = updated.steps[updated.currentStepIndex];
         const desc = step?.title;
         await notifyAssignment([ownerId] as Types.ObjectId[], updated, desc);
-        await notifyFlowAdvanced([ownerId] as Types.ObjectId[], updated, desc);
+        await notifyLoopStepReady([ownerId] as Types.ObjectId[], updated, desc);
       }
     }
     const patch = diff(task, updated.toObject());

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -14,7 +14,7 @@ vi.mock('mongoose', async () => {
   };
 });
 import mongoose from 'mongoose';
-import { notifyTaskClosed, notifyFlowAdvanced, notifyAssignment } from '@/lib/notify';
+import { notifyTaskClosed, notifyLoopStepReady, notifyAssignment } from '@/lib/notify';
 
 // mocks
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
@@ -48,7 +48,7 @@ vi.mock('@/lib/auth', () => ({ auth: vi.fn(async () => ({ userId: currentUserId,
 vi.mock('@/lib/ws', () => ({ emitTaskTransition: vi.fn() }));
 vi.mock('@/lib/notify', () => ({
   notifyStatusChange: vi.fn(),
-  notifyFlowAdvanced: vi.fn(),
+  notifyLoopStepReady: vi.fn(),
   notifyTaskClosed: vi.fn(),
   notifyAssignment: vi.fn(),
 }));
@@ -98,7 +98,7 @@ describe('task flow with steps', () => {
       expect.objectContaining({ _id: taskId }),
       'Step 2'
     );
-    expect(notifyFlowAdvanced).toHaveBeenCalledWith(
+    expect(notifyLoopStepReady).toHaveBeenCalledWith(
       [u2],
       expect.objectContaining({ _id: taskId }),
       'Step 2'
@@ -121,7 +121,7 @@ describe('task flow with steps', () => {
       expect.objectContaining({ _id: taskId }),
       'Step 3'
     );
-    expect(notifyFlowAdvanced).toHaveBeenCalledWith(
+    expect(notifyLoopStepReady).toHaveBeenCalledWith(
       [u3],
       expect.objectContaining({ _id: taskId }),
       'Step 3'

--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -4,6 +4,7 @@ import dbConnect from '@/lib/db';
 import User from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
+import { NotificationType } from '@/lib/notify';
 
 export async function GET() {
   const session = await auth();
@@ -24,10 +25,10 @@ export async function GET() {
       push: true,
       digestFrequency: 'daily',
       types: {
-        ASSIGNMENT: true,
-        FLOW_ADVANCED: true,
-        TASK_CLOSED: true,
-        OVERDUE: true,
+        [NotificationType.ASSIGNMENT]: true,
+        [NotificationType.LOOP_STEP_READY]: true,
+        [NotificationType.TASK_CLOSED]: true,
+        [NotificationType.OVERDUE]: true,
       },
     };
   return NextResponse.json(prefs);
@@ -39,10 +40,10 @@ const updateSchema = z.object({
   digestFrequency: z.enum(['daily', 'weekly']).optional(),
   types: z
     .object({
-      ASSIGNMENT: z.boolean().optional(),
-      FLOW_ADVANCED: z.boolean().optional(),
-      TASK_CLOSED: z.boolean().optional(),
-      OVERDUE: z.boolean().optional(),
+      [NotificationType.ASSIGNMENT]: z.boolean().optional(),
+      [NotificationType.LOOP_STEP_READY]: z.boolean().optional(),
+      [NotificationType.TASK_CLOSED]: z.boolean().optional(),
+      [NotificationType.OVERDUE]: z.boolean().optional(),
     })
     .optional(),
 });

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -3,9 +3,9 @@ import { Types } from 'mongoose';
 
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
-const notifyFlowAdvanced = vi.fn();
+const notifyLoopStepReady = vi.fn();
 const notifyAssignment = vi.fn();
-vi.mock('@/lib/notify', () => ({ notifyFlowAdvanced, notifyAssignment }));
+vi.mock('@/lib/notify', () => ({ notifyLoopStepReady, notifyAssignment }));
 
 const findOne = vi.fn();
 vi.mock('@/models/TaskLoop', () => ({ default: { findOne } }));
@@ -26,7 +26,7 @@ describe('completeStep', () => {
   let loop: any;
 
   beforeEach(() => {
-    notifyFlowAdvanced.mockReset();
+    notifyLoopStepReady.mockReset();
     notifyAssignment.mockReset();
     findTaskById.mockReset();
     createHistory.mockReset();
@@ -53,19 +53,19 @@ describe('completeStep', () => {
     expect(loop.sequence[2].status).toBe('BLOCKED');
     expect(loop.currentStep).toBe(1);
     expect(notifyAssignment).toHaveBeenCalledWith([userB], { _id: taskId }, undefined);
-    expect(notifyFlowAdvanced).toHaveBeenCalledWith([userB], { _id: taskId }, undefined);
+    expect(notifyLoopStepReady).toHaveBeenCalledWith([userB], { _id: taskId }, undefined);
 
     expect(createHistory).toHaveBeenCalledWith(
       expect.objectContaining({ stepIndex: 0 })
     );
 
-    notifyFlowAdvanced.mockClear();
+    notifyLoopStepReady.mockClear();
     res = await completeStep(taskId.toString(), 1, userB.toString());
     expect(loop.sequence[1].status).toBe('COMPLETED');
     expect(loop.sequence[2].status).toBe('ACTIVE');
     expect(loop.currentStep).toBe(2);
     expect(notifyAssignment).toHaveBeenCalledWith([userC], { _id: taskId }, undefined);
-    expect(notifyFlowAdvanced).toHaveBeenCalledWith([userC], { _id: taskId }, undefined);
+    expect(notifyLoopStepReady).toHaveBeenCalledWith([userC], { _id: taskId }, undefined);
     expect(createHistory).toHaveBeenCalledWith(
       expect.objectContaining({ stepIndex: 1 })
     );

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -3,7 +3,7 @@ import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
 import TaskLoop from '@/models/TaskLoop';
 import LoopHistory from '@/models/LoopHistory';
-import { notifyAssignment, notifyFlowAdvanced } from '@/lib/notify';
+import { notifyAssignment, notifyLoopStepReady } from '@/lib/notify';
 
 export async function completeStep(
   taskId: string,
@@ -101,7 +101,7 @@ export async function completeStep(
         const s = updatedLoop.sequence[idx];
         const assignee = s.assignedTo as Types.ObjectId;
         await notifyAssignment([assignee], task, s.description);
-        await notifyFlowAdvanced([assignee], task, s.description);
+        await notifyLoopStepReady([assignee], task, s.description);
       }
     }
   }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -21,7 +21,7 @@ export interface IUser extends Document {
     digestFrequency: 'daily' | 'weekly';
     types: {
       ASSIGNMENT: boolean;
-      FLOW_ADVANCED: boolean;
+      LOOP_STEP_READY: boolean;
       TASK_CLOSED: boolean;
       OVERDUE: boolean;
     };
@@ -63,7 +63,7 @@ const userSchema = new Schema<IUser>(
       },
       types: {
         ASSIGNMENT: { type: Boolean, default: true },
-        FLOW_ADVANCED: { type: Boolean, default: true },
+        LOOP_STEP_READY: { type: Boolean, default: true },
         TASK_CLOSED: { type: Boolean, default: true },
         OVERDUE: { type: Boolean, default: true },
       },


### PR DESCRIPTION
## Summary
- centralize notification types with `NotificationType` enum
- add `notifyLoopStepReady` and update task workflows to trigger it
- fire due soon/now/overdue notifications via worker

## Testing
- ⚠️ `npm install` (403 Forbidden)
- ⚠️ `npm test` (vitest not found)


------
https://chatgpt.com/codex/tasks/task_e_68bc460f395c832891c2bb9427656fee