### PR TITLE
fix type on notification digest

### DIFF
--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -30,7 +30,7 @@ async function main() {
     const interval = freq === 'weekly' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
     if (now.getTime() - last.getTime() < interval) continue;
 
-    const notifications = await Notification.find({
+    const notifications: INotification[] = await Notification.find({
       userId: user._id,
       read: false,
       createdAt: { $gt: last },
@@ -38,7 +38,7 @@ async function main() {
     if (!notifications.length) continue;
 
     const listItems = notifications
-      .map((n: INotification) => `<li>${n.message}</li>`)
+      .map((n) => `<li>${n.message}</li>`)
       .join('');
     const html = template.replace('{{content}}', listItems);
     if (resend) {


### PR DESCRIPTION
## Summary
- ensure notifications retrieved for digest are typed as `INotification[]`
- simplify mapping over notifications

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden for @dnd-kit/core)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bd89b0073483288b717c6df7d6a9e2