### PR TITLE
Handle optional tab value in context

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -6,12 +6,12 @@ import { cn } from '@/lib/utils'
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion'
 import { timing } from '@/lib/motion'
 
-const TabsContext = React.createContext<{ value: string }>({ value: '' })
+const TabsContext = React.createContext<{ value: string | undefined }>({ value: undefined })
 
 function Tabs({ defaultValue, children, ...props }: TabsPrimitive.TabsProps) {
-  const [value, setValue] = React.useState(defaultValue)
+  const [value, setValue] = React.useState<string | undefined>(defaultValue)
   return (
-    <TabsContext.Provider value={{ value: value as string }}>
+    <TabsContext.Provider value={{ value }}>
       <TabsPrimitive.Root
         value={value}
         onValueChange={setValue}
@@ -40,7 +40,7 @@ const TabsTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, children, value, ...props }, ref) => {
   const { value: current } = React.useContext(TabsContext)
-  const active = current === value
+  const active = current !== undefined && current === value
   return (
     <TabsPrimitive.Trigger
       ref={ref}
@@ -72,7 +72,7 @@ const TabsContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, children, value, ...props }, ref) => {
   const { value: current } = React.useContext(TabsContext)
-  const active = current === value
+  const active = current !== undefined && current === value
   const prefersReducedMotion = useReducedMotion()
   return (
     <TabsPrimitive.Content


### PR DESCRIPTION
## Summary
- allow `TabsContext` value to be `string | undefined`
- remove cast when providing context and track undefined state
- guard consumers against undefined context value

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bd77e580dc83288883b55c88de8a35