### PR TITLE
chore: enforce no explicit any and tighten types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,7 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
     },
   },
 ];

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -45,7 +45,7 @@ export default function EditUserPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const payload = { ...form };
-    if (!payload.password) delete (payload as any).password;
+    if (!payload.password) delete (payload as unknown).password;
     setStatus({});
     try {
       const res = await fetch('/api/users/' + id, {
@@ -58,8 +58,9 @@ export default function EditUserPage() {
         throw new Error(err?.detail || 'Failed to save');
       }
       setStatus({ success: 'Saved' });
-    } catch (e: any) {
-      setStatus({ error: e.message || 'Failed to save' });
+    } catch (e: unknown) {
+      const err = e as Error;
+      setStatus({ error: err.message || 'Failed to save' });
     }
   };
 

--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -24,8 +24,9 @@ export async function GET(req: NextRequest) {
       date: url.searchParams.get('date'),
       teamId: url.searchParams.get('teamId'),
     });
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   if (session.teamId && session.teamId !== query.teamId) {
     return problem(403, 'Forbidden', 'Wrong team');
@@ -36,7 +37,7 @@ export async function GET(req: NextRequest) {
     teamId: new Types.ObjectId(query.teamId),
   });
   const summaryMap = new Map<string, { ownerId: string; completed: number; total: number }>();
-  const pending: any[] = [];
+  const pending: unknown[] = [];
   objectives.forEach((o) => {
     const key = o.ownerId.toString();
     if (!summaryMap.has(key)) {
@@ -54,7 +55,7 @@ export async function GET(req: NextRequest) {
   const start = new Date(query.date);
   const end = new Date(start);
   end.setDate(start.getDate() + 1);
-  const access: any[] = [
+  const access: unknown[] = [
     { participantIds: new Types.ObjectId(session.userId) },
   ];
   if (session.teamId) {
@@ -64,7 +65,7 @@ export async function GET(req: NextRequest) {
     dueDate: { $gte: start, $lt: end },
     $or: access,
   });
-  const taskMap = new Map<string, any[]>();
+  const taskMap = new Map<string, unknown[]>();
   tasks.forEach((t) => {
     const key = t.ownerId.toString();
     if (!taskMap.has(key)) taskMap.set(key, []);

--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -17,8 +17,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof acceptSchema>;
   try {
     body = acceptSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
 
   const tokenHash = crypto.createHash('sha256').update(body.token).digest('hex');
@@ -40,12 +41,13 @@ export async function POST(req: NextRequest) {
     });
     await Invitation.updateOne({ tokenHash }, { $set: { used: true } });
     return NextResponse.json({ id: user._id }, { status: 201 });
-  } catch (e: any) {
-    if (e.code === 11000) {
+  } catch (e: unknown) {
+    const err = e as Error & { code?: number };
+    if (err.code === 11000) {
       return problem(409, 'Conflict', 'User already exists');
     }
-    if (e.name === 'ValidationError') {
-      return problem(400, 'Invalid request', e.message);
+    if (err.name === 'ValidationError') {
+      return problem(400, 'Invalid request', err.message);
     }
     return problem(500, 'Internal Server Error', 'Unexpected error');
   }

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -25,8 +25,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof inviteSchema>;
   try {
     body = inviteSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
 
   const token = crypto.randomBytes(20).toString('hex');

--- a/src/app/api/loop-templates/route.ts
+++ b/src/app/api/loop-templates/route.ts
@@ -26,8 +26,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof templateSchema>;
   try {
     body = templateSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
   const template = await LoopTemplate.create(body);
@@ -39,8 +40,9 @@ export async function PUT(req: NextRequest) {
   let body: z.infer<typeof schema>;
   try {
     body = schema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
   const template = await LoopTemplate.findByIdAndUpdate(
@@ -59,8 +61,9 @@ export async function DELETE(req: NextRequest) {
   let body: z.infer<typeof schema>;
   try {
     body = schema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
   const deleted = await LoopTemplate.findByIdAndDelete(body.id);

--- a/src/app/api/notifications/[id]/read/route.test.ts
+++ b/src/app/api/notifications/[id]/read/route.test.ts
@@ -6,7 +6,7 @@ vi.mock('mongoose', () => ({
 
 vi.mock('next/server', () => ({
   NextResponse: {
-    json: (data: any, init?: ResponseInit) =>
+    json: (data: unknown, init?: ResponseInit) =>
       new Response(JSON.stringify(data), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -27,7 +27,7 @@ import { POST } from './route';
 
 describe('POST /notifications/:id/read', () => {
   const id = '507f1f77bcf86cd799439011';
-  const session = { userId: '507f1f77bcf86cd799439012' } as any;
+  const session = { userId: '507f1f77bcf86cd799439012' } as unknown;
 
   beforeEach(() => {
     auth.mockResolvedValue(session);
@@ -37,7 +37,7 @@ describe('POST /notifications/:id/read', () => {
 
   it('marks notification read by default', async () => {
     const res = await POST(
-      new Request('http://test', { method: 'POST' }) as any,
+      new Request('http://test', { method: 'POST' }) as unknown,
       { params: Promise.resolve({ id }) }
     );
     expect(res.status).toBe(200);
@@ -54,7 +54,7 @@ describe('POST /notifications/:id/read', () => {
       body: JSON.stringify({ read: false }),
       headers: { 'Content-Type': 'application/json' },
     });
-    const res = await POST(req as any, { params: Promise.resolve({ id }) });
+    const res = await POST(req as unknown, { params: Promise.resolve({ id }) });
     expect(res.status).toBe(200);
     expect(findOneAndUpdate).toHaveBeenCalledWith(
       { _id: id, userId: session.userId },

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -29,7 +29,7 @@ export async function POST(
   }
 
   await dbConnect();
-  const update: any = { read };
+  const update: { read: boolean; readAt?: Date | null } = { read };
   update.readAt = read ? new Date() : null;
   const notification = await Notification.findOneAndUpdate(
     { _id: id, userId: session.userId },

--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -6,12 +6,12 @@ import { GET as dailyDashboard } from '../dashboard/daily/route';
 
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
-const objectives = new Map<string, any>();
-const tasks = new Map<string, any>();
+const objectives = new Map<string, unknown>();
+const tasks = new Map<string, unknown>();
 
 vi.mock('@/models/Objective', () => ({
   default: {
-    create: vi.fn(async (doc: any) => {
+    create: vi.fn(async (doc: unknown) => {
       const _id = doc._id || new Types.ObjectId();
       const objective = { ...doc, _id };
       objective.save = async () => {
@@ -20,7 +20,7 @@ vi.mock('@/models/Objective', () => ({
       objectives.set(_id.toString(), objective);
       return objective;
     }),
-    find: vi.fn(async (filter: any) => {
+    find: vi.fn(async (filter: unknown) => {
       return Array.from(objectives.values()).filter(
         (o) =>
           o.date === filter.date &&
@@ -40,14 +40,14 @@ vi.mock('@/models/Objective', () => ({
 
 vi.mock('@/models/Task', () => ({
   default: {
-    find: vi.fn(async (filter: any) => {
+    find: vi.fn(async (filter: unknown) => {
       return Array.from(tasks.values()).filter((t) => {
         const due =
           t.dueDate >= filter.dueDate.$gte && t.dueDate < filter.dueDate.$lt;
-        const accessible = filter.$or.some((c: any) => {
+        const accessible = filter.$or.some((c: unknown) => {
           if (c.participantIds) {
             return t.participantIds.some(
-              (p: any) => p.toString() === c.participantIds.toString()
+              (p: unknown) => p.toString() === c.participantIds.toString()
             );
           }
           if (c.visibility) {
@@ -64,7 +64,7 @@ vi.mock('@/models/Task', () => ({
   },
 }));
 
-let session: any = {};
+let session: unknown = {};
 vi.mock('@/lib/auth', () => ({ auth: vi.fn(async () => session) }));
 
 const { Types } = mongoose;
@@ -144,8 +144,8 @@ describe('objectives api', () => {
       )
     );
     const dash = await res.json();
-    const s1 = dash.summary.find((s: any) => s.ownerId === u1.toString());
-    const s2 = dash.summary.find((s: any) => s.ownerId === u2.toString());
+    const s1 = dash.summary.find((s: unknown) => s.ownerId === u1.toString());
+    const s2 = dash.summary.find((s: unknown) => s.ownerId === u2.toString());
     expect(s1.completed).toBe(1);
     expect(s1.total).toBe(1);
     expect(s2.completed).toBe(0);

--- a/src/app/api/objectives/route.ts
+++ b/src/app/api/objectives/route.ts
@@ -24,8 +24,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof upsertSchema>;
   try {
     body = upsertSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   if (session.teamId && session.teamId !== body.teamId) {
     return problem(403, 'Forbidden', 'Wrong team');
@@ -76,8 +77,9 @@ export async function GET(req: NextRequest) {
       date: url.searchParams.get('date'),
       teamId: url.searchParams.get('teamId'),
     });
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   if (session.teamId && session.teamId !== query.teamId) {
     return problem(403, 'Forbidden', 'Wrong team');

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -20,8 +20,9 @@ export async function POST(req: NextRequest) {
   let data: z.infer<typeof bodySchema>;
   try {
     data = bodySchema.parse(await req.json());
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const err = e as Error;
+    return NextResponse.json({ error: err.message }, { status: 400 });
   }
 
   await dbConnect();

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -17,8 +17,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof bodySchema>;
   try {
     body = bodySchema.parse(await req.json());
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const err = e as Error;
+    return NextResponse.json({ error: err.message }, { status: 400 });
   }
 
   await dbConnect();

--- a/src/app/api/search/export/route.ts
+++ b/src/app/api/search/export/route.ts
@@ -46,20 +46,24 @@ export async function GET(req: NextRequest) {
   let rows: string[][];
   if (data.results?.[0]?.type) {
     headersRow = ['id', 'type', 'title', 'excerpt'];
-    rows = data.results.map((r: any) => [
-      r._id,
-      r.type,
-      '"' + String(r.title ?? '').replace(/"/g, '""') + '"',
-      '"' + String(r.excerpt ?? '').replace(/"/g, '""') + '"',
-    ]);
+    rows = data.results.map(
+      (r: { _id: string; type: string; title?: string; excerpt?: string }) => [
+        r._id,
+        r.type,
+        '"' + String(r.title ?? '').replace(/"/g, '""') + '"',
+        '"' + String(r.excerpt ?? '').replace(/"/g, '""') + '"',
+      ]
+    );
   } else {
     headersRow = ['id', 'title', 'status', 'dueDate'];
-    rows = data.results.map((t: any) => [
-      t._id,
-      '"' + String(t.title ?? '').replace(/"/g, '""') + '"',
-      t.status ?? '',
-      t.dueDate ? new Date(t.dueDate).toISOString() : '',
-    ]);
+    rows = data.results.map(
+      (t: { _id: string; title?: string; status?: string; dueDate?: string }) => [
+        t._id,
+        '"' + String(t.title ?? '').replace(/"/g, '""') + '"',
+        t.status ?? '',
+        t.dueDate ? new Date(t.dueDate).toISOString() : '',
+      ]
+    );
   }
   const csv = [headersRow.join(','), ...rows.map((r) => r.join(','))].join('\n');
   return new NextResponse(csv, {

--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -47,8 +47,9 @@ export async function PUT(req: NextRequest, { params }: Params) {
   let body: z.infer<typeof bodySchema>;
   try {
     body = bodySchema.parse(await req.json());
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const err = e as Error;
+    return NextResponse.json({ error: err.message }, { status: 400 });
   }
 
   await dbConnect();

--- a/src/app/api/search/saved/route.ts
+++ b/src/app/api/search/saved/route.ts
@@ -33,8 +33,9 @@ export async function POST(req: NextRequest) {
   let body: z.infer<typeof bodySchema>;
   try {
     body = bodySchema.parse(await req.json());
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message }, { status: 400 });
+  } catch (e: unknown) {
+    const err = e as Error;
+    return NextResponse.json({ error: err.message }, { status: 400 });
   }
 
   await dbConnect();

--- a/src/app/api/search/suggestions/route.ts
+++ b/src/app/api/search/suggestions/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
 
   await dbConnect();
 
-  const access: any[] = [
+  const access: unknown[] = [
     { participantIds: new Types.ObjectId(session.userId) },
   ];
   if (session.teamId) {
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest) {
   const suggestions = new Set<string>();
 
   if (useAtlas) {
-    const titlePipeline: any[] = [
+    const titlePipeline: unknown[] = [
       {
         $search: {
           index: 'tasks',
@@ -42,11 +42,11 @@ export async function GET(req: NextRequest) {
       { $project: { title: 1 } },
     ];
     const titleResults = await Task.aggregate(titlePipeline);
-    titleResults.forEach((t: any) => {
+    titleResults.forEach((t: { title?: string }) => {
       if (t.title) suggestions.add(t.title);
     });
 
-    const tagPipeline: any[] = [
+    const tagPipeline: unknown[] = [
       {
         $search: {
           index: 'tasks',
@@ -58,7 +58,7 @@ export async function GET(req: NextRequest) {
       { $project: { tags: 1 } },
     ];
     const tagResults = await Task.aggregate(tagPipeline);
-    tagResults.forEach((t: any) => {
+    tagResults.forEach((t: { tags?: string[] }) => {
       t.tags?.forEach((tag: string) => suggestions.add(tag));
     });
   } else {
@@ -69,7 +69,7 @@ export async function GET(req: NextRequest) {
     )
       .limit(10)
       .lean();
-    results.forEach((t: any) => {
+    results.forEach((t: { title?: string; tags?: string[] }) => {
       if (t.title && regex.test(t.title)) suggestions.add(t.title);
       t.tags?.forEach((tag: string) => {
         if (regex.test(tag)) suggestions.add(tag);

--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -35,13 +35,15 @@ export async function GET(
 
   const events = logs.map((log) => {
     let type = log.type;
-    if (log.type === 'TRANSITIONED' && (log as any).payload?.action) {
-      type = (log as any).payload.action;
+    const payload = (log as { payload?: { action?: string } }).payload;
+    if (log.type === 'TRANSITIONED' && payload?.action) {
+      type = payload.action;
     }
+    const actor = log.actorId as { name?: string };
     return {
       id: log._id.toString(),
       type,
-      user: { name: (log.actorId as any)?.name || 'Unknown' },
+      user: { name: actor?.name || 'Unknown' },
       date: log.createdAt,
     };
   });

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -21,15 +21,16 @@ export const GET = withOrganization(
     session: Session
   ) => {
     const url = new URL(req.url);
-    const raw: Record<string, any> = {};
+    const raw: Record<string, unknown> = {};
     url.searchParams.forEach((value, key) => {
       raw[key] = value;
     });
     let query: z.infer<typeof querySchema>;
     try {
       query = querySchema.parse(raw);
-    } catch (e: any) {
-      return problem(400, 'Invalid request', e.message);
+    } catch (e: unknown) {
+      const err = e as Error;
+      return problem(400, 'Invalid request', err.message);
     }
 
     const { id } = await params;

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -23,7 +23,7 @@ vi.mock('@/lib/access', () => ({ canWriteTask: () => true }));
 
 const startSession = vi.fn();
 vi.mock('mongoose', async () => {
-  const actual: any = await vi.importActual('mongoose');
+  const actual: unknown = await vi.importActual('mongoose');
   return { ...actual, startSession };
 });
 
@@ -38,9 +38,9 @@ describe('PATCH /tasks/:id/loop assignedTo updates', () => {
     userId: new Types.ObjectId().toString(),
     teamId: null,
     organizationId: orgId.toString(),
-  } as any;
+  } as unknown;
 
-  let loop: any;
+  let loop: unknown;
 
   beforeEach(() => {
     auth.mockResolvedValue(sessionData);
@@ -60,10 +60,10 @@ describe('PATCH /tasks/:id/loop assignedTo updates', () => {
     findLoop.mockReset();
     findLoop.mockReturnValue({
       session: vi.fn().mockReturnThis(),
-      then: (resolve: any) => resolve(loop),
+      then: (resolve: unknown) => resolve(loop),
     });
 
-    const withTransaction = vi.fn(async (fn: any) => {
+    const withTransaction = vi.fn(async (fn: unknown) => {
       await fn();
     });
     startSession.mockReset();

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -66,8 +66,9 @@ export const POST = withOrganization(
     let body: z.infer<typeof loopSchema>;
     try {
       body = loopSchema.parse(await req.json().catch(() => ({})));
-    } catch (e: any) {
-      return problem(400, 'Invalid request', e.message);
+    } catch (e: unknown) {
+      const err = e as Error;
+      return problem(400, 'Invalid request', err.message);
     }
 
     const { id } = await params;
@@ -180,8 +181,9 @@ export const PATCH = withOrganization(
     let body: z.infer<typeof loopPatchSchema>;
     try {
       body = loopPatchSchema.parse(await req.json());
-    } catch (e: any) {
-      return problem(400, 'Invalid request', e.message);
+    } catch (e: unknown) {
+      const err = e as Error;
+      return problem(400, 'Invalid request', err.message);
     }
 
     const { id } = await params;
@@ -260,7 +262,7 @@ export const PATCH = withOrganization(
     const newAssignments: { userId: string; description: string }[] = [];
     const oldAssignments: { userId: string; description: string }[] = [];
     const history: { stepIndex: number; action: 'UPDATE' | 'COMPLETE' | 'REASSIGN' }[] = [];
-    let updatedLoop: any = null;
+    let updatedLoop: unknown = null;
   try {
     await sessionDb.withTransaction(async () => {
       const loopDoc = await TaskLoop.findOne({ taskId: id }).session(sessionDb);

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -94,8 +94,9 @@ export const PATCH = withOrganization(
   let body: Partial<TaskPayload>;
   try {
     body = patchSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   const { id } = await params;
   await dbConnect();
@@ -206,8 +207,9 @@ export const PUT = withOrganization(
     let body: TaskPayload;
     try {
       body = putSchema.parse(await req.json());
-    } catch (e: any) {
-      return problem(400, 'Invalid request', e.message);
+    } catch (e: unknown) {
+      const err = e as Error;
+      return problem(400, 'Invalid request', err.message);
     }
     const { id } = await params;
     await dbConnect();

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -33,8 +33,9 @@ export async function POST(
   let body: z.infer<typeof bodySchema>;
   try {
     body = bodySchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
 
   await dbConnect();

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -38,8 +38,9 @@ export const POST = withOrganization(async (req, session) => {
   let body: TaskPayload;
   try {
     body = createTaskSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   const createdBy = session.userId;
   let ownerId = body.ownerId;
@@ -171,11 +172,12 @@ export const GET = withOrganization(async (req, session) => {
   let query: TaskListQuery;
   try {
     query = listQuerySchema.parse(raw);
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
-  const filter: any = { organizationId: new Types.ObjectId(session.organizationId) };
+  const filter: unknown = { organizationId: new Types.ObjectId(session.organizationId) };
   if (query.ownerId) filter.ownerId = new Types.ObjectId(query.ownerId);
   if (query.createdBy) filter.createdBy = new Types.ObjectId(query.createdBy);
   if (query.status && query.status.length) filter.status = { $in: query.status };
@@ -190,7 +192,7 @@ export const GET = withOrganization(async (req, session) => {
   if (query.teamId) filter.teamId = new Types.ObjectId(query.teamId);
   if (query.q) filter.$text = { $search: query.q };
 
-  const access: any[] = [
+  const access: unknown[] = [
     { participantIds: new Types.ObjectId(session.userId) },
   ];
   if (session.teamId) {

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -7,7 +7,7 @@ vi.mock('mongoose', async () => {
   return {
     ...actual,
     startSession: vi.fn(async () => ({
-      withTransaction: async (fn: any) => {
+      withTransaction: async (fn: unknown) => {
         await fn();
       },
     })),
@@ -19,7 +19,7 @@ import { notifyTaskClosed, notifyLoopStepReady, notifyAssignment } from '@/lib/n
 // mocks
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
-const tasks = new Map<string, any>();
+const tasks = new Map<string, unknown>();
 
 vi.mock('@/models/Task', () => ({
   default: {

--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -56,8 +56,9 @@ export async function PUT(req: NextRequest) {
   let body: z.infer<typeof updateSchema>;
   try {
     body = updateSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
   try {
@@ -72,7 +73,8 @@ export async function PUT(req: NextRequest) {
       return problem(404, 'Not found', 'User not found.');
     }
     return NextResponse.json(user.notificationSettings);
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -36,8 +36,9 @@ export async function PUT(req: NextRequest) {
   let body: z.infer<typeof updateSchema>;
   try {
     body = updateSchema.parse(await req.json());
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
   try {
@@ -51,7 +52,8 @@ export async function PUT(req: NextRequest) {
       return problem(404, 'Not found', 'User not found.');
     }
     return NextResponse.json(user);
-  } catch (e: any) {
-    return problem(400, 'Invalid request', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
   }
 }

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -2,6 +2,12 @@ import { addClient } from '@/lib/ws';
 import { auth } from '@/lib/auth';
 import { type NextRequest } from 'next/server';
 
+interface MetaWebSocket extends WebSocket {
+  userId?: string;
+  organizationId?: string;
+  taskIds?: string[];
+}
+
 export async function GET(request: NextRequest) {
   const upgrade = request.headers.get('upgrade');
   if (upgrade?.toLowerCase() !== 'websocket') {
@@ -16,15 +22,15 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const taskIds = searchParams.getAll('taskId');
 
-  const { 0: client, 1: server } = Object.values(new WebSocketPair()) as unknown as [
-    WebSocket,
-    WebSocket
+  const { 0: client, 1: server } = Object.values(new WebSocketPair()) as [
+    MetaWebSocket,
+    MetaWebSocket
   ];
   server.accept();
-  (server as any).userId = session.userId;
-  (server as any).organizationId = session.organizationId;
-  if (taskIds.length) (server as any).taskIds = taskIds;
-  addClient(server as any);
+  server.userId = session.userId;
+  server.organizationId = session.organizationId;
+  if (taskIds.length) server.taskIds = taskIds;
+  addClient(server);
 
   const interval = setInterval(() => {
     try {

--- a/src/app/organization/invite/page.tsx
+++ b/src/app/organization/invite/page.tsx
@@ -35,8 +35,9 @@ export default function InvitePage() {
       }
       setSuccess('Invitation sent');
       reset({ email: '', role: data.role });
-    } catch (e: any) {
-      setError('root', { message: e.message || 'Failed to send' });
+    } catch (e: unknown) {
+      const err = e as Error;
+      setError('root', { message: err.message || 'Failed to send' });
     }
   };
 

--- a/src/app/organization/members/page.tsx
+++ b/src/app/organization/members/page.tsx
@@ -45,8 +45,9 @@ function MemberRow({ user, onUpdated }: MemberRowProps) {
       const updated = await res.json();
       onUpdated(updated);
       setSuccess('Saved');
-    } catch (e: any) {
-      setError(e.message || 'Failed to update');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setError(err.message || 'Failed to update');
     }
   };
 
@@ -86,8 +87,9 @@ export default function MembersPage() {
         }
         const data = await res.json();
         setMembers(data);
-      } catch (e: any) {
-        setError(e.message || 'Failed to load');
+      } catch (e: unknown) {
+        const err = e as Error;
+        setError(err.message || 'Failed to load');
       } finally {
         setLoading(false);
       }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -58,8 +58,9 @@ export default function ProfilePage() {
         throw new Error(err?.detail || 'Failed to update');
       }
       setSuccess('Profile updated successfully');
-    } catch (e: any) {
-      setError(e.message || 'Failed to update');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setError(err.message || 'Failed to update');
     }
   };
 

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -17,7 +17,7 @@ export default function TaskSearchPage() {
   const router = useRouter();
   const { data: session } = useSession();
   const presets = getPresets(session?.userId);
-  const [data, setData] = useState<{ results: SearchResult[]; verification: any }>();
+  const [data, setData] = useState<{ results: SearchResult[]; verification: unknown }>();
   const [saved, setSaved] = useState<{ _id: string; name: string; query: string }[]>([]);
 
   const [ownerIds, setOwnerIds] = useState<string[]>(() => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -101,8 +101,9 @@ export default function SettingsPage() {
       }
       resetPassword();
       setPasswordSuccess('Password updated');
-    } catch (e: any) {
-      setPasswordError(e.message || 'Failed to update password');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setPasswordError(err.message || 'Failed to update password');
     }
   };
 
@@ -120,8 +121,9 @@ export default function SettingsPage() {
         throw new Error(err?.detail || 'Failed to update notifications');
       }
       setNotificationsSuccess('Preferences saved');
-    } catch (e: any) {
-      setNotificationsError(e.message || 'Failed to update notifications');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setNotificationsError(err.message || 'Failed to update notifications');
     }
   };
 
@@ -139,8 +141,9 @@ export default function SettingsPage() {
         throw new Error(err?.detail || 'Failed to update timezone');
       }
       setTimezoneSuccess('Timezone updated');
-    } catch (e: any) {
-      setTimezoneError(e.message || 'Failed to update timezone');
+    } catch (e: unknown) {
+      const err = e as Error;
+      setTimezoneError(err.message || 'Failed to update timezone');
     }
   };
 

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -61,10 +61,10 @@ const uploadSchema = z.object({
 });
 
 function createResolver<T>(schema: z.ZodSchema<T>) {
-  return (values: any) => {
+  return (values: unknown) => {
     const result = schema.safeParse(values);
     if (result.success) return { values: result.data, errors: {} };
-    const errors = result.error.issues.reduce<Record<string, any>>(
+    const errors = result.error.issues.reduce<Record<string, unknown>>(
       (acc, issue) => {
         const path = issue.path[0] as string;
         acc[path] = { type: issue.code, message: issue.message };

--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -7,6 +7,11 @@ import { useSession } from 'next-auth/react';
 import useTyping from '@/hooks/useTyping';
 import useRealtime from '@/hooks/useRealtime';
 
+interface EnqueueResponse {
+  ok?: boolean;
+  offline?: boolean;
+}
+
 interface Comment {
   _id: string;
   content: string;
@@ -50,12 +55,12 @@ export default function CommentThread({
 
   const handleCreate = async (pid?: string | null) => {
     const content = pid ? replyContent : newContent;
-    const res: any = await enqueue('/api/comments', {
+    const res: EnqueueResponse = await enqueue('/api/comments', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ taskId, content, parentId: pid ?? undefined }),
     });
-    if (res?.ok || res?.offline) {
+    if (res.ok || res.offline) {
       if (pid) {
         setReplyContent('');
         setReplyingTo(null);
@@ -63,7 +68,7 @@ export default function CommentThread({
         setNewContent('');
       }
     }
-    if (res?.ok) {
+    if (res.ok) {
       await load();
     }
   };

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -9,6 +9,11 @@ import useRealtime from "@/hooks/useRealtime";
 import usePresence from "@/hooks/usePresence";
 import { Avatar } from "@/components/ui/avatar";
 
+interface User {
+  _id: string;
+  name?: string;
+}
+
 interface Task {
   title?: string;
   description?: string;
@@ -79,11 +84,11 @@ export default function TaskDetail({ id }: { id: string }) {
             const data = await userRes.json();
             const map: UserMap = Array.isArray(data)
               ? data.reduce(
-                  (acc: UserMap, u: any) => {
+                  (acc: UserMap, u: User) => {
                     acc[u._id] = u;
                     return acc;
                   },
-                  {}
+                  {} as UserMap
                 )
               : data;
             setUsers(map);
@@ -106,7 +111,7 @@ export default function TaskDetail({ id }: { id: string }) {
   }, [refreshLoop]);
 
   const handleMessage = useCallback(
-    (data: any) => {
+    (data: unknown) => {
       if (data.taskId !== id) return;
       switch (data.event) {
         case "task.updated":
@@ -131,13 +136,13 @@ export default function TaskDetail({ id }: { id: string }) {
               const next: TaskLoop = { ...prev };
               if (Array.isArray(data.patch.sequence)) {
                 const seq = [...prev.sequence];
-                if (data.patch.sequence.every((s: any) => typeof s.index === "number")) {
-                  data.patch.sequence.forEach((s: any) => {
+                if (data.patch.sequence.every((s: unknown) => typeof s.index === "number")) {
+                  data.patch.sequence.forEach((s: unknown) => {
                     seq[s.index] = { ...seq[s.index], ...s };
                   });
                   next.sequence = seq;
                 } else {
-                  next.sequence = data.patch.sequence as any;
+                  next.sequence = data.patch.sequence as unknown;
                 }
               }
               if (data.patch.parallel !== undefined) next.parallel = data.patch.parallel;

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,11 +1,11 @@
-export function diff<T extends Record<string, any>>(prev: T, next: T): Partial<T> {
+export function diff<T extends Record<string, unknown>>(prev: T, next: T): Partial<T> {
   const patch: Partial<T> = {};
   const keys = new Set([...Object.keys(prev || {}), ...Object.keys(next || {})]);
   keys.forEach((key) => {
-    const a = (prev as any)[key];
-    const b = (next as any)[key];
+    const a = (prev as Record<string, unknown>)[key];
+    const b = (next as Record<string, unknown>)[key];
     if (JSON.stringify(a) !== JSON.stringify(b)) {
-      (patch as any)[key] = b === undefined ? null : b;
+      (patch as Record<string, unknown>)[key] = b === undefined ? null : b;
     }
   });
   return patch;

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -23,7 +23,7 @@ describe('completeStep', () => {
   const userA = new Types.ObjectId();
   const userB = new Types.ObjectId();
   const userC = new Types.ObjectId();
-  let loop: any;
+  let loop: unknown;
 
   beforeEach(() => {
     notifyLoopStepReady.mockReset();

--- a/src/lib/middleware/withOrganization.ts
+++ b/src/lib/middleware/withOrganization.ts
@@ -9,8 +9,10 @@ export function withOrganization(
 export function withOrganization<C>(
   handler: (req: NextRequest, ctx: C, session: Session) => Promise<Response>
 ): (req: NextRequest, ctx: C) => Promise<Response>;
-export function withOrganization(handler: any) {
-  return async (req: NextRequest, ctx?: any) => {
+export function withOrganization(
+  handler: (...args: unknown[]) => Promise<Response>
+) {
+  return async (req: NextRequest, ctx?: unknown) => {
     const session = await auth();
     if (!session?.userId || !session.organizationId) {
       return problem(401, 'Unauthorized', 'You must be signed in.');

--- a/src/lib/otp.test.ts
+++ b/src/lib/otp.test.ts
@@ -10,16 +10,16 @@ import {
 
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
-const tokens: any[] = [];
+const tokens: unknown[] = [];
 vi.mock('@/models/OtpToken', () => ({
   default: {
-    findOne: vi.fn(async (query: any) =>
+    findOne: vi.fn(async (query: unknown) =>
       tokens.filter((t) => t.email === query.email).sort((a, b) => b.createdAt - a.createdAt)[0] || null
     ),
-    create: vi.fn(async (doc: any) => {
+    create: vi.fn(async (doc: unknown) => {
       tokens.push({ ...doc, attempts: 0, createdAt: new Date() });
     }),
-    deleteMany: vi.fn(async (query: any) => {
+    deleteMany: vi.fn(async (query: unknown) => {
       for (let i = tokens.length - 1; i >= 0; i--) {
         if (tokens[i].email === query.email) tokens.splice(i, 1);
       }
@@ -27,11 +27,11 @@ vi.mock('@/models/OtpToken', () => ({
   },
 }));
 
-const rates = new Map<string, any>();
+const rates = new Map<string, unknown>();
 vi.mock('@/models/RateLimit', () => ({
   default: {
-    findOne: vi.fn(async ({ key }: any) => rates.get(key) || null),
-    updateOne: vi.fn(async ({ key }: any, update: any, opts?: any) => {
+    findOne: vi.fn(async ({ key }: unknown) => rates.get(key) || null),
+    updateOne: vi.fn(async ({ key }: unknown, update: unknown, opts?: unknown) => {
       const record = rates.get(key);
       if (opts?.upsert && (!record || record.windowEndsAt < new Date())) {
         rates.set(key, { key, ...(update.$set || {}) });

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -10,7 +10,7 @@ if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
 
 export async function sendPush(
   subscription: PushSubscription,
-  data: Record<string, any>
+  data: Record<string, unknown>
 ) {
   if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) return;
   try {
@@ -22,7 +22,7 @@ export async function sendPush(
 
 export async function sendPushToUser(
   user: { pushSubscriptions?: PushSubscription[] },
-  data: Record<string, any>
+  data: Record<string, unknown>
 ) {
   const subs: PushSubscription[] = user.pushSubscriptions || [];
   await Promise.all(subs.map((s) => sendPush(s, data)));

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -37,7 +37,7 @@ export interface ITask extends Document {
   steps?: IStep[];
   currentStepIndex?: number;
   participantIds?: Types.ObjectId[];
-  custom?: Record<string, any>;
+  custom?: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }


### PR DESCRIPTION
## Summary
- enable `no-explicit-any` ESLint rule
- replace remaining `any` usages with `unknown` or specific interfaces
- add helper types to middleware and components to satisfy stricter typing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb36452048328a77115390182765a