### PR TITLE
Fix type check for loop updatedAt

### DIFF
--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -316,21 +316,22 @@ export const PATCH = withOrganization(
   } finally {
     await sessionDb.endSession();
   }
-    if (!updatedLoop) return problem(404, 'Not Found', 'Loop not found');
+  if (!updatedLoop) return problem(404, 'Not Found', 'Loop not found');
 
-    const notifyTask = task as Pick<ITask, '_id' | 'title' | 'status'>;
+  const notifyTask = task as Pick<ITask, '_id' | 'title' | 'status'>;
 
-    for (const a of newAssignments) {
-      const uid = new Types.ObjectId(a.userId);
-      await notifyAssignment([uid], notifyTask, a.description);
-      await notifyLoopStepReady([uid], notifyTask, a.description);
-    }
-    for (const a of oldAssignments) {
-      const uid = new Types.ObjectId(a.userId);
-      await notifyAssignment([uid], notifyTask, a.description);
-    }
-    emitLoopUpdated({ taskId: id, patch: body, updatedAt: updatedLoop.updatedAt });
-    return NextResponse.json(updatedLoop);
+  for (const a of newAssignments) {
+    const uid = new Types.ObjectId(a.userId);
+    await notifyAssignment([uid], notifyTask, a.description);
+    await notifyLoopStepReady([uid], notifyTask, a.description);
+  }
+  for (const a of oldAssignments) {
+    const uid = new Types.ObjectId(a.userId);
+    await notifyAssignment([uid], notifyTask, a.description);
+  }
+  const loop = updatedLoop as ITaskLoop;
+  emitLoopUpdated({ taskId: id, patch: body, updatedAt: loop.updatedAt });
+  return NextResponse.json(loop);
   }
 );
 


### PR DESCRIPTION
## Summary
- Avoid TypeScript `never` inference by casting updated loop to `ITaskLoop` before emitting updates

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint src/app/api/tasks/[id]/loop/route.ts` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bd799ce4008328b1b272dcb243701a