### PR TITLE
fix: specify user type arrays for LeanUser queries

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -97,7 +97,7 @@ export const POST = withOrganization(
     if (!errors.length && userIds.size) {
       const users = await User.find({
         _id: { $in: Array.from(userIds).map((id) => new Types.ObjectId(id)) },
-      }).lean<LeanUser>();
+      }).lean<LeanUser[]>();
       const userMap = new Map(users.map((u) => [u._id.toString(), u]));
       steps.forEach((s, idx) => {
         const u = userMap.get(s.assignedTo);
@@ -229,7 +229,7 @@ export const PATCH = withOrganization(
       if (!errors.length && userIds.size) {
         const users = await User.find({
           _id: { $in: Array.from(userIds).map((id) => new Types.ObjectId(id)) },
-        }).lean<LeanUser>();
+        }).lean<LeanUser[]>();
         const userMap = new Map(users.map((u) => [u._id.toString(), u]));
         steps.forEach((s, idx) => {
           if (s.assignedTo !== undefined) {


### PR DESCRIPTION
## Summary
- ensure user queries in loop route treat lean results as arrays

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bca4c0185c83289eec53f24661513c