### PR TITLE
feat: add pagination and indexes to search endpoints

### DIFF
--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -11,7 +11,7 @@ import { problem } from '@/lib/http';
 const querySchema = z.object({
   q: z.string().optional(),
   limit: z.coerce.number().min(1).max(100).default(20),
-  skip: z.coerce.number().min(0).default(0),
+  page: z.coerce.number().min(1).default(1),
   sort: z.enum(['recent', 'oldest']).optional(),
 });
 
@@ -132,7 +132,8 @@ export async function GET(req: Request) {
     );
   }
 
-  const paged = results.slice(query.skip, query.skip + query.limit);
+  const skip = (query.page - 1) * query.limit;
+  const paged = results.slice(skip, skip + query.limit);
 
   return NextResponse.json({ results: paged, total: results.length });
 }

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -18,6 +18,8 @@ const commentSchema = new Schema<IComment>(
 );
 
 commentSchema.index({ taskId: 1, parentId: 1, createdAt: -1 });
+commentSchema.index({ updatedAt: -1 });
+commentSchema.index({ userId: 1 });
 commentSchema.index({ content: 'text' });
 
 export default models.Comment || model<IComment>('Comment', commentSchema);

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -85,6 +85,12 @@ taskSchema.index({ ownerId: 1 });
 taskSchema.index({ helpers: 1 });
 taskSchema.index({ 'custom.$**': 1 });
 taskSchema.index({ updatedAt: -1 });
+taskSchema.index({ createdAt: -1 });
+taskSchema.index({ dueDate: 1 });
+taskSchema.index({ createdBy: 1 });
+taskSchema.index({ teamId: 1 });
+taskSchema.index({ tags: 1 });
+taskSchema.index({ visibility: 1 });
 taskSchema.index({ title: 'text', description: 'text' });
 
 taskSchema.pre('save', function (next) {

--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -69,5 +69,7 @@ const taskLoopSchema = new Schema<ITaskLoop>(
 taskLoopSchema.index({ taskId: 1 });
 taskLoopSchema.index({ 'sequence.status': 1 });
 taskLoopSchema.index({ 'sequence.description': 'text' });
+taskLoopSchema.index({ createdAt: -1 });
+taskLoopSchema.index({ updatedAt: -1 });
 
 export default models.TaskLoop || model<ITaskLoop>('TaskLoop', taskLoopSchema);


### PR DESCRIPTION
## Summary
- add page/limit parameters and total counts to search APIs
- index created/updated/due fields and common filters for faster queries

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc6ac708c48328905403427be84504