### PR TITLE
fix: remove any cast for team timezone

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,6 +1,6 @@
 import agenda, { initAgenda, DEFAULT_TZ } from '@/lib/agenda';
 import User from '@/models/User';
-import Team from '@/models/Team';
+import Team, { type ITeam } from '@/models/Team';
 import Task from '@/models/Task';
 import type { ITask } from '@/models/Task';
 import { notifyDueSoon, notifyDueNow, notifyOverdue } from '@/lib/notify';
@@ -64,9 +64,9 @@ agenda.define('dashboard.dailySnapshot', async (job: Job) => {
       }
     );
   }
-  const teams = await Team.find({});
+  const teams: ITeam[] = await Team.find({});
   for (const team of teams) {
-    const tz = (team as any).timezone || DEFAULT_TZ;
+    const tz = team.timezone || DEFAULT_TZ;
     await agenda.every(
       '0 18 * * *',
       'dashboard.dailySnapshot',


### PR DESCRIPTION
## Summary
- type teams query with `ITeam` and drop `any` cast when accessing timezone

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc92c18b6c8328a199fbe1972aac10