### PR TITLE
fix lint warnings

### DIFF
--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -105,7 +105,7 @@ describe('objectives api', () => {
         }),
       })
     );
-    const obj2 = await res.json();
+    await res.json();
 
     res = await listObjectives(
       new Request(

--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -166,7 +166,7 @@ export async function GET(req: Request) {
           }
         }
       }
-    } catch (e) {
+    } catch {
       // ignore invalid JSON
     }
   }

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -84,7 +84,7 @@ export const DELETE = withOrganization(
     try {
       const filePath = path.join(process.cwd(), 'public', attachment.url);
       await fs.unlink(filePath);
-    } catch (_) {}
+    } catch {}
     await Attachment.findByIdAndDelete(attachmentId);
     return NextResponse.json({ success: true });
   }

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -277,7 +277,7 @@ export default function TaskSearchPage() {
       </form>
       {data?.verification && (
         <p className="mb-2 text-sm text-gray-600">
-          Search for "{data.verification.q}" with filters applied
+          Search for &quot;{data.verification.q}&quot; with filters applied
         </p>
       )}
       <ul>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -30,7 +30,7 @@ export default function SettingsPage() {
   const {
     register: registerNotifications,
     handleSubmit: handleNotificationsSubmit,
-    formState: { errors: notificationsErrors, isSubmitting: notificationsSubmitting },
+    formState: { isSubmitting: notificationsSubmitting },
     reset: resetNotifications,
   } = useForm<NotificationsFormData>();
 

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -17,15 +17,6 @@ interface Task {
   priority?: string;
 }
 
-const statusLabels: Record<string, string> = {
-  OPEN: 'Open',
-  IN_PROGRESS: 'In Progress',
-  IN_REVIEW: 'In Review',
-  REVISIONS: 'Revisions',
-  FLOW_IN_PROGRESS: 'Flow In Progress',
-  DONE: 'Done',
-};
-
 const statusTabs = [
   { value: 'OPEN', label: 'Open', query: ['OPEN'] },
   {

--- a/src/components/filter-builder.tsx
+++ b/src/components/filter-builder.tsx
@@ -18,7 +18,7 @@ export default function FilterBuilder() {
         const parsed = JSON.parse(existing);
         if (Array.isArray(parsed) && parsed.length) return parsed;
       }
-    } catch (e) {
+    } catch {
       // ignore
     }
     return [{ field: '', op: 'eq', value: '' }];
@@ -37,7 +37,7 @@ export default function FilterBuilder() {
           setFilters(parsed);
         }
       }
-    } catch (e) {
+    } catch {
       // ignore
     }
     setLogic(params.get('logic') === 'OR' ? 'OR' : 'AND');

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -99,16 +99,18 @@ export default function LoopBuilder() {
   const handleUpdateStep = (id: string, data: Partial<LoopStep>) => {
     updateStep(id, data);
     setErrors((prev) => {
-      const { [id]: _omit, ...rest } = prev;
-      return rest;
+      const next = { ...prev };
+      delete next[id];
+      return next;
     });
   };
 
   const handleRemoveStep = (id: string) => {
     removeStep(id);
     setErrors((prev) => {
-      const { [id]: _omit, ...rest } = prev;
-      return rest;
+      const next = { ...prev };
+      delete next[id];
+      return next;
     });
   };
 


### PR DESCRIPTION
## Summary
- resolve TypeScript unused variable warnings
- escape unescaped quotes in search page
- simplify error handling for filter and loop builders

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc8810af6883288b0ccce4efb078f8