### PR TITLE
refactor: use local timers in effect cleanup

### DIFF
--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -20,6 +20,7 @@ export default function useTyping(
     const url = `${window.location.origin.replace(/^http/, 'ws')}/api/ws?taskId=${taskId}`;
     const ws = new WebSocket(url);
     wsRef.current = ws;
+    const localTimers = timers.current;
     ws.addEventListener('message', (event) => {
       try {
         const data = JSON.parse(event.data);
@@ -52,7 +53,7 @@ export default function useTyping(
     });
     return () => {
       ws.close();
-      Object.values(timers.current).forEach(clearTimeout);
+      Object.values(localTimers).forEach(clearTimeout);
     };
   }, [taskId, userId, enabled]);
 


### PR DESCRIPTION
## Summary
- copy timers.current to a local variable in useTyping hook
- use local timer reference in effect cleanup

## Testing
- `npm run lint` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bc855684988328ac0f8e12c788caae