### PR TITLE
feat: add preset search filters

### DIFF
--- a/src/app/api/search/saved/route.ts
+++ b/src/app/api/search/saved/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import SavedSearch from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
+import { getPresets } from '@/app/search/filters';
 
 const bodySchema = z.object({
   name: z.string(),
@@ -16,8 +17,11 @@ export async function GET() {
   }
 
   await dbConnect();
-  const searches = await SavedSearch.find({ userId: session.userId }).sort({ createdAt: -1 });
-  return NextResponse.json(searches);
+  const searches = await SavedSearch.find({ userId: session.userId })
+    .sort({ createdAt: -1 })
+    .lean();
+  const presets = getPresets(session.userId);
+  return NextResponse.json([...presets, ...searches]);
 }
 
 export async function POST(req: Request) {

--- a/src/app/search/filters.ts
+++ b/src/app/search/filters.ts
@@ -1,0 +1,43 @@
+export interface PresetSearch {
+  _id: string;
+  name: string;
+  query: string;
+}
+
+const formatDate = (d: Date) => d.toISOString().split('T')[0];
+
+export function getPresets(userId?: string | null): PresetSearch[] {
+  const presets: PresetSearch[] = [];
+
+  if (userId) {
+    presets.push({
+      _id: 'preset-myTasks',
+      name: 'My Tasks',
+      query: `ownerId=${userId}`,
+    });
+  }
+
+  const today = new Date();
+  presets.push({
+    _id: 'preset-overdue',
+    name: 'Overdue',
+    query:
+      'status=OPEN&status=IN_PROGRESS&status=IN_REVIEW&status=REVISIONS&status=FLOW_IN_PROGRESS&dueTo=' +
+      formatDate(today),
+  });
+
+  const start = new Date(today);
+  const day = start.getDay();
+  const diff = day === 0 ? -6 : 1 - day; // start week on Monday
+  start.setDate(start.getDate() + diff);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+
+  presets.push({
+    _id: 'preset-thisWeek',
+    name: 'This Week',
+    query: `dueFrom=${formatDate(start)}&dueTo=${formatDate(end)}`,
+  });
+
+  return presets;
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import FilterBuilder from '@/components/filter-builder';
+import { useSession } from 'next-auth/react';
+import { getPresets } from './filters';
 
 interface SearchItem {
   _id: string;
@@ -15,6 +17,9 @@ interface SearchItem {
 
 export default function GlobalSearchPage() {
   const params = useSearchParams();
+  const router = useRouter();
+  const { data: session } = useSession();
+  const presets = getPresets(session?.userId);
   const [data, setData] = useState<{ results: SearchItem[]; total: number }>();
   const [saved, setSaved] = useState<{ _id: string; name: string; query: string }[]>([]);
   const [q, setQ] = useState(params.get('q') ?? '');
@@ -67,6 +72,19 @@ export default function GlobalSearchPage() {
   return (
     <div className="p-4">
       <h1 className="text-lg mb-4">Search</h1>
+      {presets.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {presets.map((p) => (
+            <button
+              key={p._id}
+              onClick={() => router.push(`?${p.query}`)}
+              className="border rounded px-2 py-1"
+            >
+              {p.name}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <button onClick={saveCurrent} className="border rounded px-2 py-1">
           Save Search

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import FilterBuilder from '@/components/filter-builder';
+import { useSession } from 'next-auth/react';
+import { getPresets } from '../filters';
 
 interface SearchResult {
   _id: string;
@@ -12,6 +14,9 @@ interface SearchResult {
 
 export default function TaskSearchPage() {
   const params = useSearchParams();
+  const router = useRouter();
+  const { data: session } = useSession();
+  const presets = getPresets(session?.userId);
   const [data, setData] = useState<{ results: SearchResult[]; verification: any }>();
   const [saved, setSaved] = useState<{ _id: string; name: string; query: string }[]>([]);
 
@@ -65,6 +70,19 @@ export default function TaskSearchPage() {
   return (
     <div className="p-4">
       <h1 className="text-lg mb-4">Task Search</h1>
+      {presets.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {presets.map((p) => (
+            <button
+              key={p._id}
+              onClick={() => router.push(`?${p.query}`)}
+              className="border rounded px-2 py-1"
+            >
+              {p.name}
+            </button>
+          ))}
+        </div>
+      )}
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <button onClick={saveCurrent} className="border rounded px-2 py-1">
           Save Search


### PR DESCRIPTION
## Summary
- add built-in search presets like "My Tasks", "Overdue" and "This Week"
- expose presets via saved-search API
- surface preset buttons on search pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc68780c008328af5f03e459cf04ea