### PR TITLE
feat: add notification payload interface

### DIFF
--- a/src/hooks/useNotificationsChannel.ts
+++ b/src/hooks/useNotificationsChannel.ts
@@ -1,7 +1,18 @@
 import { useEffect } from 'react';
 
+export interface NotificationPayload {
+  _id: string;
+  userId: string;
+  type: string;
+  message: string;
+  taskId?: string;
+  read: boolean;
+  readAt: string | null;
+  createdAt: string;
+}
+
 interface Options {
-  onNotification?: (notification: any) => void;
+  onNotification?: (notification: NotificationPayload) => void;
 }
 
 export default function useNotificationsChannel({ onNotification }: Options = {}) {
@@ -10,7 +21,10 @@ export default function useNotificationsChannel({ onNotification }: Options = {}
     const ws = new WebSocket(url);
     ws.addEventListener('message', (event) => {
       try {
-        const data = JSON.parse(event.data);
+        const data = JSON.parse(event.data) as {
+          event: string;
+          notification: NotificationPayload;
+        };
         if (data.event === 'notification.created') {
           onNotification?.(data.notification);
         }


### PR DESCRIPTION
## Summary
- add `NotificationPayload` interface for websocket notifications
- type `useNotificationsChannel` options and messages using `NotificationPayload`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc786aeb84832880710d859842422a