### PR TITLE
chore: enable typed linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,12 @@ const eslintConfig = [
       "build/**",
       "next-env.d.ts",
     ],
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.json",
+        tsconfigRootDir: __dirname,
+      },
+    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-floating-promises": "error",


### PR DESCRIPTION
## Summary
- enable typed linting by pointing ESLint to the repo's tsconfig

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc629202883289025e0075b0434b9