### PR TITLE
fix: type loop sequence

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -5,7 +5,7 @@ import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
 import type { ITask } from '@/models/Task';
-import TaskLoop from '@/models/TaskLoop';
+import TaskLoop, { type ITaskLoop } from '@/models/TaskLoop';
 import LoopHistory from '@/models/LoopHistory';
 import User, { type IUser } from '@/models/User';
 import { canWriteTask } from '@/lib/access';
@@ -165,7 +165,7 @@ export const GET = withOrganization(
     ) {
       return problem(403, 'Forbidden', 'You cannot access this loop');
     }
-      const loop = await TaskLoop.findOne({ taskId: id }).lean();
+      const loop = await TaskLoop.findOne({ taskId: id }).lean<ITaskLoop>();
     if (!loop) return problem(404, 'Not Found', 'Loop not found');
     return NextResponse.json(loop);
   }
@@ -196,7 +196,7 @@ export const PATCH = withOrganization(
     ) {
       return problem(403, 'Forbidden', 'You cannot modify this loop');
     }
-      const loop = await TaskLoop.findOne({ taskId: id }).lean();
+      const loop = await TaskLoop.findOne({ taskId: id }).lean<ITaskLoop>();
     if (!loop) return problem(404, 'Not Found', 'Loop not found');
 
     const { sequence: steps, parallel } = body;


### PR DESCRIPTION
## Summary
- ensure TaskLoop queries return typed objects

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden)
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bca5a615448328a93178019c44d479