### PR TITLE
Ensure React type packages available in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
         "agenda": "^5.0.0",
         "next-auth": "^4.24.7",
         "@dnd-kit/modifiers": "^9.0.0",
-        "@radix-ui/react-tabs": "^1.0.5"
+        "@radix-ui/react-tabs": "^1.0.5",
+        "@types/react": "^19",
+        "@types/react-dom": "^19"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
         "tailwindcss": "^4",
@@ -1313,7 +1313,6 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1323,7 +1322,6 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "@radix-ui/react-tabs": "^1.0.5",
     "bcrypt": "^5.1.1",
     "react-hook-form": "^7.51.5",
-    "web-push": "^3.6.6"
+    "web-push": "^3.6.6",
+    "@types/react": "^19",
+    "@types/react-dom": "^19"
   },
   "devDependencies": {
     "typescript": "^5",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
     "@tailwindcss/postcss": "^4",
     "tailwindcss": "^4",
     "eslint": "^9",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["react", "react-dom"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- include `@types/react` and `@types/react-dom` in dependencies for production builds
- configure TypeScript to load React and React DOM types explicitly

## Testing
- `npm install` *(fails: 403 Forbidden fetching @dnd-kit/core)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcd552ca883289169b15340e0abd7