### PR TITLE
fix: update notification read route for Next.js params

### DIFF
--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,20 +1,19 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Notification from '@/models/Notification';
 import { auth } from '@/lib/auth';
 
-interface Params {
-  params: { id: string };
-}
-
-export async function POST(request: Request, { params }: Params) {
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = params;
+  const { id } = await params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- adapt notification read route to Next.js `params` Promise API and `NextRequest`
- adjust route tests with mocks and Promise-based params

## Testing
- `npx vitest run` *(fails: 403 Forbidden fetching vitest)*
- `npx eslint .` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc893201e08328afc8fad6f58b9e82