### PR TITLE
refactor loop utilities export

### DIFF
--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -109,5 +109,6 @@ export async function completeStep(
   return updatedLoop;
 }
 
-export default { completeStep };
+const loopUtils = { completeStep };
+export default loopUtils;
 


### PR DESCRIPTION
## Summary
- assign loop utilities to a `loopUtils` constant
- export `loopUtils` as the default from `loop.ts`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85e05abc8328a89b62f963435a0a