### PR TITLE
fix: ensure TaskLoop lean returns array

### DIFF
--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -78,7 +78,7 @@ export async function GET(req: NextRequest) {
   if (regex) loopFilter['sequence.description'] = regex;
   const loops = await TaskLoop.find(loopFilter)
     .select('taskId sequence createdAt')
-    .lean<{ _id: Types.ObjectId; taskId: Types.ObjectId; sequence: { description: string }[]; createdAt: Date }>();
+    .lean<{ _id: Types.ObjectId; taskId: Types.ObjectId; sequence: { description: string }[]; createdAt: Date }[]>();
 
   const commentFilter: Record<string, unknown> = { taskId: { $in: accessibleTaskIds } };
   if (regex) commentFilter.content = regex;


### PR DESCRIPTION
## Summary
- correct TaskLoop.find lean type to return an array

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bcbce58b8883288fd8280b247cef64