### PR TITLE
refactor: share task step schema

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -16,18 +16,8 @@ import { withOrganization } from '@/lib/middleware/withOrganization';
 import type {
   TaskPayload,
   TaskResponse,
-  TaskStepPayload,
 } from '@/types/api/task';
-
-const stepSchema: z.ZodType<TaskStepPayload> = z
-  .object({
-    title: z.string(),
-    ownerId: z.string(),
-    description: z.string().optional(),
-    dueAt: z.coerce.date().optional(),
-    status: z.enum(['OPEN', 'DONE']).optional(),
-    completedAt: z.coerce.date().optional(),
-  });
+import { stepSchema } from '@/lib/schemas/taskStep';
 
 const patchSchema: z.ZodType<Partial<TaskPayload>> = z
   .object({

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -15,18 +15,8 @@ import type {
   TaskListQuery,
   TaskPayload,
   TaskResponse,
-  TaskStepPayload,
 } from '@/types/api/task';
-
-const stepSchema: z.ZodType<TaskStepPayload> = z
-  .object({
-    title: z.string(),
-    ownerId: z.string(),
-    description: z.string().optional(),
-    dueAt: z.coerce.date().optional(),
-    status: z.enum(['OPEN', 'DONE']).optional(),
-    completedAt: z.coerce.date().optional(),
-  });
+import { stepSchema } from '@/lib/schemas/taskStep';
 
 const createTaskSchema: z.ZodType<TaskPayload> = z
   .object({

--- a/src/lib/schemas/taskStep.ts
+++ b/src/lib/schemas/taskStep.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import type { TaskStepPayload } from '@/types/api/task';
+
+export const stepSchema: z.ZodType<TaskStepPayload> = z
+  .object({
+    title: z.string(),
+    ownerId: z.string(),
+    description: z.string().optional(),
+    dueAt: z.coerce.date().optional(),
+    status: z.enum(['OPEN', 'DONE']).optional(),
+    completedAt: z.coerce.date().optional(),
+  });
+
+export default stepSchema;


### PR DESCRIPTION
## Summary
- extract reusable task step zod schema to src/lib/schemas/taskStep.ts
- import shared step schema in tasks API routes instead of duplicating definitions

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: src/components/loop-timeline.tsx:269:1 - error TS1005: '}' expected)*

------
https://chatgpt.com/codex/tasks/task_e_68bc73cd57d88328b17190c162d5394d