### PR TITLE
fix missing closing brace in loop timeline component

### DIFF
--- a/src/components/loop-timeline.tsx
+++ b/src/components/loop-timeline.tsx
@@ -266,3 +266,4 @@ export default function LoopTimeline({
       </Dialog>
     </>
   );
+}


### PR DESCRIPTION
## Summary
- add missing closing brace to LoopTimeline component to fix JSX syntax

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc843d927c8328b9671a32c01dcb70