### PR TITLE
Handle async route parameters

### DIFF
--- a/src/app/api/objectives/[id]/route.ts
+++ b/src/app/api/objectives/[id]/route.ts
@@ -6,14 +6,15 @@ import { problem } from '@/lib/http';
 
 export async function PATCH(
   _request: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
   }
   await dbConnect();
-  const { id } = params;
   const objective = await Objective.findById(id);
   if (!objective) {
     return problem(404, 'Not Found', 'Objective not found');

--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -6,7 +6,7 @@ import SavedSearch from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 const bodySchema = z.object({
@@ -14,13 +14,13 @@ const bodySchema = z.object({
   query: z.string().optional(),
 });
 
-export async function GET(_req: NextRequest, { params }: Params) {
+export async function GET(_req: NextRequest, context: Params) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-
-  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -33,13 +33,13 @@ export async function GET(_req: NextRequest, { params }: Params) {
   return NextResponse.json(search);
 }
 
-export async function PUT(req: NextRequest, { params }: Params) {
+export async function PUT(req: NextRequest, context: Params) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-
-  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }
@@ -64,13 +64,13 @@ export async function PUT(req: NextRequest, { params }: Params) {
   return NextResponse.json(search);
 }
 
-export async function DELETE(_req: NextRequest, { params }: Params) {
+export async function DELETE(_req: NextRequest, context: Params) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-
-  const { id } = params;
   if (!Types.ObjectId.isValid(id)) {
     return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
   }

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -13,10 +13,11 @@ import { withOrganization } from '@/lib/middleware/withOrganization';
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
@@ -36,7 +37,7 @@ export const GET = withOrganization(
 export const POST = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
     const form = await req.formData();
@@ -44,7 +45,8 @@ export const POST = withOrganization(
     if (!(file instanceof File)) {
       return problem(400, 'Invalid request', 'File is required');
     }
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
@@ -75,7 +77,7 @@ export const POST = withOrganization(
 export const DELETE = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
     const url = new URL(req.url);
@@ -83,7 +85,8 @@ export const DELETE = withOrganization(
     if (!attachmentId) return problem(400, 'Invalid request', 'id is required');
     await dbConnect();
     const attachment = await Attachment.findById(attachmentId);
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     if (!attachment || attachment.taskId.toString() !== id) {
       return problem(404, 'Not Found', 'Attachment not found');
     }

--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -9,14 +9,14 @@ import { problem } from '@/lib/http';
 
 export async function GET(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId || !session.organizationId) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
   }
-
-  const { id } = params;
   await dbConnect();
   const task = await Task.findById(id);
   if (

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -17,9 +17,11 @@ const querySchema = z.object({
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
+    const { params } = context;
+    const { id } = await params;
     const url = new URL(req.url);
     const raw: Record<string, unknown> = {};
     url.searchParams.forEach((value, key) => {
@@ -33,7 +35,6 @@ export const GET = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = params;
     await dbConnect();
     const task = await Task.findById(id);
     if (

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -62,7 +62,7 @@ type LoopPatchStep = z.infer<typeof loopPatchStepSchema>;
 export const POST = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
     let body: z.infer<typeof loopSchema>;
@@ -73,7 +73,8 @@ export const POST = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -153,10 +154,11 @@ export const POST = withOrganization(
 export const GET = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -177,7 +179,7 @@ export const GET = withOrganization(
 export const PATCH = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
     let body: z.infer<typeof loopPatchSchema>;
@@ -188,7 +190,8 @@ export const PATCH = withOrganization(
       return problem(400, 'Invalid request', err.message);
     }
 
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -341,10 +344,11 @@ export const PATCH = withOrganization(
 export const DELETE = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
       const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -67,10 +67,11 @@ const putSchema: z.ZodType<TaskPayload> = z
 export const GET = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
-  const { id } = params;
+  const { params } = context;
+  const { id } = await params;
   await dbConnect();
   const task: ITask | null = await Task.findById(id);
   if (
@@ -88,7 +89,7 @@ export const GET = withOrganization(
 export const PATCH = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
   let body: Partial<TaskPayload>;
@@ -98,7 +99,8 @@ export const PATCH = withOrganization(
     const err = e as Error;
     return problem(400, 'Invalid request', err.message);
   }
-  const { id } = params;
+  const { params } = context;
+  const { id } = await params;
   await dbConnect();
   const task: ITask | null = await Task.findById(id);
   if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -175,10 +177,11 @@ export const PATCH = withOrganization(
 export const DELETE = withOrganization(
   async (
     _req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');
@@ -204,7 +207,7 @@ export const DELETE = withOrganization(
 export const PUT = withOrganization(
   async (
     req: NextRequest,
-    { params }: { params: { id: string } },
+    context: { params: Promise<{ id: string }> },
     session: Session
   ) => {
     let body: TaskPayload;
@@ -214,7 +217,8 @@ export const PUT = withOrganization(
       const err = e as Error;
       return problem(400, 'Invalid request', err.message);
     }
-    const { id } = params;
+    const { params } = context;
+    const { id } = await params;
     await dbConnect();
     const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -24,8 +24,10 @@ const bodySchema = z.object({
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
+  const { params } = context;
+  const { id } = await params;
   const session = await auth();
   if (!session?.userId || !session.organizationId)
     return problem(401, 'Unauthorized', 'You must be signed in.');
@@ -39,7 +41,6 @@ export async function POST(
   }
 
   await dbConnect();
-  const { id } = params;
   const task = await Task.findById(id).lean<ITask>();
   if (!task || task.organizationId.toString() !== session.organizationId)
     return problem(404, 'Not Found', 'Task not found');

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -4,10 +4,11 @@ import User from '@/models/User';
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
+  const { params } = context;
+  const { id } = await params;
   await dbConnect();
-  const { id } = params;
   const user = await User.findById(id).lean();
   if (!user) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(user);
@@ -15,11 +16,12 @@ export async function GET(
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
   const data = await req.json();
+  const { params } = context;
+  const { id } = await params;
   await dbConnect();
-  const { id } = params;
   const user = await User.findByIdAndUpdate(id, data, {
     new: true,
     runValidators: true,
@@ -30,10 +32,11 @@ export async function PUT(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
+  const { params } = context;
+  const { id } = await params;
   await dbConnect();
-  const { id } = params;
   await User.findByIdAndDelete(id);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- handle Promise-based `params` in objective patch route
- support async params across user, task, loop, attachment, transition, and saved search APIs

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68bdca50e1408328a3fab6fb1ad66e40