### PR TITLE
refactor: add typed interfaces to components

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -3,13 +3,21 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 
+interface User {
+  _id: string;
+  name: string;
+  email: string;
+  username: string;
+  role: string;
+}
+
 export default function UsersPage() {
-  const [users, setUsers] = useState<any[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
   const [q, setQ] = useState('');
 
   const load = async (search = '') => {
     const res = await fetch('/api/users?q=' + encodeURIComponent(search));
-    const data = await res.json();
+    const data = (await res.json()) as User[];
     setUsers(data);
   };
 

--- a/src/app/dashboard/daily/page.tsx
+++ b/src/app/dashboard/daily/page.tsx
@@ -1,17 +1,44 @@
 'use client';
 import { useEffect, useState } from 'react';
 
+interface SummaryItem {
+  ownerId: string;
+  completed: number;
+  total: number;
+}
+
+interface PendingObjective {
+  _id: string;
+  title: string;
+}
+
+interface TaskItem {
+  _id: string;
+  title: string;
+}
+
+interface TaskGroup {
+  ownerId: string;
+  tasks: TaskItem[];
+}
+
+interface DashboardData {
+  summary: SummaryItem[];
+  pending: PendingObjective[];
+  tasks: TaskGroup[];
+}
+
 export default function DailyDashboardPage() {
   const [date, setDate] = useState(
     new Date().toISOString().split('T')[0]
   );
   const [teamId, setTeamId] = useState('');
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<DashboardData | null>(null);
 
   useEffect(() => {
     if (!teamId) return;
     fetch(`/api/dashboard/daily?date=${date}&teamId=${teamId}`)
-      .then((res) => res.json())
+      .then((res) => res.json() as Promise<DashboardData>)
       .then(setData)
       .catch(() => setData(null));
   }, [date, teamId]);
@@ -38,7 +65,7 @@ export default function DailyDashboardPage() {
           <div>
             <h2 className="font-semibold">Summary</h2>
             <ul className="list-disc pl-6">
-              {data.summary.map((s: any) => (
+              {data.summary.map((s) => (
                 <li key={s.ownerId}>
                   {s.ownerId}: {s.completed}/{s.total}
                 </li>
@@ -48,18 +75,18 @@ export default function DailyDashboardPage() {
           <div>
             <h2 className="font-semibold">Pending Objectives</h2>
             <ul className="list-disc pl-6">
-              {data.pending.map((o: any) => (
+              {data.pending.map((o) => (
                 <li key={o._id}>{o.title}</li>
               ))}
             </ul>
           </div>
           <div>
             <h2 className="font-semibold">Tasks Due Today</h2>
-            {data.tasks.map((group: any) => (
+            {data.tasks.map((group) => (
               <div key={group.ownerId} className="pl-4">
                 <h3 className="font-medium">{group.ownerId}</h3>
                 <ul className="list-disc pl-6">
-                  {group.tasks.map((t: any) => (
+                  {group.tasks.map((t) => (
                     <li key={t._id}>{t.title}</li>
                   ))}
                 </ul>

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState, useCallback } from 'react';
-import useNotificationsChannel from '@/hooks/useNotificationsChannel';
+import useNotificationsChannel, { type NotificationPayload } from '@/hooks/useNotificationsChannel';
 
 const PAGE_SIZE = 20;
 
@@ -11,7 +11,7 @@ export default function NotificationsPage() {
     startDate: '',
     endDate: '',
   });
-  const [items, setItems] = useState<any[]>([]);
+  const [items, setItems] = useState<NotificationPayload[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -29,7 +29,7 @@ export default function NotificationsPage() {
         params.append('page', nextPage.toString());
         const res = await fetch(`/api/notifications?${params.toString()}`);
         if (res.ok) {
-          const data = await res.json();
+          const data = (await res.json()) as NotificationPayload[];
           setItems((prev) => (replace ? data : [...prev, ...data]));
           setHasMore(data.length === PAGE_SIZE);
           setPage(nextPage);

--- a/src/app/objectives/page.tsx
+++ b/src/app/objectives/page.tsx
@@ -1,17 +1,23 @@
 'use client';
 import { useEffect, useState } from 'react';
 
+interface Objective {
+  _id: string;
+  title: string;
+  status: string;
+}
+
 export default function ObjectivesPage() {
   const [date, setDate] = useState(
     new Date().toISOString().split('T')[0]
   );
   const [teamId, setTeamId] = useState('');
-  const [objectives, setObjectives] = useState<any[]>([]);
+  const [objectives, setObjectives] = useState<Objective[]>([]);
 
   useEffect(() => {
     if (!teamId) return;
     fetch(`/api/objectives?date=${date}&teamId=${teamId}`)
-      .then((res) => res.json())
+      .then((res) => res.json() as Promise<Objective[]>)
       .then(setObjectives)
       .catch(() => setObjectives([]));
   }, [date, teamId]);

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -12,10 +12,14 @@ const simpleSchema = z.object({
   owner: z.string().min(1, 'Owner is required'),
 });
 
+interface User {
+  _id: string;
+  name: string;
+}
 
 export default function NewTaskPage() {
   const router = useRouter();
-  const [users, setUsers] = useState<any[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
   const [simple, setSimple] = useState({ title: '', owner: '' });
   const [simpleError, setSimpleError] = useState<string | null>(null);
 
@@ -23,7 +27,7 @@ export default function NewTaskPage() {
     const load = async () => {
       const res = await fetch('/api/users', { credentials: 'include' });
       if (res.ok) {
-        const data = await res.json();
+        const data = (await res.json()) as User[];
         setUsers(data);
       }
     };
@@ -52,9 +56,10 @@ export default function NewTaskPage() {
       }
       const task = await resp.json();
       router.push(`/tasks/${task._id}`);
-    } catch (err: any) {
-      setSimpleError(err.message || 'Failed to create task');
-    }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to create task';
+        setSimpleError(message);
+      }
   };
 
   const [flowTitle, setFlowTitle] = useState('');
@@ -102,10 +107,11 @@ export default function NewTaskPage() {
       }
       const task = await resp.json();
       router.push(`/tasks/${task._id}`);
-    } catch (err: any) {
-      setFlowError(err.message || 'Failed to create task');
-    }
-  };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to create task';
+        setFlowError(message);
+      }
+    };
 
   const flowContent = (
     <form onSubmit={submitFlow} className="space-y-4">

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -11,6 +11,17 @@ import useLoopBuilder, { type LoopStep, type TemplateStep } from '@/hooks/useLoo
 import { registerLoopBuilder } from '@/lib/loopBuilder';
 import LoopTimeline from '@/components/loop-timeline';
 
+interface User {
+  _id: string;
+  name: string;
+}
+
+interface Template {
+  _id: string;
+  name: string;
+  steps: TemplateStep[];
+}
+
 export default function LoopBuilder() {
   const {
     open,
@@ -24,8 +35,8 @@ export default function LoopBuilder() {
     reorderSteps,
     setFromTemplate,
   } = useLoopBuilder();
-  const [users, setUsers] = useState<any[]>([]);
-  const [templates, setTemplates] = useState<any[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [templates, setTemplates] = useState<Template[]>([]);
   const [selectedTemplate, setSelectedTemplate] = useState('');
   const [templateName, setTemplateName] = useState('');
   const [mode, setMode] = useState<'edit' | 'preview'>('edit');
@@ -42,8 +53,8 @@ export default function LoopBuilder() {
           fetch('/api/users', { credentials: 'include' }),
           fetch('/api/loop-templates', { credentials: 'include' }),
         ]);
-        if (usersRes.ok) setUsers(await usersRes.json());
-        if (tmplRes.ok) setTemplates(await tmplRes.json());
+        if (usersRes.ok) setUsers((await usersRes.json()) as User[]);
+        if (tmplRes.ok) setTemplates((await tmplRes.json()) as Template[]);
       } catch {
         // ignore
       }
@@ -134,16 +145,16 @@ export default function LoopBuilder() {
     setTemplateName('');
     try {
       const res = await fetch('/api/loop-templates', { credentials: 'include' });
-      if (res.ok) setTemplates(await res.json());
+      if (res.ok) setTemplates((await res.json()) as Template[]);
     } catch {
       // ignore
     }
   };
 
   const handleApplyTemplate = () => {
-    const tmpl = templates.find((t: any) => t._id === selectedTemplate);
+    const tmpl = templates.find((t) => t._id === selectedTemplate);
     if (!tmpl) return;
-    setFromTemplate(tmpl.steps as TemplateStep[]);
+    setFromTemplate(tmpl.steps);
   };
 
   return (
@@ -251,7 +262,7 @@ function StepItem({
 }: {
   step: LoopStep;
   allSteps: LoopStep[];
-  users: any[];
+  users: User[];
   onChange: (id: string, data: Partial<LoopStep>) => void;
   onRemove: (id: string) => void;
   index: number;


### PR DESCRIPTION
## Summary
- define User and Template interfaces for loop builder and wire them through state and props
- add explicit User typing to admin user list and new task form
- model dashboard and objective data with interfaces and remove implicit `any`
- type notification payloads to enforce structure

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bcb212a4a0832884af1ecd5ce11709