### PR TITLE
Fix Task API TypeScript response type

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -19,6 +19,7 @@ import type {
   TaskResponse,
 } from '@/types/api/task';
 import { stepSchema } from '@/lib/schemas/taskStep';
+import { serializeTask } from '@/lib/serializeTask';
 
 const patchSchema: z.ZodType<Partial<TaskPayload>> = z
   .object({
@@ -81,7 +82,7 @@ export const GET = withOrganization(
   ) {
     return problem(404, 'Not Found', 'Task not found');
   }
-  return NextResponse.json<TaskResponse>(task);
+  return NextResponse.json<TaskResponse>(serializeTask(task));
 });
 
 export const PATCH = withOrganization(
@@ -164,7 +165,7 @@ export const PATCH = withOrganization(
   });
   await scheduleTaskJobs(task);
   emitTaskUpdated({ taskId: task._id, patch: body, updatedAt: task.updatedAt });
-  return NextResponse.json<TaskResponse>(task);
+  return NextResponse.json<TaskResponse>(serializeTask(task));
 });
 
 export const DELETE = withOrganization(
@@ -279,7 +280,7 @@ export const PUT = withOrganization(
     await scheduleTaskJobs(task);
     const patch = diff(oldTask, task.toObject());
     emitTaskUpdated({ taskId: task._id, patch, updatedAt: task.updatedAt });
-    return NextResponse.json<TaskResponse>(task);
+    return NextResponse.json<TaskResponse>(serializeTask(task));
   }
 );
 

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -17,6 +17,7 @@ import type {
   TaskResponse,
 } from '@/types/api/task';
 import { stepSchema } from '@/lib/schemas/taskStep';
+import { serializeTask } from '@/lib/serializeTask';
 
 const createTaskSchema: z.ZodType<TaskPayload> = z
   .object({
@@ -123,7 +124,7 @@ export const POST = withOrganization(async (req, session) => {
   if (mentionIds.length) {
     await notifyMention(mentionIds as Types.ObjectId[], task._id);
   }
-  return NextResponse.json<TaskResponse>(task, { status: 201 });
+  return NextResponse.json<TaskResponse>(serializeTask(task), { status: 201 });
 });
 
 const listQuerySchema: z.ZodType<TaskListQuery> = z
@@ -211,6 +212,6 @@ export const GET = withOrganization(async (req, session) => {
     })
     .skip((page - 1) * limit)
     .limit(limit);
-  return NextResponse.json<TaskResponse[]>(tasks);
+  return NextResponse.json<TaskResponse[]>(tasks.map(serializeTask));
 });
 

--- a/src/lib/serializeTask.ts
+++ b/src/lib/serializeTask.ts
@@ -1,0 +1,34 @@
+import type { ITask } from '@/models/Task';
+import type { TaskResponse } from '@/types/api/task';
+
+export function serializeTask(task: ITask): TaskResponse {
+  return {
+    _id: task._id.toString(),
+    title: task.title,
+    description: task.description,
+    createdBy: task.createdBy.toString(),
+    ownerId: task.ownerId?.toString(),
+    helpers: task.helpers?.map((id) => id.toString()),
+    mentions: task.mentions?.map((id) => id.toString()),
+    organizationId: task.organizationId.toString(),
+    teamId: task.teamId?.toString(),
+    status: task.status,
+    priority: task.priority,
+    tags: task.tags,
+    visibility: task.visibility ?? 'PRIVATE',
+    dueDate: task.dueDate?.toISOString(),
+    steps: task.steps?.map((s) => ({
+      title: s.title,
+      ownerId: s.ownerId.toString(),
+      description: s.description,
+      dueAt: s.dueAt?.toISOString(),
+      status: s.status,
+      completedAt: s.completedAt?.toISOString(),
+    })),
+    currentStepIndex: task.currentStepIndex,
+    participantIds: task.participantIds?.map((id) => id.toString()),
+    createdAt: task.createdAt.toISOString(),
+    updatedAt: task.updatedAt.toISOString(),
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `serializeTask` helper to convert Mongoose `ITask` documents into plain `TaskResponse` objects
- use `serializeTask` in task API routes to ensure all IDs are serialized as strings

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bca86d2dd48328858ffef0855bb545