### PR TITLE
chore: type websocket ping

### DIFF
--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,6 +1,7 @@
 import { addClient } from '@/lib/ws';
 import { auth } from '@/lib/auth';
 import { type NextRequest } from 'next/server';
+import type { WebSocket } from 'ws';
 
 interface MetaWebSocket extends WebSocket {
   userId?: string;
@@ -34,7 +35,6 @@ export async function GET(request: NextRequest) {
 
   const interval = setInterval(() => {
     try {
-      // @ts-expect-error Node's WebSocket supports ping
       server.ping();
     } catch {
       try {


### PR DESCRIPTION
## Summary
- import typed WebSocket
- invoke server.ping without ts-expect-error

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bdb67a61e0832895313bb02697bea3