### PR TITLE
feat: highlight search results

### DIFF
--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -164,10 +164,15 @@ export default function GlobalSearchPage() {
               href={r.type === 'task' ? `/tasks/${r._id}` : `/tasks/${r.taskId}`}
               className="font-semibold text-blue-600"
             >
-              {r.title || '(no title)'}
+              <span
+                dangerouslySetInnerHTML={{ __html: r.title || '(no title)' }}
+              />
             </Link>
             {r.excerpt && (
-              <div className="text-sm text-gray-700">{r.excerpt}</div>
+              <div
+                className="text-sm text-gray-700"
+                dangerouslySetInnerHTML={{ __html: r.excerpt }}
+              />
             )}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- compute highlighted snippets in global search API
- return highlight markup in results and render with `dangerouslySetInnerHTML`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69d266448328a5d94ff9adf38b2a