### PR TITLE
feat: add saved search model and api

### DIFF
--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { Types } from 'mongoose';
+import { z } from 'zod';
+import dbConnect from '@/lib/db';
+import SavedSearch from '@/models/SavedSearch';
+import { auth } from '@/lib/auth';
+
+interface Params {
+  params: { id: string };
+}
+
+const bodySchema = z.object({
+  name: z.string().optional(),
+  query: z.string().optional(),
+});
+
+export async function GET(_req: Request, { params }: Params) {
+  const session = await auth();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  await dbConnect();
+  const search = await SavedSearch.findOne({ _id: id, userId: session.userId });
+  if (!search) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(search);
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const session = await auth();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+
+  await dbConnect();
+  const search = await SavedSearch.findOneAndUpdate(
+    { _id: id, userId: session.userId },
+    body,
+    { new: true }
+  );
+  if (!search) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(search);
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const session = await auth();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = params;
+  if (!Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+
+  await dbConnect();
+  const result = await SavedSearch.deleteOne({ _id: id, userId: session.userId });
+  if (result.deletedCount === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/search/saved/route.ts
+++ b/src/app/api/search/saved/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import dbConnect from '@/lib/db';
+import SavedSearch from '@/models/SavedSearch';
+import { auth } from '@/lib/auth';
+
+const bodySchema = z.object({
+  name: z.string(),
+  query: z.string(),
+});
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  await dbConnect();
+  const searches = await SavedSearch.find({ userId: session.userId }).sort({ createdAt: -1 });
+  return NextResponse.json(searches);
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let body: z.infer<typeof bodySchema>;
+  try {
+    body = bodySchema.parse(await req.json());
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+
+  await dbConnect();
+  const search = await SavedSearch.create({
+    userId: session.userId,
+    name: body.name,
+    query: body.query,
+  });
+  return NextResponse.json(search, { status: 201 });
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -15,15 +15,52 @@ interface SearchItem {
 export default function GlobalSearchPage() {
   const params = useSearchParams();
   const [data, setData] = useState<{ results: SearchItem[]; total: number }>();
+  const [saved, setSaved] = useState<{ _id: string; name: string; query: string }[]>([]);
 
   useEffect(() => {
     const qs = params.toString();
     fetch(`/api/search/global?${qs}`).then((res) => res.json()).then(setData);
   }, [params]);
 
+  useEffect(() => {
+    fetch('/api/search/saved').then((res) => res.json()).then(setSaved);
+  }, []);
+
+  const saveCurrent = () => {
+    const name = prompt('Name this search');
+    if (!name) return;
+    const qs = params.toString();
+    fetch('/api/search/saved', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, query: qs }),
+    }).then(() =>
+      fetch('/api/search/saved').then((res) => res.json()).then(setSaved)
+    );
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-lg mb-4">Search</h1>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <button onClick={saveCurrent} className="border rounded px-2 py-1">
+          Save Search
+        </button>
+        {saved.length > 0 && (
+          <ul className="flex flex-wrap gap-2">
+            {saved.map((s) => (
+              <li key={s._id}>
+                <Link
+                  href={`/search?${s.query}`}
+                  className="text-blue-600 underline"
+                >
+                  {s.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
       <form method="GET" className="flex flex-wrap gap-2 mb-4">
         <input
           type="text"

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -12,6 +12,7 @@ interface SearchResult {
 export default function TaskSearchPage() {
   const params = useSearchParams();
   const [data, setData] = useState<{ results: SearchResult[]; verification: any }>();
+  const [saved, setSaved] = useState<{ _id: string; name: string; query: string }[]>([]);
 
   const [ownerIds, setOwnerIds] = useState<string[]>(() => {
     const vals = params.getAll('ownerId');
@@ -43,9 +44,45 @@ export default function TaskSearchPage() {
     fetch(`/api/search/tasks?${qs}`).then((res) => res.json()).then(setData);
   }, [params]);
 
+  useEffect(() => {
+    fetch('/api/search/saved').then((res) => res.json()).then(setSaved);
+  }, []);
+
+  const saveCurrent = () => {
+    const name = prompt('Name this search');
+    if (!name) return;
+    const qs = params.toString();
+    fetch('/api/search/saved', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, query: qs }),
+    }).then(() =>
+      fetch('/api/search/saved').then((res) => res.json()).then(setSaved)
+    );
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-lg mb-4">Task Search</h1>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <button onClick={saveCurrent} className="border rounded px-2 py-1">
+          Save Search
+        </button>
+        {saved.length > 0 && (
+          <ul className="flex flex-wrap gap-2">
+            {saved.map((s) => (
+              <li key={s._id}>
+                <a
+                  href={`/search/tasks?${s.query}`}
+                  className="text-blue-600 underline"
+                >
+                  {s.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
       <form method="GET" className="flex flex-wrap gap-2 mb-4">
         <input
           type="text"

--- a/src/models/SavedSearch.ts
+++ b/src/models/SavedSearch.ts
@@ -1,0 +1,19 @@
+import { Schema, model, models, type Document, type Types } from 'mongoose';
+
+export interface ISavedSearch extends Document {
+  userId: Types.ObjectId;
+  name: string;
+  query: string;
+  createdAt: Date;
+}
+
+const savedSearchSchema = new Schema<ISavedSearch>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    name: { type: String, required: true },
+    query: { type: String, required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+export default models.SavedSearch || model<ISavedSearch>('SavedSearch', savedSearchSchema);


### PR DESCRIPTION
## Summary
- add SavedSearch model for storing user saved queries
- expose CRUD routes under `/api/search/saved`
- allow saving and reusing searches on search pages

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6370009c8328b013c7f7034a60ae