### PR TITLE
feat: add notification digest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint",
     "worker": "tsx scripts/worker.ts",
     "seed": "tsx scripts/seed.ts",
+    "digest": "tsx scripts/digest.ts",
     "test": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -1,0 +1,60 @@
+import dbConnect from '@/lib/db';
+import User from '@/models/User';
+import Notification from '@/models/Notification';
+import { Resend } from 'resend';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
+
+async function loadTemplate(): Promise<string> {
+  const fullPath = path.join(process.cwd(), 'src', 'emails', 'notification-digest.html');
+  return fs.readFile(fullPath, 'utf8');
+}
+
+async function main() {
+  await dbConnect();
+  const template = await loadTemplate();
+  const now = new Date();
+  const users = await User.find({
+    isActive: true,
+    'notificationSettings.digestFrequency': { $ne: 'immediate' },
+    'notificationSettings.email': { $ne: false },
+  });
+
+  for (const user of users) {
+    const prefs: any = user.notificationSettings || {};
+    const freq = prefs.digestFrequency;
+    const last: Date = prefs.lastDigestAt || new Date(0);
+    const interval = freq === 'weekly' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+    if (now.getTime() - last.getTime() < interval) continue;
+
+    const notifications = await Notification.find({
+      userId: user._id,
+      read: false,
+      createdAt: { $gt: last },
+    }).lean();
+    if (!notifications.length) continue;
+
+    const listItems = notifications.map((n: any) => `<li>${n.message}</li>`).join('');
+    const html = template.replace('{{content}}', listItems);
+    if (resend) {
+      await resend.emails.send({
+        from: 'notify@example.com',
+        to: user.email,
+        subject: 'Notification Digest',
+        html,
+      });
+    }
+    await User.updateOne(
+      { _id: user._id },
+      { 'notificationSettings.lastDigestAt': now }
+    );
+  }
+  console.log('Digest complete');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
     {
       email: true,
       push: true,
-      digestFrequency: 'daily',
+      digestFrequency: 'immediate',
       types: {
         [NotificationType.ASSIGNMENT]: true,
         [NotificationType.LOOP_STEP_READY]: true,
@@ -37,7 +37,7 @@ export async function GET() {
 const updateSchema = z.object({
   email: z.boolean().optional(),
   push: z.boolean().optional(),
-  digestFrequency: z.enum(['daily', 'weekly']).optional(),
+  digestFrequency: z.enum(['immediate', 'daily', 'weekly']).optional(),
   types: z
     .object({
       [NotificationType.ASSIGNMENT]: z.boolean().optional(),

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -12,7 +12,7 @@ interface PasswordFormData {
 interface NotificationsFormData {
   email: boolean;
   push: boolean;
-  digestFrequency: 'daily' | 'weekly';
+  digestFrequency: 'immediate' | 'daily' | 'weekly';
 }
 
 interface TimezoneFormData {
@@ -68,7 +68,7 @@ export default function SettingsPage() {
         resetNotifications({
           email: prefs.email ?? true,
           push: prefs.push ?? true,
-          digestFrequency: prefs.digestFrequency || 'daily',
+          digestFrequency: prefs.digestFrequency || 'immediate',
         });
       } catch {
         setLoadError('Failed to load settings');
@@ -220,6 +220,7 @@ export default function SettingsPage() {
               className="border p-2"
               {...registerNotifications('digestFrequency')}
             >
+              <option value="immediate">Immediate</option>
               <option value="daily">Daily</option>
               <option value="weekly">Weekly</option>
             </select>

--- a/src/emails/notification-digest.html
+++ b/src/emails/notification-digest.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <p>You have unread notifications:</p>
+    <ul>
+      {{content}}
+    </ul>
+  </body>
+</html>

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -78,7 +78,12 @@ async function createAndEmail(
   }
   if (!recipients.length) return;
   const notifications = await Notification.insertMany(
-    recipients.map((userId) => ({ userId, type, entityRef }))
+    recipients.map((userId) => ({
+      userId,
+      type,
+      message: text,
+      taskId: entityRef.taskId,
+    }))
   );
   notifications.forEach((n) =>
     emitNotification(n.toObject(), n.userId.toString())

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -18,7 +18,8 @@ export interface IUser extends Document {
   notificationSettings: {
     email: boolean;
     push: boolean;
-    digestFrequency: 'daily' | 'weekly';
+    digestFrequency: 'immediate' | 'daily' | 'weekly';
+    lastDigestAt?: Date;
     types: {
       ASSIGNMENT: boolean;
       LOOP_STEP_READY: boolean;
@@ -58,9 +59,10 @@ const userSchema = new Schema<IUser>(
       push: { type: Boolean, default: true },
       digestFrequency: {
         type: String,
-        enum: ['daily', 'weekly'],
-        default: 'daily',
+        enum: ['immediate', 'daily', 'weekly'],
+        default: 'immediate',
       },
+      lastDigestAt: { type: Date },
       types: {
         ASSIGNMENT: { type: Boolean, default: true },
         LOOP_STEP_READY: { type: Boolean, default: true },


### PR DESCRIPTION
## Summary
- support immediate, daily, and weekly digest frequencies with last sent tracking
- add script to send notification digests via Resend templates
- persist notification messages for digest summarization

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc48e3b68c8328bddf239dbe85c04d