### PR TITLE
refactor: add typed ws event payloads

### DIFF
--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -86,7 +86,7 @@ async function createAndEmail(
     }))
   );
   notifications.forEach((n) =>
-    emitNotification(n.toObject(), n.userId.toString())
+    emitNotification({ notification: n.toObject(), userId: n.userId.toString() })
   );
   const users = await User.find({ _id: { $in: recipients } });
   const pushUsers = users.filter((u) => {


### PR DESCRIPTION
## Summary
- add interfaces for websocket event payloads
- refactor websocket emitters to use typed payloads
- adjust notification emitter call for new signature

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc797af4a48328b1a73c30410c23b7