### PR TITLE
Refine push subscription typing

### DIFF
--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,4 +1,5 @@
 import webpush from 'web-push';
+import type { PushSubscription } from '@/models/User';
 
 const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
 const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
@@ -7,7 +8,10 @@ if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
   webpush.setVapidDetails('mailto:notify@example.com', VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
 }
 
-export async function sendPush(subscription: any, data: Record<string, any>) {
+export async function sendPush(
+  subscription: PushSubscription,
+  data: Record<string, any>
+) {
   if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) return;
   try {
     await webpush.sendNotification(subscription, JSON.stringify(data));
@@ -16,7 +20,10 @@ export async function sendPush(subscription: any, data: Record<string, any>) {
   }
 }
 
-export async function sendPushToUser(user: any, data: Record<string, any>) {
-  const subs: any[] = user.pushSubscriptions || [];
+export async function sendPushToUser(
+  user: { pushSubscriptions?: PushSubscription[] },
+  data: Record<string, any>
+) {
+  const subs: PushSubscription[] = user.pushSubscriptions || [];
   await Promise.all(subs.map((s) => sendPush(s, data)));
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -9,6 +9,14 @@ import bcrypt from 'bcrypt';
 
 const SALT_ROUNDS = 10;
 
+export interface PushSubscription {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
+
 export interface IUser {
   name: string;
   email: string;
@@ -33,7 +41,7 @@ export interface IUser {
       OVERDUE: boolean;
     };
   };
-  pushSubscriptions: any[];
+  pushSubscriptions: PushSubscription[];
 }
 
 export type UserDocument = HydratedDocument<IUser>;
@@ -78,7 +86,18 @@ const userSchema = new Schema<IUser>(
         OVERDUE: { type: Boolean, default: true },
       },
     },
-    pushSubscriptions: { type: [Schema.Types.Mixed], default: [] },
+    pushSubscriptions: {
+      type: [
+        {
+          endpoint: { type: String, required: true },
+          keys: {
+            p256dh: { type: String, required: true },
+            auth: { type: String, required: true },
+          },
+        },
+      ],
+      default: [],
+    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- Define `PushSubscription` interface and use it for user push subscriptions
- Model push subscription structure in Mongoose schema
- Use typed push subscriptions when sending notifications

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc76a884d88328bfd99383d73011b3