### PR TITLE
Refine TypeScript types for search and task APIs

### DIFF
--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Objective from '@/models/Objective';
+import Objective, { type IObjective } from '@/models/Objective';
 import Task, { type ITask } from '@/models/Task';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest) {
     teamId: new Types.ObjectId(query.teamId),
   });
   const summaryMap = new Map<string, { ownerId: string; completed: number; total: number }>();
-  const pending: unknown[] = [];
+  const pending: IObjective[] = [];
   objectives.forEach((o) => {
     const key = o.ownerId.toString();
     if (!summaryMap.has(key)) {

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -262,7 +262,7 @@ export const PATCH = withOrganization(
     const newAssignments: { userId: string; description: string }[] = [];
     const oldAssignments: { userId: string; description: string }[] = [];
     const history: { stepIndex: number; action: 'UPDATE' | 'COMPLETE' | 'REASSIGN' }[] = [];
-    let updatedLoop: unknown = null;
+    let updatedLoop: ITaskLoop | null = null;
   try {
     await sessionDb.withTransaction(async () => {
       const loopDoc = await TaskLoop.findOne({ taskId: id }).session(sessionDb);

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { Types } from 'mongoose';
+import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
 import type { ITask } from '@/models/Task';
@@ -177,7 +177,9 @@ export const GET = withOrganization(async (req, session) => {
     return problem(400, 'Invalid request', err.message);
   }
   await dbConnect();
-  const filter: unknown = { organizationId: new Types.ObjectId(session.organizationId) };
+  const filter: FilterQuery<ITask> = {
+    organizationId: new Types.ObjectId(session.organizationId),
+  };
   if (query.ownerId) filter.ownerId = new Types.ObjectId(query.ownerId);
   if (query.createdBy) filter.createdBy = new Types.ObjectId(query.createdBy);
   if (query.status && query.status.length) filter.status = { $in: query.status };
@@ -192,7 +194,7 @@ export const GET = withOrganization(async (req, session) => {
   if (query.teamId) filter.teamId = new Types.ObjectId(query.teamId);
   if (query.q) filter.$text = { $search: query.q };
 
-  const access: unknown[] = [
+  const access: FilterQuery<ITask>[] = [
     { participantIds: new Types.ObjectId(session.userId) },
   ];
   if (session.teamId) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server';
-import { Types } from 'mongoose';
+import { Types, type FilterQuery } from 'mongoose';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import User, { type IUser } from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -17,7 +17,7 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q') || '';
   await dbConnect();
-  const query: unknown = {
+  const query: FilterQuery<IUser> = {
     organizationId: new Types.ObjectId(session.organizationId),
   };
   if (q) {


### PR DESCRIPTION
## Summary
- use typed filters and results in task search API
- apply FilterQuery types to task listing and user search routes
- add concrete types for loop updates and dashboard pending objectives

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc16119b8832885fb2fab791e78a7