### PR TITLE
Handle optional organization, team, and role fields in NextAuth session

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -52,18 +52,18 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.userId = user.id;
         token.email = user.email;
-        token.organizationId = user.organizationId;
-        token.teamId = user.teamId;
-        token.role = user.role;
+        if (user.organizationId) token.organizationId = user.organizationId;
+        if (user.teamId) token.teamId = user.teamId;
+        if (user.role) token.role = user.role;
       }
       return token;
     },
     async session({ session, token }) {
       session.userId = token.userId;
       session.email = token.email;
-      session.organizationId = token.organizationId;
-      session.teamId = token.teamId;
-      session.role = token.role;
+      if (token.organizationId) session.organizationId = token.organizationId;
+      if (token.teamId) session.teamId = token.teamId;
+      if (token.role) session.role = token.role;
       return session;
     },
   },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,9 +5,9 @@ declare module 'next-auth' {
   interface Session {
     userId: string;
     email: string;
-    organizationId: string;
-    teamId: string;
-    role: string;
+    organizationId: string | undefined;
+    teamId: string | undefined;
+    role: string | undefined;
   }
 }
 
@@ -15,8 +15,8 @@ declare module 'next-auth/jwt' {
   interface JWT {
     userId: string;
     email: string;
-    organizationId: string;
-    teamId: string;
-    role: string;
+    organizationId: string | undefined;
+    teamId: string | undefined;
+    role: string | undefined;
   }
 }


### PR DESCRIPTION
## Summary
- allow `organizationId`, `teamId`, and `role` to be undefined in NextAuth session and JWT types
- guard callback assignments to avoid overwriting token/session when these values are missing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bd7700cdfc8328b25b45ee163d2bee