### PR TITLE
refactor: use ts-expect-error for WebSocket ping

### DIFF
--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
 
   const interval = setInterval(() => {
     try {
-      // @ts-ignore
+      // @ts-expect-error Node's WebSocket supports ping
       server.ping();
     } catch {
       try {


### PR DESCRIPTION
## Summary
- replace ts-ignore with ts-expect-error in WebSocket route

## Testing
- `npx tsc --noEmit /tmp/route_no_comment.ts` *(fails: Property 'ping' does not exist on type 'WebSocket')*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bc82559a548328aa499c9f72f7b67d