### PR TITLE
refactor worker job data typing

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -7,8 +7,8 @@ import { notifyDueSoon, notifyDueNow, notifyOverdue } from '@/lib/notify';
 import { Types } from 'mongoose';
 import type { Job } from 'agenda';
 
-agenda.define('task.dueSoon', async (job: Job) => {
-  const { taskId, stepId } = job.attrs.data as { taskId: string; stepId?: string };
+agenda.define('task.dueSoon', async (job: Job<{ taskId: string; stepId?: string }>) => {
+  const { taskId, stepId } = job.attrs.data;
   const task = await Task.findById(taskId).lean<ITask>();
   if (!task) return;
   let recipients: Types.ObjectId[] = [];
@@ -22,8 +22,8 @@ agenda.define('task.dueSoon', async (job: Job) => {
   if (recipients.length) await notifyDueSoon(recipients, task);
 });
 
-agenda.define('task.dueNow', async (job: Job) => {
-  const { taskId, stepId } = job.attrs.data as { taskId: string; stepId?: string };
+agenda.define('task.dueNow', async (job: Job<{ taskId: string; stepId?: string }>) => {
+  const { taskId, stepId } = job.attrs.data;
   const task = await Task.findById(taskId).lean<ITask>();
   if (!task) return;
   let recipients: Types.ObjectId[] = [];


### PR DESCRIPTION
## Summary
- type `task.dueSoon` Agenda job with specific task data
- type `task.dueNow` Agenda job with specific task data

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: missing @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9217fc788328bd6272c00c74628f