### PR TITLE
fix: ensure steps provided in task update

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -227,6 +227,9 @@ export const PUT = withOrganization(
     if (!owner) {
       return problem(400, 'Invalid request', 'Owner must be in your organization');
     }
+    if (!body.steps) {
+      return problem(400, 'Invalid request', 'Steps are required');
+    }
     for (const s of body.steps) {
       const stepOwner = await User.findOne({
         _id: new Types.ObjectId(s.ownerId),


### PR DESCRIPTION
## Summary
- validate task steps exist before processing update to avoid undefined errors

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bcaed8010c8328a1991681cf3bfe30