### PR TITLE
Define push subscription schema

### DIFF
--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -4,8 +4,17 @@ import { auth } from '@/lib/auth';
 import dbConnect from '@/lib/db';
 import User from '@/models/User';
 
+const subscriptionSchema = z.object({
+  endpoint: z.string(),
+  expirationTime: z.number().nullable().optional(),
+  keys: z.object({
+    p256dh: z.string(),
+    auth: z.string(),
+  }),
+});
+
 const bodySchema = z.object({
-  subscription: z.any(),
+  subscription: subscriptionSchema,
 });
 
 export async function POST(req: NextRequest) {
@@ -14,7 +23,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  let body: z.infer<typeof bodySchema>;
+  let body: { subscription: z.infer<typeof subscriptionSchema> };
   try {
     body = bodySchema.parse(await req.json());
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary
- validate push subscription fields for endpoint, expirationTime, and keys
- infer subscription type from schema in request body

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bdb872597c8328bcba8205ad3a4493