### PR TITLE
Handle undefined step in task transition

### DIFF
--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -108,8 +108,8 @@ export async function POST(
     } else {
       const ownerId = updated.ownerId;
       if (ownerId && ownerId.toString() !== actorId) {
-        const step = updated.steps[updated.currentStepIndex];
-        const desc = step?.title;
+        const step = updated.steps?.[updated.currentStepIndex];
+        const desc = step ? step.title : undefined;
         await notifyAssignment([ownerId] as Types.ObjectId[], updated, desc);
         await notifyLoopStepReady([ownerId] as Types.ObjectId[], updated, desc);
       }


### PR DESCRIPTION
## Summary
- Safely access the current step during task transitions using optional chaining
- Allow assignment and step-ready notifications to work even when the next step description is missing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8265e61883289ac59c94528066de