### PR TITLE
refactor: use NextRequest in API routes

### DIFF
--- a/src/app/api/auth/otp/request/route.ts
+++ b/src/app/api/auth/otp/request/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { generateOtp, createOtpToken, checkRateLimit } from '@/lib/otp';
 import { sendOtpEmail } from '@/lib/email';
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const { email } = await req.json();
   if (!email) {
     return NextResponse.json(

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { verifyAndConsumeOtp } from '@/lib/otp';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
@@ -7,7 +7,7 @@ import bcrypt from 'bcrypt';
 
 const SALT_ROUNDS = 10;
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const { email, code } = await req.json();
   if (!email || !code) {
     return NextResponse.json(

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -23,7 +23,7 @@ const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
   return NextResponse.json(comment, { status: 201 });
 }
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -12,7 +12,7 @@ const querySchema = z.object({
   teamId: z.string(),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
@@ -13,7 +13,7 @@ const acceptSchema = z.object({
   password: z.string(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   let body: z.infer<typeof acceptSchema>;
   try {
     body = acceptSchema.parse(await req.json());

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
@@ -13,7 +13,7 @@ const inviteSchema = z.object({
   role: z.enum(['ADMIN', 'USER']).optional(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/loop-templates/route.ts
+++ b/src/app/api/loop-templates/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import LoopTemplate from '@/models/LoopTemplate';
@@ -22,7 +22,7 @@ export async function GET() {
   return NextResponse.json(templates);
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   let body: z.infer<typeof templateSchema>;
   try {
     body = templateSchema.parse(await req.json());
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
   return NextResponse.json(template, { status: 201 });
 }
 
-export async function PUT(req: Request) {
+export async function PUT(req: NextRequest) {
   const schema = templateSchema.extend({ id: z.string() });
   let body: z.infer<typeof schema>;
   try {
@@ -54,7 +54,7 @@ export async function PUT(req: Request) {
   return NextResponse.json(template);
 }
 
-export async function DELETE(req: Request) {
+export async function DELETE(req: NextRequest) {
   const schema = z.object({ id: z.string() });
   let body: z.infer<typeof schema>;
   try {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import Notification, { type INotification } from '@/models/Notification';
@@ -17,7 +17,7 @@ const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/objectives/route.ts
+++ b/src/app/api/objectives/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -16,7 +16,7 @@ const upsertSchema = z.object({
   status: z.enum(['OPEN', 'DONE']).optional(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
@@ -64,7 +64,7 @@ const listQuery = z.object({
   teamId: z.string(),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { auth } from '@/lib/auth';
 import dbConnect from '@/lib/db';
@@ -11,7 +11,7 @@ const bodySchema = z.object({
   body: z.string(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { auth } from '@/lib/auth';
 import dbConnect from '@/lib/db';
@@ -8,7 +8,7 @@ const bodySchema = z.object({
   subscription: z.any(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -14,7 +14,7 @@ const registerSchema = z.object({
   organizationName: z.string().optional(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   let body: z.infer<typeof registerSchema>;
   try {
     body = registerSchema.parse(await req.json());

--- a/src/app/api/search/export/route.ts
+++ b/src/app/api/search/export/route.ts
@@ -1,8 +1,8 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { GET as searchTasks } from '../tasks/route';
 import { GET as searchGlobal } from '../global/route';
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const format = url.searchParams.get('format') || 'csv';
   url.searchParams.delete('format');

--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -15,7 +15,7 @@ const querySchema = z.object({
   sort: z.enum(['recent', 'oldest']).optional(),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
@@ -6,7 +6,7 @@ import SavedSearch from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 const bodySchema = z.object({
@@ -14,13 +14,13 @@ const bodySchema = z.object({
   query: z.string().optional(),
 });
 
-export async function GET(_req: Request, { params }: Params) {
+export async function GET(_req: NextRequest, { params }: Params) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = params;
+  const { id } = await params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -33,13 +33,13 @@ export async function GET(_req: Request, { params }: Params) {
   return NextResponse.json(search);
 }
 
-export async function PUT(req: Request, { params }: Params) {
+export async function PUT(req: NextRequest, { params }: Params) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = params;
+  const { id } = await params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -63,13 +63,13 @@ export async function PUT(req: Request, { params }: Params) {
   return NextResponse.json(search);
 }
 
-export async function DELETE(_req: Request, { params }: Params) {
+export async function DELETE(_req: NextRequest, { params }: Params) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = params;
+  const { id } = await params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }

--- a/src/app/api/search/saved/route.ts
+++ b/src/app/api/search/saved/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import SavedSearch from '@/models/SavedSearch';
@@ -24,7 +24,7 @@ export async function GET() {
   return NextResponse.json([...presets, ...searches]);
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/search/suggestions/route.ts
+++ b/src/app/api/search/suggestions/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -45,7 +45,7 @@ const querySchema = z.object({
   limit: z.coerce.number().min(1).max(100).default(20),
 });
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -63,9 +63,14 @@ const putSchema: z.ZodType<TaskPayload> = z
   });
 
 export const GET = withOrganization(
-  async (req: Request, { params }: { params: { id: string } }, session) => {
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+    session
+  ) => {
+  const { id } = await params;
   await dbConnect();
-  const task: ITask | null = await Task.findById(params.id);
+  const task: ITask | null = await Task.findById(id);
   if (
     !task ||
     !canReadTask(
@@ -79,15 +84,20 @@ export const GET = withOrganization(
 });
 
 export const PATCH = withOrganization(
-  async (req: Request, { params }: { params: { id: string } }, session) => {
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+    session
+  ) => {
   let body: Partial<TaskPayload>;
   try {
     body = patchSchema.parse(await req.json());
   } catch (e: any) {
     return problem(400, 'Invalid request', e.message);
   }
+  const { id } = await params;
   await dbConnect();
-  const task: ITask | null = await Task.findById(params.id);
+  const task: ITask | null = await Task.findById(id);
   if (!task) return problem(404, 'Not Found', 'Task not found');
   if (
     !canWriteTask(
@@ -157,9 +167,14 @@ export const PATCH = withOrganization(
 });
 
 export const DELETE = withOrganization(
-  async (_req: Request, { params }: { params: { id: string } }, session) => {
+  async (
+    _req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+    session
+  ) => {
+    const { id } = await params;
     await dbConnect();
-    const task: ITask | null = await Task.findById(params.id);
+    const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
@@ -181,15 +196,20 @@ export const DELETE = withOrganization(
 );
 
 export const PUT = withOrganization(
-  async (req: Request, { params }: { params: { id: string } }, session) => {
+  async (
+    req: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+    session
+  ) => {
     let body: TaskPayload;
     try {
       body = putSchema.parse(await req.json());
     } catch (e: any) {
       return problem(400, 'Invalid request', e.message);
     }
+    const { id } = await params;
     await dbConnect();
-    const task: ITask | null = await Task.findById(params.id);
+    const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,24 +1,39 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 
-export async function GET(_req: Request, { params }: { params: { id: string } }) {
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   await dbConnect();
-  const user = await User.findById(params.id).lean();
+  const { id } = await params;
+  const user = await User.findById(id).lean();
   if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(user);
 }
 
-export async function PUT(req: Request, { params }: { params: { id: string } }) {
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const data = await req.json();
   await dbConnect();
-  const user = await User.findByIdAndUpdate(params.id, data, { new: true, runValidators: true });
+  const { id } = await params;
+  const user = await User.findByIdAndUpdate(id, data, {
+    new: true,
+    runValidators: true,
+  });
   if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(user);
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
   await dbConnect();
-  await User.findByIdAndDelete(params.id);
+  const { id } = await params;
+  await User.findByIdAndDelete(id);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
@@ -48,7 +48,7 @@ const updateSchema = z.object({
     .optional(),
 });
 
-export async function PUT(req: Request) {
+export async function PUT(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
@@ -28,7 +28,7 @@ const updateSchema = z.object({
   timezone: z.string().optional(),
 });
 
-export async function PUT(req: Request) {
+export async function PUT(req: NextRequest) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
@@ -6,7 +6,7 @@ import User from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
@@ -45,7 +45,7 @@ const createUserSchema = z.object({
   permissions: z.array(z.string()).optional(),
 });
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,7 +1,8 @@
 import { addClient } from '@/lib/ws';
 import { auth } from '@/lib/auth';
+import { type NextRequest } from 'next/server';
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const upgrade = request.headers.get('upgrade');
   if (upgrade?.toLowerCase() !== 'websocket') {
     return new Response('Expected websocket', { status: 400 });

--- a/src/lib/middleware/withOrganization.ts
+++ b/src/lib/middleware/withOrganization.ts
@@ -1,15 +1,16 @@
 import type { Session } from 'next-auth';
+import { type NextRequest } from 'next/server';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
 export function withOrganization(
-  handler: (req: Request, session: Session) => Promise<Response>
-): (req: Request) => Promise<Response>;
+  handler: (req: NextRequest, session: Session) => Promise<Response>
+): (req: NextRequest) => Promise<Response>;
 export function withOrganization<C>(
-  handler: (req: Request, ctx: C, session: Session) => Promise<Response>
-): (req: Request, ctx: C) => Promise<Response>;
+  handler: (req: NextRequest, ctx: C, session: Session) => Promise<Response>
+): (req: NextRequest, ctx: C) => Promise<Response>;
 export function withOrganization(handler: any) {
-  return async (req: Request, ctx?: any) => {
+  return async (req: NextRequest, ctx?: any) => {
     const session = await auth();
     if (!session?.userId || !session.organizationId) {
       return problem(401, 'Unauthorized', 'You must be signed in.');


### PR DESCRIPTION
## Summary
- use `NextRequest` and async params in API route handlers
- update `withOrganization` middleware accordingly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bd576d0832890dacefded9fc6d9