### PR TITLE
test: await route params

### DIFF
--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -138,7 +138,7 @@ describe('objectives api', () => {
     expect(list.length).toBe(2);
 
     await toggleObjective(new Request('http://test', { method: 'PATCH' }), {
-      params: { id: obj1._id },
+      params: Promise.resolve({ id: obj1._id }),
     });
 
     const task1 = {

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -93,7 +93,7 @@ describe('PATCH /tasks/:id/loop assignedTo updates', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    const res = await PATCH(req, { params: { id: taskId.toString() } });
+    const res = await PATCH(req, { params: Promise.resolve({ id: taskId.toString() }) });
     expect(res.status).toBe(200);
     expect(loop.sequence[0].assignedTo).toEqual(newUser);
     expect(loop.sequence[0].status).toBe('PENDING');

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -101,7 +101,7 @@ describe('task flow with steps', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'DONE' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     let t = tasks.get(taskId.toString());
     expect(t.currentStepIndex).toBe(1);
@@ -124,7 +124,7 @@ describe('task flow with steps', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'DONE' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     t = tasks.get(taskId.toString());
     expect(t.currentStepIndex).toBe(2);
@@ -147,7 +147,7 @@ describe('task flow with steps', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'DONE' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     t = tasks.get(taskId.toString());
     expect(t.status).toBe('DONE');
@@ -181,7 +181,7 @@ describe('task flow with steps', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'DONE' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
 
     const t = tasks.get(taskId.toString());
@@ -215,7 +215,7 @@ describe('simple task status transitions', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'START' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     let t = tasks.get(taskId.toString());
     expect(t.status).toBe('IN_PROGRESS');
@@ -225,7 +225,7 @@ describe('simple task status transitions', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'SEND_FOR_REVIEW' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     t = tasks.get(taskId.toString());
     expect(t.status).toBe('IN_REVIEW');
@@ -235,7 +235,7 @@ describe('simple task status transitions', () => {
         method: 'POST',
         body: JSON.stringify({ action: 'DONE' }),
       }),
-      { params: { id: taskId.toString() } }
+      { params: Promise.resolve({ id: taskId.toString() }) }
     );
     t = tasks.get(taskId.toString());
     expect(t.status).toBe('DONE');


### PR DESCRIPTION
## Summary
- update tests to pass `Promise.resolve` for route params to match new async handler signature

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcb3ce4c88328b9b44e7389ead2f3