### PR TITLE
Fix password handling in admin user edit form

### DIFF
--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -44,14 +44,14 @@ export default function EditUserPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const payload = { ...form };
-    if (!payload.password) delete (payload as unknown).password;
+    const { password, ...payload } = form;
+    const body = password ? { ...payload, password } : payload;
     setStatus({});
     try {
       const res = await fetch('/api/users/' + id, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => null);


### PR DESCRIPTION
## Summary
- avoid deleting unknown by destructuring password from form
- send password only when provided when updating a user

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb6512ad4832899fdc81942387870