### PR TITLE
Add typed RealtimeMessage interface and guard message handlers

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { openLoopBuilder } from "@/lib/loopBuilder";
 import LoopVisualizer, { StepWithStatus, UserMap } from "@/components/loop-visualizer";
 import LoopProgress from "@/components/loop-progress";
-import useRealtime from "@/hooks/useRealtime";
+import useRealtime, { RealtimeMessage } from "@/hooks/useRealtime";
 import usePresence from "@/hooks/usePresence";
 import { Avatar } from "@/components/ui/avatar";
 
@@ -111,7 +111,7 @@ export default function TaskDetail({ id }: { id: string }) {
   }, [refreshLoop]);
 
   const handleMessage = useCallback(
-    (data: unknown) => {
+    (data: RealtimeMessage) => {
       if (data.taskId !== id) return;
       switch (data.event) {
         case "task.updated":

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { isRealtimeMessage } from '@/hooks/useRealtime';
 
 interface Viewer {
   _id: string;
@@ -19,10 +20,10 @@ export default function usePresence(taskId: string) {
 
     ws.addEventListener('message', (event) => {
       try {
-        const data = JSON.parse(event.data);
-        if (data.taskId !== taskId) return;
+        const data: unknown = JSON.parse(event.data);
+        if (!isRealtimeMessage(data) || data.taskId !== taskId) return;
         if (data.event === 'user.joined') {
-          const userId: string = data.userId;
+          const userId: string = (data as any).userId;
           if (!viewersRef.current[userId]) {
             viewersRef.current[userId] = { _id: userId };
             update();
@@ -39,7 +40,7 @@ export default function usePresence(taskId: string) {
             })();
           }
         } else if (data.event === 'user.left') {
-          const userId: string = data.userId;
+          const userId: string = (data as any).userId;
           if (viewersRef.current[userId]) {
             delete viewersRef.current[userId];
             update();

--- a/src/hooks/useRealtime.ts
+++ b/src/hooks/useRealtime.ts
@@ -3,7 +3,10 @@ import { useEffect, useState } from 'react';
 export type ConnectionStatus = 'connecting' | 'connected' | 'offline';
 
 export interface RealtimeMessage {
+  taskId: string;
   event: string;
+  patch?: any;
+  updatedAt?: string;
   [key: string]: unknown;
 }
 
@@ -27,12 +30,14 @@ const HEARTBEAT_INTERVAL = 30000;
 const HEARTBEAT_TIMEOUT = 10000;
 const MAX_BACKOFF = 30000;
 
-function isRealtimeMessage(data: unknown): data is RealtimeMessage {
+export function isRealtimeMessage(data: unknown): data is RealtimeMessage {
   return (
     typeof data === 'object' &&
     data !== null &&
     'event' in data &&
-    typeof (data as { event: unknown }).event === 'string'
+    typeof (data as { event: unknown }).event === 'string' &&
+    'taskId' in data &&
+    typeof (data as { taskId: unknown }).taskId === 'string'
   );
 }
 

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { isRealtimeMessage } from '@/hooks/useRealtime';
 
 interface User {
   _id: string;
@@ -23,10 +24,10 @@ export default function useTyping(
     const localTimers = timers.current;
     ws.addEventListener('message', (event) => {
       try {
-        const data = JSON.parse(event.data);
-        if (data.taskId !== taskId) return;
+        const data: unknown = JSON.parse(event.data);
+        if (!isRealtimeMessage(data) || data.taskId !== taskId) return;
         if (data.event === 'comment.typing') {
-          const uid: string = data.userId;
+          const uid: string = (data as any).userId;
           if (!uid || uid === userId) return;
           if (!usersRef.current[uid]) {
             usersRef.current[uid] = { _id: uid };


### PR DESCRIPTION
## Summary
- add RealtimeMessage interface with taskId and event
- type task detail message handler with RealtimeMessage
- validate presence and typing hooks with realtime type guard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bdbe294c98832880ed75deeecb38e5