### PR TITLE
fix: resolve loop search type mismatch

### DIFF
--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import Task from '@/models/Task';
-import TaskLoop, { type ILoopStep } from '@/models/TaskLoop';
+import TaskLoop from '@/models/TaskLoop';
 import Comment from '@/models/Comment';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
@@ -107,7 +107,7 @@ export async function GET(req: NextRequest) {
   });
 
   loops.forEach((l) => {
-    const step = l.sequence.find((s: ILoopStep) =>
+    const step = l.sequence.find((s) =>
       regex ? regex.test(s.description) : true
     );
     const desc = step?.description || '';


### PR DESCRIPTION
## Summary
- remove incorrect `ILoopStep` cast when scanning loop steps in global search
- drop unused `ILoopStep` import

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7de1eb9483288692fc85f907f3bf