### PR TITLE
Fix Task find result typing in global search route

### DIFF
--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -70,7 +70,7 @@ export async function GET(req: NextRequest) {
 
   const tasks = await Task.find(taskFilter)
     .select('title description createdAt')
-    .lean<{ _id: Types.ObjectId; title: string; description?: string; createdAt: Date }>();
+    .lean<{ _id: Types.ObjectId; title: string; description?: string; createdAt: Date }[]>();
 
   const accessibleTaskIds = tasks.map((t) => t._id);
 


### PR DESCRIPTION
## Summary
- fix `Task.find` lean generic so tasks are typed as an array, avoiding TypeScript error when mapping

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bcbace195c8328b723f90842519de2