### PR TITLE
Validate step index before assigning owner

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -146,9 +146,12 @@ export const PATCH = withOrganization(
         }))
       : task.steps,
   });
-  if (task.steps?.length) {
-    task.status = 'FLOW_IN_PROGRESS';
-    task.ownerId = task.steps[task.currentStepIndex ?? 0].ownerId;
+  if (Array.isArray(task.steps) && task.steps.length) {
+    const stepIndex = task.currentStepIndex ?? 0;
+    if (stepIndex >= 0 && stepIndex < task.steps.length) {
+      task.status = 'FLOW_IN_PROGRESS';
+      task.ownerId = task.steps[stepIndex].ownerId;
+    }
   }
   task.participantIds = computeParticipants({
     createdBy: task.createdBy,
@@ -264,9 +267,12 @@ export const PUT = withOrganization(
       })),
       currentStepIndex: body.currentStepIndex,
     });
-    if (task.steps?.length) {
-      task.status = 'FLOW_IN_PROGRESS';
-      task.ownerId = task.steps[task.currentStepIndex ?? 0].ownerId;
+    if (Array.isArray(task.steps) && task.steps.length) {
+      const stepIndex = task.currentStepIndex ?? 0;
+      if (stepIndex >= 0 && stepIndex < task.steps.length) {
+        task.status = 'FLOW_IN_PROGRESS';
+        task.ownerId = task.steps[stepIndex].ownerId;
+      }
     }
     task.participantIds = computeParticipants({
       createdBy: task.createdBy,


### PR DESCRIPTION
## Summary
- guard step index to avoid out-of-range step access

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd819f337083288d826e1b5c9c9c4f