### PR TITLE
Fix mismatched date types in task API schemas

### DIFF
--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -4,9 +4,9 @@ export interface TaskStepPayload {
   title: string;
   ownerId: string;
   description?: string;
-  dueAt?: string;
+  dueAt?: Date;
   status?: 'OPEN' | 'DONE';
-  completedAt?: string;
+  completedAt?: Date;
 }
 
 export interface TaskPayload {
@@ -20,7 +20,7 @@ export interface TaskPayload {
   priority?: TaskPriority;
   tags?: string[];
   visibility?: TaskVisibility;
-  dueDate?: string;
+  dueDate?: Date;
   steps?: TaskStepPayload[];
   currentStepIndex?: number;
 }
@@ -29,8 +29,8 @@ export interface TaskListQuery {
   ownerId?: string;
   createdBy?: string;
   status?: TaskStatus[];
-  dueFrom?: string;
-  dueTo?: string;
+  dueFrom?: Date;
+  dueTo?: Date;
   priority?: TaskPriority[];
   tag?: string[];
   visibility?: TaskVisibility;


### PR DESCRIPTION
## Summary
- use Date fields in task payload and query types to match Zod schemas and Task model

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bca6f8a4e08328a4b7fe5c17ebcc9a