### PR TITLE
refactor: reuse ITask subset for notifications

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
+import type { ITask } from '@/models/Task';
 import TaskLoop from '@/models/TaskLoop';
 import LoopHistory from '@/models/LoopHistory';
 import User from '@/models/User';
@@ -68,7 +69,7 @@ export const POST = withOrganization(
 
     const { id } = await params;
     await dbConnect();
-    const task = await Task.findById(id).lean();
+    const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
@@ -151,7 +152,7 @@ export const GET = withOrganization(
   ) => {
     const { id } = await params;
     await dbConnect();
-    const task = await Task.findById(id).lean();
+    const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
@@ -182,7 +183,7 @@ export const PATCH = withOrganization(
 
     const { id } = await params;
     await dbConnect();
-    const task = await Task.findById(id).lean();
+    const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
@@ -334,7 +335,7 @@ export const DELETE = withOrganization(
   ) => {
     const { id } = await params;
     await dbConnect();
-      const task = await Task.findById(id).lean();
+      const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -1,6 +1,7 @@
 import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
+import type { ITask } from '@/models/Task';
 import TaskLoop from '@/models/TaskLoop';
 import LoopHistory from '@/models/LoopHistory';
 import { notifyAssignment, notifyLoopStepReady } from '@/lib/notify';
@@ -95,7 +96,7 @@ export async function completeStep(
   if (!updatedLoop) return null;
 
   if (newlyActiveIndexes.length) {
-    const task = await Task.findById(taskId).lean();
+    const task = await Task.findById(taskId).lean<Pick<ITask, '_id' | 'title' | 'status'>>();
     if (task) {
       for (const idx of newlyActiveIndexes) {
         const s = updatedLoop.sequence[idx];

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -8,16 +8,13 @@ import { emitNotification } from '@/lib/ws';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { sendPushToUser } from '@/lib/push';
+import type { ITask } from '@/models/Task';
 
 const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 const THROTTLE_SECONDS = 60;
 
-interface Task {
-  _id: Types.ObjectId;
-  title: string;
-  status?: string;
-}
+type Task = Pick<ITask, '_id' | 'title' | 'status'>;
 
 interface EntityRef {
   taskId?: Types.ObjectId;


### PR DESCRIPTION
## Summary
- derive notification Task type from existing ITask model
- fetch tasks with typed lean queries for notification calls

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'mongoose' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9588639883289dda87a046d6e599