### PR TITLE
Fix implicit any for session in task API routes

### DIFF
--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
 import { Types } from 'mongoose';
 import path from 'node:path';
 import fs from 'node:fs/promises';
@@ -13,7 +14,7 @@ export const GET = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const { id } = await params;
     await dbConnect();
@@ -36,7 +37,7 @@ export const POST = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const form = await req.formData();
     const file = form.get('file');
@@ -75,7 +76,7 @@ export const DELETE = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const url = new URL(req.url);
     const attachmentId = url.searchParams.get('id');

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -17,7 +18,7 @@ export const GET = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const url = new URL(req.url);
     const raw: Record<string, any> = {};

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
 import { z } from 'zod';
 import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -58,7 +59,7 @@ export const POST = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     let body: z.infer<typeof loopSchema>;
     try {
@@ -148,7 +149,7 @@ export const GET = withOrganization(
   async (
     _req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const { id } = await params;
     await dbConnect();
@@ -172,7 +173,7 @@ export const PATCH = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     let body: z.infer<typeof loopPatchSchema>;
     try {
@@ -333,7 +334,7 @@ export const DELETE = withOrganization(
   async (
     _req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const { id } = await params;
     await dbConnect();

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server';
+import type { Session } from 'next-auth';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
@@ -66,7 +67,7 @@ export const GET = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
   const { id } = await params;
   await dbConnect();
@@ -87,7 +88,7 @@ export const PATCH = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
   let body: Partial<TaskPayload>;
   try {
@@ -170,7 +171,7 @@ export const DELETE = withOrganization(
   async (
     _req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     const { id } = await params;
     await dbConnect();
@@ -199,7 +200,7 @@ export const PUT = withOrganization(
   async (
     req: NextRequest,
     { params }: { params: Promise<{ id: string }> },
-    session
+    session: Session
   ) => {
     let body: TaskPayload;
     try {


### PR DESCRIPTION
## Summary
- type session parameter as next-auth `Session` in task attachment API handlers
- import `Session` and annotate session parameter across task/loop API routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/eslintrc)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules like mongoose)*

------
https://chatgpt.com/codex/tasks/task_e_68bca1729c74832889e0c0f8f1732c07