### PR TITLE
refactor: add explicit zod schema types

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -19,7 +19,7 @@ import type {
   TaskStepPayload,
 } from '@/types/api/task';
 
-const stepSchema = z
+const stepSchema: z.ZodType<TaskStepPayload> = z
   .object({
     title: z.string(),
     ownerId: z.string(),
@@ -27,10 +27,9 @@ const stepSchema = z
     dueAt: z.coerce.date().optional(),
     status: z.enum(['OPEN', 'DONE']).optional(),
     completedAt: z.coerce.date().optional(),
-  })
-  satisfies z.ZodType<TaskStepPayload>;
+  });
 
-const patchSchema = z
+const patchSchema: z.ZodType<Partial<TaskPayload>> = z
   .object({
     title: z.string().optional(),
     description: z.string().optional(),
@@ -47,10 +46,9 @@ const patchSchema = z
     dueDate: z.coerce.date().optional(),
     steps: z.array(stepSchema).optional(),
     currentStepIndex: z.number().int().optional(),
-  })
-  satisfies z.ZodType<Partial<TaskPayload>>;
+  });
 
-const putSchema = z
+const putSchema: z.ZodType<TaskPayload> = z
   .object({
     title: z.string(),
     description: z.string().optional(),
@@ -72,8 +70,7 @@ const putSchema = z
     dueDate: z.coerce.date().optional(),
     steps: z.array(stepSchema),
     currentStepIndex: z.number().int().optional(),
-  })
-  satisfies z.ZodType<TaskPayload>;
+  });
 
 export const GET = withOrganization(
   async (req: Request, { params }: { params: { id: string } }, session) => {

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -18,7 +18,7 @@ import type {
   TaskStepPayload,
 } from '@/types/api/task';
 
-const stepSchema = z
+const stepSchema: z.ZodType<TaskStepPayload> = z
   .object({
     title: z.string(),
     ownerId: z.string(),
@@ -26,10 +26,9 @@ const stepSchema = z
     dueAt: z.coerce.date().optional(),
     status: z.enum(['OPEN', 'DONE']).optional(),
     completedAt: z.coerce.date().optional(),
-  })
-  satisfies z.ZodType<TaskStepPayload>;
+  });
 
-const createTaskSchema = z
+const createTaskSchema: z.ZodType<TaskPayload> = z
   .object({
     title: z.string(),
     description: z.string().optional(),
@@ -42,8 +41,7 @@ const createTaskSchema = z
     visibility: z.enum(['PRIVATE', 'TEAM']).optional(),
     dueDate: z.coerce.date().optional(),
     steps: z.array(stepSchema).optional(),
-  })
-  satisfies z.ZodType<TaskPayload>;
+  });
 
 export const POST = withOrganization(async (req, session) => {
   let body: TaskPayload;
@@ -138,7 +136,7 @@ export const POST = withOrganization(async (req, session) => {
   return NextResponse.json<TaskResponse>(task, { status: 201 });
 });
 
-const listQuerySchema = z
+const listQuerySchema: z.ZodType<TaskListQuery> = z
   .object({
     ownerId: z.string().optional(),
     createdBy: z.string().optional(),
@@ -165,8 +163,7 @@ const listQuerySchema = z
     sort: z.enum(['dueDate', 'priority', 'createdAt', 'title']).optional(),
     limit: z.coerce.number().int().positive().optional(),
     page: z.coerce.number().int().positive().optional(),
-  })
-  satisfies z.ZodType<TaskListQuery>;
+  });
 
 export const GET = withOrganization(async (req, session) => {
   const url = new URL(req.url);


### PR DESCRIPTION
## Summary
- explicitly type task step schemas instead of using `satisfies`
- add explicit type annotations for task create, update, and list schemas

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc727b59e883288d426113d52b2a5a