### PR TITLE
feat: add export endpoint and button

### DIFF
--- a/src/app/api/search/export/route.ts
+++ b/src/app/api/search/export/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { GET as searchTasks } from '../tasks/route';
+import { GET as searchGlobal } from '../global/route';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const format = url.searchParams.get('format') || 'csv';
+  url.searchParams.delete('format');
+
+  // Decide which search endpoint to use
+  const sort = url.searchParams.get('sort');
+  const hasTaskSpecific =
+    ['status', 'tag', 'ownerId', 'helpers', 'createdBy', 'teamId', 'visibility'].some((p) =>
+      url.searchParams.has(p)
+    ) || (sort ? ['relevance', 'updatedAt', 'dueDate'].includes(sort) : false);
+
+  let searchRes: Response;
+  if (!hasTaskSpecific) {
+    // global search: convert skip to page if present
+    const skip = url.searchParams.get('skip');
+    if (skip) {
+      const limit = Number(url.searchParams.get('limit') || '20');
+      const page = Math.floor(Number(skip) / limit) + 1;
+      url.searchParams.delete('skip');
+      url.searchParams.set('page', String(page));
+    }
+    searchRes = await searchGlobal(new Request(url.toString(), { headers: req.headers }));
+  } else {
+    searchRes = await searchTasks(new Request(url.toString(), { headers: req.headers }));
+  }
+
+  if (!searchRes.ok) {
+    return searchRes;
+  }
+  const data = await searchRes.json();
+  if (format === 'json') {
+    return NextResponse.json(data);
+  }
+
+  // Build CSV depending on result shape
+  let headersRow: string[];
+  let rows: string[][];
+  if (data.results?.[0]?.type) {
+    headersRow = ['id', 'type', 'title', 'excerpt'];
+    rows = data.results.map((r: any) => [
+      r._id,
+      r.type,
+      '"' + String(r.title ?? '').replace(/"/g, '""') + '"',
+      '"' + String(r.excerpt ?? '').replace(/"/g, '""') + '"',
+    ]);
+  } else {
+    headersRow = ['id', 'title', 'status', 'dueDate'];
+    rows = data.results.map((t: any) => [
+      t._id,
+      '"' + String(t.title ?? '').replace(/"/g, '""') + '"',
+      t.status ?? '',
+      t.dueDate ? new Date(t.dueDate).toISOString() : '',
+    ]);
+  }
+  const csv = [headersRow.join(','), ...rows.map((r) => r.join(','))].join('\n');
+  return new NextResponse(csv, {
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': 'attachment; filename="search-results.csv"',
+    },
+  });
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -89,6 +89,12 @@ export default function GlobalSearchPage() {
         <button onClick={saveCurrent} className="border rounded px-2 py-1">
           Save Search
         </button>
+        <a
+          href={`/api/search/export?${params.toString()}`}
+          className="border rounded px-2 py-1"
+        >
+          Export
+        </a>
         {saved.length > 0 && (
           <ul className="flex flex-wrap gap-2">
             {saved.map((s) => (

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -87,6 +87,12 @@ export default function TaskSearchPage() {
         <button onClick={saveCurrent} className="border rounded px-2 py-1">
           Save Search
         </button>
+        <a
+          href={`/api/search/export?${params.toString()}`}
+          className="border rounded px-2 py-1"
+        >
+          Export
+        </a>
         {saved.length > 0 && (
           <ul className="flex flex-wrap gap-2">
             {saved.map((s) => (


### PR DESCRIPTION
## Summary
- add `/api/search/export` supporting CSV and JSON for task/global searches
- add Export button to search and task search pages

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc6b9eb1b48328b596038ff98c5659