### PR TITLE
Fix Atlas search sorting type

### DIFF
--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -285,7 +285,7 @@ export async function GET(req: NextRequest) {
       pipeline.push({ $sort: { dueDate: 1 } });
     } else {
       pipeline.push({
-        $sort: { score: { $meta: 'searchScore' as unknown as string } },
+        $sort: { score: -1 },
       });
     }
     results = await Task.aggregate<SearchResult>(pipeline);


### PR DESCRIPTION
## Summary
- Sort Atlas search results by the projected score field instead of unsupported `$meta: 'searchScore'`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78c821688328a7166a7a20f46f2b