### PR TITLE
refactor: remove redundant interface

### DIFF
--- a/src/components/role-selector.tsx
+++ b/src/components/role-selector.tsx
@@ -4,12 +4,10 @@ import React, { forwardRef } from 'react';
 
 export type Role = 'ADMIN' | 'USER';
 
-export interface RoleSelectorProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
-
-const RoleSelector = forwardRef<HTMLSelectElement, RoleSelectorProps>(function RoleSelector(
-  props,
-  ref
-) {
+const RoleSelector = forwardRef<
+  HTMLSelectElement,
+  React.SelectHTMLAttributes<HTMLSelectElement>
+>(function RoleSelector(props, ref) {
   return (
     <select ref={ref} {...props}>
       <option value="USER">Member</option>


### PR DESCRIPTION
## Summary
- remove empty `RoleSelectorProps` interface and use `React.SelectHTMLAttributes<HTMLSelectElement>` directly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc81ae72b88328a7f00923ff69cad7