### PR TITLE
refactor: simplify route params

### DIFF
--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -6,14 +6,14 @@ import { auth } from '@/lib/auth';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = await params;
+  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }

--- a/src/app/api/objectives/[id]/route.ts
+++ b/src/app/api/objectives/[id]/route.ts
@@ -6,14 +6,14 @@ import { problem } from '@/lib/http';
 
 export async function PATCH(
   _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
   }
   await dbConnect();
-  const { id } = await params;
+  const { id } = params;
   const objective = await Objective.findById(id);
   if (!objective) {
     return problem(404, 'Not Found', 'Objective not found');

--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -6,7 +6,7 @@ import SavedSearch from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
 
 interface Params {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 const bodySchema = z.object({
@@ -20,7 +20,7 @@ export async function GET(_req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = await params;
+  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -39,7 +39,7 @@ export async function PUT(req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = await params;
+  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -70,7 +70,7 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { id } = await params;
+  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -13,10 +13,10 @@ import { withOrganization } from '@/lib/middleware/withOrganization';
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
@@ -36,7 +36,7 @@ export const GET = withOrganization(
 export const POST = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     const form = await req.formData();
@@ -44,7 +44,7 @@ export const POST = withOrganization(
     if (!(file instanceof File)) {
       return problem(400, 'Invalid request', 'File is required');
     }
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
@@ -75,7 +75,7 @@ export const POST = withOrganization(
 export const DELETE = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     const url = new URL(req.url);
@@ -83,7 +83,7 @@ export const DELETE = withOrganization(
     if (!attachmentId) return problem(400, 'Invalid request', 'id is required');
     await dbConnect();
     const attachment = await Attachment.findById(attachmentId);
-    const { id } = await params;
+    const { id } = params;
     if (!attachment || attachment.taskId.toString() !== id) {
       return problem(404, 'Not Found', 'Attachment not found');
     }

--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -9,14 +9,14 @@ import { problem } from '@/lib/http';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
   }
 
-  const { id } = await params;
+  const { id } = params;
   await dbConnect();
   const task = await Task.findById(id);
   if (

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -17,7 +17,7 @@ const querySchema = z.object({
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     const url = new URL(req.url);
@@ -33,7 +33,7 @@ export const GET = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id);
     if (

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -62,7 +62,7 @@ type LoopPatchStep = z.infer<typeof loopPatchStepSchema>;
 export const POST = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     let body: z.infer<typeof loopSchema>;
@@ -73,7 +73,7 @@ export const POST = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -153,10 +153,10 @@ export const POST = withOrganization(
 export const GET = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -177,7 +177,7 @@ export const GET = withOrganization(
 export const PATCH = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     let body: z.infer<typeof loopPatchSchema>;
@@ -188,7 +188,7 @@ export const PATCH = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -341,10 +341,10 @@ export const PATCH = withOrganization(
 export const DELETE = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
       const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -67,10 +67,10 @@ const putSchema: z.ZodType<TaskPayload> = z
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
-  const { id } = await params;
+  const { id } = params;
   await dbConnect();
   const task: ITask | null = await Task.findById(id);
   if (
@@ -88,7 +88,7 @@ export const GET = withOrganization(
 export const PATCH = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
   let body: Partial<TaskPayload>;
@@ -98,7 +98,7 @@ export const PATCH = withOrganization(
     const err = e as Error;
     return problem(400, 'Invalid request', err.message);
   }
-  const { id } = await params;
+  const { id } = params;
   await dbConnect();
   const task: ITask | null = await Task.findById(id);
   if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -175,10 +175,10 @@ export const PATCH = withOrganization(
 export const DELETE = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -204,7 +204,7 @@ export const DELETE = withOrganization(
 export const PUT = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: Promise<{ id: string }> },
+    { params }: { params: { id: string } },
     session: Session
   ) => {
     let body: TaskPayload;
@@ -214,7 +214,7 @@ export const PUT = withOrganization(
       const err = e as Error;
       return problem(400, 'Invalid request', err.message);
     }
-    const { id } = await params;
+    const { id } = params;
     await dbConnect();
     const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -24,7 +24,7 @@ const bodySchema = z.object({
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const session = await auth();
   if (!session?.userId || !session.organizationId)
@@ -39,7 +39,7 @@ export async function POST(
   }
 
   await dbConnect();
-  const { id } = await params;
+  const { id } = params;
   const task = await Task.findById(id).lean<ITask>();
   if (!task || task.organizationId.toString() !== session.organizationId)
     return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -4,10 +4,10 @@ import User from '@/models/User';
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   await dbConnect();
-  const { id } = await params;
+  const { id } = params;
   const user = await User.findById(id).lean();
   if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(user);
@@ -15,11 +15,11 @@ export async function GET(
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   const data = await req.json();
   await dbConnect();
-  const { id } = await params;
+  const { id } = params;
   const user = await User.findByIdAndUpdate(id, data, {
     new: true,
     runValidators: true,
@@ -30,10 +30,10 @@ export async function PUT(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: { id: string } }
 ) {
   await dbConnect();
-  const { id } = await params;
+  const { id } = params;
   await User.findByIdAndDelete(id);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- replace Promise-based route params with synchronous objects
- remove redundant `await params` in API endpoints

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bd8cdb2f708328b67978afb09a01f6