### PR TITLE
fix: type Task _id as ObjectId

### DIFF
--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -20,6 +20,7 @@ export interface IStep {
 }
 
 export interface ITask extends Document {
+  _id: Types.ObjectId;
   title: string;
   description?: string;
   createdBy: Types.ObjectId;


### PR DESCRIPTION
## Summary
- type task model _id as ObjectId to satisfy downstream usage

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bcaac76a30832881a7f839d7fb0c03