### PR TITLE
Fix Invitation typing for accept API route

### DIFF
--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
-import Invitation from '@/models/Invitation';
+import Invitation, { type IInvitation } from '@/models/Invitation';
 import User from '@/models/User';
 import { problem } from '@/lib/http';
 import { Types } from 'mongoose';
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
 
   const tokenHash = crypto.createHash('sha256').update(body.token).digest('hex');
   await dbConnect();
-  const invite = await Invitation.findOne({ tokenHash }).lean();
+  const invite = await Invitation.findOne({ tokenHash }).lean<IInvitation>();
   if (!invite || invite.used || invite.expiresAt < new Date()) {
     return problem(400, 'Invalid request', 'Invalid or expired token');
   }

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -1,6 +1,6 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import { Schema, model, models, type Model, type Types } from 'mongoose';
 
-export interface IInvitation extends Document {
+export interface IInvitation {
   email: string;
   organizationId: Types.ObjectId;
   tokenHash: string;
@@ -27,4 +27,7 @@ const invitationSchema = new Schema<IInvitation>(
 
 invitationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-export default models.Invitation || model<IInvitation>('Invitation', invitationSchema);
+const Invitation: Model<IInvitation> =
+  models.Invitation || model<IInvitation>('Invitation', invitationSchema);
+
+export default Invitation;


### PR DESCRIPTION
## Summary
- type Invitation model explicitly with Model<IInvitation>
- ensure accept invitation endpoint uses typed lean query

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9aa320b0832883f17fc990575910