### PR TITLE
Fix worker options typing

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -8,9 +8,9 @@ import { Types } from 'mongoose';
 import type { Job } from 'agenda';
 
 type EveryOptions = Parameters<typeof agenda.every>[3];
-interface EveryOptionsWithUnique extends EveryOptions {
+type EveryOptionsWithUnique = EveryOptions & {
   unique?: Record<string, unknown>;
-}
+};
 
 agenda.define('task.dueSoon', async (job: Job<{ taskId: string; stepId?: string }>) => {
   const { taskId, stepId } = job.attrs.data;


### PR DESCRIPTION
## Summary
- ensure worker options type uses type alias intersection for agenda.every options with unique field

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/eslintrc)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc989297b4832882376698bb995894