### PR TITLE
Seed multiple organizations with teams and users

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -13,68 +13,76 @@ async function run() {
     Task.deleteMany({})
   ]);
 
-  const org = await Organization.create({ name: 'Acme' });
-  const team = await Team.create({ name: 'Accounts' });
-  const [user1, user2, user3, _admin] = await User.create([
-    {
-      name: 'User One',
-      email: 'user1@ex.com',
-      username: 'user1',
-      password: 'user1',
-      organizationId: org._id,
-      teamId: team._id,
-    },
-    {
-      name: 'User Two',
-      email: 'user2@ex.com',
-      username: 'user2',
-      password: 'user2',
-      organizationId: org._id,
-      teamId: team._id,
-    },
-    {
-      name: 'User Three',
-      email: 'user3@ex.com',
-      username: 'user3',
-      password: 'user3',
-      organizationId: org._id,
-      teamId: team._id,
-    },
-    {
-      name: 'Admin',
-      email: 'admin@ex.com',
-      username: 'admin',
-      password: 'admin',
-      organizationId: org._id,
-      teamId: team._id,
-      role: 'ADMIN',
-    },
+  const organizations = await Organization.create([
+    { name: 'Acme', domain: 'acme.com' },
+    { name: 'Globex', domain: 'globex.com' },
+    { name: 'Initech', domain: 'initech.com' },
   ]);
 
-  const simpleDue = new Date(Date.now() + 2 * 60 * 60 * 1000);
-  await Task.create({
-    title: 'Simple task',
-    createdBy: user1._id,
-    ownerId: user1._id,
-    organizationId: org._id,
-    teamId: team._id,
-    dueDate: simpleDue,
-  });
+  for (const org of organizations) {
+    const team = await Team.create({ name: `${org.name} Team` });
+    const base = org.name.toLowerCase().replace(/\s+/g, '');
+    const [user1, user2, user3, _admin] = await User.create([
+      {
+        name: 'User One',
+        email: `user1@${org.domain}`,
+        username: `${base}user1`,
+        password: 'user1',
+        organizationId: org._id,
+        teamId: team._id,
+      },
+      {
+        name: 'User Two',
+        email: `user2@${org.domain}`,
+        username: `${base}user2`,
+        password: 'user2',
+        organizationId: org._id,
+        teamId: team._id,
+      },
+      {
+        name: 'User Three',
+        email: `user3@${org.domain}`,
+        username: `${base}user3`,
+        password: 'user3',
+        organizationId: org._id,
+        teamId: team._id,
+      },
+      {
+        name: 'Admin',
+        email: `admin@${org.domain}`,
+        username: `${base}admin`,
+        password: 'admin',
+        organizationId: org._id,
+        teamId: team._id,
+        role: 'ADMIN',
+      },
+    ]);
 
-  await Task.create({
-    title: 'Flow task',
-    createdBy: user1._id,
-    ownerId: user1._id,
-    organizationId: org._id,
-    teamId: team._id,
-    status: 'FLOW_IN_PROGRESS',
-    steps: [
-      { title: 'Step 1', ownerId: user1._id, status: 'OPEN' },
-      { title: 'Step 2', ownerId: user2._id, status: 'OPEN' },
-      { title: 'Step 3', ownerId: user3._id, status: 'OPEN' }
-    ],
-    currentStepIndex: 0,
-  });
+    const simpleDue = new Date(Date.now() + 2 * 60 * 60 * 1000);
+    await Task.create({
+      title: 'Simple task',
+      createdBy: user1._id,
+      ownerId: user1._id,
+      organizationId: org._id,
+      teamId: team._id,
+      dueDate: simpleDue,
+    });
+
+    await Task.create({
+      title: 'Flow task',
+      createdBy: user1._id,
+      ownerId: user1._id,
+      organizationId: org._id,
+      teamId: team._id,
+      status: 'FLOW_IN_PROGRESS',
+      steps: [
+        { title: 'Step 1', ownerId: user1._id, status: 'OPEN' },
+        { title: 'Step 2', ownerId: user2._id, status: 'OPEN' },
+        { title: 'Step 3', ownerId: user3._id, status: 'OPEN' }
+      ],
+      currentStepIndex: 0,
+    });
+  }
 
   console.log('Seeding complete');
   process.exit(0);


### PR DESCRIPTION
## Summary
- seed script now creates three organizations with domains
- each organization gets a team, four users (including admin), and sample tasks

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run seed` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6e0436308328bca29a1b7ce5b726