### PR TITLE
Resolve TypeScript error in invitation acceptance route

### DIFF
--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
       organizationId: new Types.ObjectId(invite.organizationId),
       role: invite.role,
     });
-    await Invitation.updateOne({ _id: invite._id }, { $set: { used: true } });
+    await Invitation.updateOne({ tokenHash }, { $set: { used: true } });
     return NextResponse.json({ id: user._id }, { status: 201 });
   } catch (e: any) {
     if (e.code === 11000) {


### PR DESCRIPTION
## Summary
- mark invitation as used via token hash to avoid relying on `_id`

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')

------
https://chatgpt.com/codex/tasks/task_e_68bc9e76c9408328b1eb2c1eb6e161af