### PR TITLE
refactor: type MongoDB metadata

### DIFF
--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -7,6 +7,7 @@ import Comment from '@/models/Comment';
 import TaskLoop from '@/models/TaskLoop';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
+import { meta } from '@/lib/mongo';
 
 interface RangeFilter {
   $gte?: Date;
@@ -274,8 +275,8 @@ export async function GET(req: NextRequest) {
           teamId: 1,
           visibility: 1,
           dueDate: 1,
-          highlights: { $meta: 'searchHighlights' as unknown as string },
-          score: { $meta: 'searchScore' as unknown as string },
+          highlights: meta('searchHighlights'),
+          score: meta('searchScore'),
         },
       },
     ];

--- a/src/lib/mongo.ts
+++ b/src/lib/mongo.ts
@@ -1,0 +1,3 @@
+export type MetaField<T extends string> = { $meta: T };
+
+export const meta = <T extends string>(value: T): MetaField<T> => ({ $meta: value });


### PR DESCRIPTION
## Summary
- add generic meta helper for MongoDB $meta projections
- use meta helper in task search pipeline to avoid unsafe casts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb767a8fc8328b92f9fb22d78e474