### PR TITLE
Use task participant IDs for notification recipients

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -17,7 +17,7 @@ agenda.define('task.dueSoon', async (job: Job<{ taskId: string; stepId?: string 
     const step = task.steps?.[idx];
     if (step?.ownerId) recipients = [step.ownerId];
   } else {
-    recipients = (task.participantIds || []) as Types.ObjectId[];
+    recipients = task.participantIds ?? [];
   }
   if (recipients.length) await notifyDueSoon(recipients, task);
 });
@@ -32,7 +32,7 @@ agenda.define('task.dueNow', async (job: Job<{ taskId: string; stepId?: string }
     const step = task.steps?.[idx];
     if (step?.ownerId) recipients = [step.ownerId];
   } else {
-    recipients = (task.participantIds || []) as Types.ObjectId[];
+    recipients = task.participantIds ?? [];
   }
   if (recipients.length) {
     await notifyDueNow(recipients, task);


### PR DESCRIPTION
## Summary
- default `recipients` to `task.participantIds` in dueSoon and dueNow workers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc93ae78188328b6f07b9630909c50