### PR TITLE
validate search tasks response

### DIFF
--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -5,10 +5,11 @@ import { useEffect, useState } from 'react';
 import FilterBuilder from '@/components/filter-builder';
 import { useSession } from 'next-auth/react';
 import { getPresets } from '../filters';
-import type {
-  SearchResult,
-  SearchTasksResponse,
-  SavedSearch,
+import {
+  SearchTasksResponseSchema,
+  type SearchResult,
+  type SearchTasksResponse,
+  type SavedSearch,
 } from '@/types/api/search';
 
 export default function TaskSearchPage() {
@@ -49,7 +50,12 @@ export default function TaskSearchPage() {
     const run = async () => {
       const res = await fetch(`/api/search/tasks?${qs}`);
       if (!res.ok) return;
-      setData((await res.json()) as SearchTasksResponse);
+      const parsed = SearchTasksResponseSchema.safeParse(await res.json());
+      if (!parsed.success) {
+        console.error(parsed.error);
+        return;
+      }
+      setData(parsed.data);
     };
     void run();
   }, [params]);

--- a/src/types/api/search.ts
+++ b/src/types/api/search.ts
@@ -1,13 +1,21 @@
-export interface SearchResult {
-  _id: string;
-  title: string;
-  excerpt: string;
-}
+import { z } from 'zod';
 
-export interface SearchTasksResponse {
-  results: SearchResult[];
-  verification: unknown;
-}
+export const SearchResultSchema = z.object({
+  _id: z.string(),
+  title: z.string(),
+  excerpt: z.string(),
+});
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+
+export const SearchTasksResponseSchema = z.object({
+  results: z.array(SearchResultSchema),
+  total: z.number(),
+  verification: z.object({
+    q: z.string().optional(),
+    filters: z.record(z.unknown()),
+  }),
+});
+export type SearchTasksResponse = z.infer<typeof SearchTasksResponseSchema>;
 
 export interface SearchItem {
   _id: string;


### PR DESCRIPTION
## Summary
- add zod schema for search task API response
- validate search tasks fetch response before setting state

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68bdbf3fe2c88328b47fd3f0c49bfeff