### PR TITLE
Use TestLoop interface in unit tests

### DIFF
--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -19,12 +19,26 @@ vi.mock('@/models/LoopHistory', () => ({ default: { create: createHistory } }));
 
 import { completeStep } from './loop';
 
+interface TestLoop {
+  taskId: Types.ObjectId;
+  sequence: Array<{
+    assignedTo: Types.ObjectId;
+    status: string;
+    description?: string;
+    dependencies?: number[];
+  }>;
+  currentStep: number;
+  isActive: boolean;
+  save: () => Promise<null>;
+  parallel?: boolean;
+}
+
 describe('completeStep', () => {
   const taskId = new Types.ObjectId();
   const userA = new Types.ObjectId();
   const userB = new Types.ObjectId();
   const userC = new Types.ObjectId();
-  let loop: unknown;
+  let loop: TestLoop;
 
   beforeEach(() => {
     notifyLoopStepReady.mockReset();
@@ -40,6 +54,7 @@ describe('completeStep', () => {
         { assignedTo: userC, status: 'PENDING', dependencies: [1] },
       ],
       currentStep: 0,
+      isActive: true,
       save: vi.fn().mockResolvedValue(null),
     };
     findOne.mockResolvedValue(loop);


### PR DESCRIPTION
## Summary
- add dedicated TestLoop interface for test objects
- remove unknown casts and type loops with TestLoop

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd85bc64648328963fc28f9a754221