### PR TITLE
fix agenda unique job options

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -7,6 +7,11 @@ import { notifyDueSoon, notifyDueNow, notifyOverdue } from '@/lib/notify';
 import { Types } from 'mongoose';
 import type { Job } from 'agenda';
 
+type EveryOptions = Parameters<typeof agenda.every>[3];
+interface EveryOptionsWithUnique extends EveryOptions {
+  unique?: Record<string, unknown>;
+}
+
 agenda.define('task.dueSoon', async (job: Job<{ taskId: string; stepId?: string }>) => {
   const { taskId, stepId } = job.attrs.data;
   const task = await Task.findById(taskId).lean<ITask>();
@@ -61,7 +66,7 @@ agenda.define('dashboard.dailySnapshot', async (job: Job) => {
         timezone: user.timezone || DEFAULT_TZ,
         unique: { name: 'task.overdueDigest', 'data.userId': user._id.toString() },
         skipImmediate: true,
-      }
+      } as EveryOptionsWithUnique
     );
   }
   const teams: ITeam[] = await Team.find({});
@@ -75,7 +80,7 @@ agenda.define('dashboard.dailySnapshot', async (job: Job) => {
         timezone: tz,
         unique: { name: 'dashboard.dailySnapshot', 'data.teamId': team._id.toString() },
         skipImmediate: true,
-      }
+      } as EveryOptionsWithUnique
     );
   }
   console.log('Worker started');


### PR DESCRIPTION
## Summary
- extend Agenda every() options to allow `unique` property

## Testing
- `npm install` *(fails: 403 Forbidden)
- `npm test` *(fails: vitest: not found)
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')


------
https://chatgpt.com/codex/tasks/task_e_68bc972317f083289408c176fcd8fef4