### PR TITLE
feat: allow toggling notification read state

### DIFF
--- a/src/app/api/notifications/[id]/read/route.test.ts
+++ b/src/app/api/notifications/[id]/read/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Types } from 'mongoose';
+
+vi.mock('@/lib/db', () => ({ default: vi.fn() }));
+
+const auth = vi.fn();
+vi.mock('@/lib/auth', () => ({ auth }));
+
+const findOneAndUpdate = vi.fn();
+vi.mock('@/models/Notification', () => ({ default: { findOneAndUpdate } }));
+
+import { POST } from './route';
+
+describe('POST /notifications/:id/read', () => {
+  const id = new Types.ObjectId().toString();
+  const session = { userId: new Types.ObjectId().toString() } as any;
+
+  beforeEach(() => {
+    auth.mockResolvedValue(session);
+    findOneAndUpdate.mockReset();
+    findOneAndUpdate.mockResolvedValue({ _id: id });
+  });
+
+  it('marks notification read by default', async () => {
+    const res = await POST(new Request('http://test', { method: 'POST' }), { params: { id } });
+    expect(res.status).toBe(200);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: id, userId: session.userId },
+      { read: true, readAt: expect.any(Date) },
+      { new: true }
+    );
+  });
+
+  it('marks notification unread when read is false', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ read: false }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req, { params: { id } });
+    expect(res.status).toBe(200);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: id, userId: session.userId },
+      { read: false, readAt: null },
+      { new: true }
+    );
+  });
+});
+

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -19,10 +19,22 @@ export async function POST(request: Request, { params }: Params) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
 
+  let read = true;
+  try {
+    const body = await request.json();
+    if (typeof body.read === 'boolean') {
+      read = body.read;
+    }
+  } catch {
+    // ignore invalid json and default to true
+  }
+
   await dbConnect();
+  const update: any = { read };
+  update.readAt = read ? new Date() : null;
   const notification = await Notification.findOneAndUpdate(
     { _id: id, userId: session.userId },
-    { read: true, readAt: new Date() },
+    update,
     { new: true }
   );
 

--- a/src/components/notifications-badge.tsx
+++ b/src/components/notifications-badge.tsx
@@ -11,12 +11,20 @@ export default function NotificationsBadge() {
       .then((res) => (res.ok ? res.json() : { count: 0 }))
       .then((data) => setCount(data.count))
       .catch(() => {});
-    const handler = (e: Event) => {
+    const readHandler = (e: Event) => {
       const detail = (e as CustomEvent<{ count?: number }>).detail;
       setCount((c) => Math.max(0, c - (detail?.count ?? 1)));
     };
-    window.addEventListener('notification-read', handler);
-    return () => window.removeEventListener('notification-read', handler);
+    const unreadHandler = (e: Event) => {
+      const detail = (e as CustomEvent<{ count?: number }>).detail;
+      setCount((c) => c + (detail?.count ?? 1));
+    };
+    window.addEventListener('notification-read', readHandler);
+    window.addEventListener('notification-unread', unreadHandler);
+    return () => {
+      window.removeEventListener('notification-read', readHandler);
+      window.removeEventListener('notification-unread', unreadHandler);
+    };
   }, []);
 
   useNotificationsChannel({


### PR DESCRIPTION
## Summary
- allow notifications read endpoint to toggle read/unread
- add "Mark as unread" action and handle unread events in badge
- cover notification read endpoint with unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc47c53c4c8328b9417b1e66adfc35