### PR TITLE
fix: correct comment search result typing

### DIFF
--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -84,7 +84,7 @@ export async function GET(req: NextRequest) {
   if (regex) commentFilter.content = regex;
   const comments = await Comment.find(commentFilter)
     .select('taskId content createdAt')
-    .lean<{ _id: Types.ObjectId; taskId: Types.ObjectId; content: string; createdAt: Date }>();
+    .lean<{ _id: Types.ObjectId; taskId: Types.ObjectId; content: string; createdAt: Date }[]>();
 
   const results: Array<{
     _id: Types.ObjectId;


### PR DESCRIPTION
## Summary
- fix Comment.find result typing to array for global search

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden for @dnd-kit/core)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bcbe214cf88328970ef9c4f821eeab