### PR TITLE
Fix NextRequest usage in export search route

### DIFF
--- a/src/app/api/search/export/route.ts
+++ b/src/app/api/search/export/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { GET as searchTasks } from '../tasks/route';
 import { GET as searchGlobal } from '../global/route';
 
@@ -24,9 +24,13 @@ export async function GET(req: NextRequest) {
       url.searchParams.delete('skip');
       url.searchParams.set('page', String(page));
     }
-    searchRes = await searchGlobal(new Request(url.toString(), { headers: req.headers }));
+    searchRes = await searchGlobal(
+      new NextRequest(url.toString(), { headers: req.headers })
+    );
   } else {
-    searchRes = await searchTasks(new Request(url.toString(), { headers: req.headers }));
+    searchRes = await searchTasks(
+      new NextRequest(url.toString(), { headers: req.headers })
+    );
   }
 
   if (!searchRes.ok) {


### PR DESCRIPTION
## Summary
- use `NextRequest` to forward headers when invoking internal search routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bc9f9064f8832880154b38fca882d7