### PR TITLE
chore: type task mocks in tests

### DIFF
--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -7,7 +7,18 @@ import { GET as dailyDashboard } from '../dashboard/daily/route';
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
 const objectives = new Map<string, unknown>();
-const tasks = new Map<string, unknown>();
+
+interface Task {
+  _id: mongoose.Types.ObjectId;
+  title: string;
+  ownerId: mongoose.Types.ObjectId;
+  dueDate: Date;
+  participantIds: mongoose.Types.ObjectId[];
+  visibility?: string;
+  teamId?: mongoose.Types.ObjectId;
+}
+
+const tasks = new Map<string, Task>();
 
 vi.mock('@/models/Objective', () => ({
   default: {
@@ -40,14 +51,14 @@ vi.mock('@/models/Objective', () => ({
 
 vi.mock('@/models/Task', () => ({
   default: {
-    find: vi.fn(async (filter: unknown) => {
+    find: vi.fn(async (filter: any): Promise<Task[]> => {
       return Array.from(tasks.values()).filter((t) => {
         const due =
           t.dueDate >= filter.dueDate.$gte && t.dueDate < filter.dueDate.$lt;
-        const accessible = filter.$or.some((c: unknown) => {
+        const accessible = filter.$or.some((c: any) => {
           if (c.participantIds) {
             return t.participantIds.some(
-              (p: unknown) => p.toString() === c.participantIds.toString()
+              (p) => p.toString() === c.participantIds.toString()
             );
           }
           if (c.visibility) {

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -10,7 +10,8 @@ const notifyAssignment = vi.fn();
 const notifyLoopStepReady = vi.fn();
 vi.mock('@/lib/notify', () => ({ notifyAssignment, notifyLoopStepReady }));
 
-const findTaskById = vi.fn();
+interface Task { _id: Types.ObjectId; organizationId: Types.ObjectId }
+const findTaskById = vi.fn<[string], Promise<Task | null>>();
 vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
 
 const findLoop = vi.fn();

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -19,11 +19,25 @@ import { notifyTaskClosed, notifyLoopStepReady, notifyAssignment } from '@/lib/n
 // mocks
 vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
-const tasks = new Map<string, unknown>();
+interface Task {
+  _id: mongoose.Types.ObjectId;
+  title: string;
+  createdBy: mongoose.Types.ObjectId;
+  ownerId: mongoose.Types.ObjectId;
+  organizationId: mongoose.Types.ObjectId;
+  status: string;
+  steps: { title: string; ownerId: mongoose.Types.ObjectId; status: string }[];
+  currentStepIndex: number;
+  participantIds?: mongoose.Types.ObjectId[];
+  save?: () => Promise<void>;
+  session?: () => Task;
+}
+
+const tasks = new Map<string, Task>();
 
 vi.mock('@/models/Task', () => ({
   default: {
-    findById: vi.fn(async (id: string) => {
+    findById: vi.fn(async (id: string): Promise<Task | null> => {
       const doc = tasks.get(id);
       if (!doc) return null;
       doc.save = async function () {

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -10,7 +10,8 @@ vi.mock('@/lib/notify', () => ({ notifyLoopStepReady, notifyAssignment }));
 const findOne = vi.fn();
 vi.mock('@/models/TaskLoop', () => ({ default: { findOne } }));
 
-const findTaskById = vi.fn();
+interface Task { _id: Types.ObjectId }
+const findTaskById = vi.fn<[string], Promise<Task | null>>();
 vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
 
 const createHistory = vi.fn();


### PR DESCRIPTION
## Summary
- define task interfaces for mocked data in objective and transition tests
- return typed arrays from mocked Task.find and drop unknown casts
- use typed task mocks in other tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd84bd9a588328b4e91f4c48542793