### PR TITLE
Move type dependencies to runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@radix-ui/react-tabs": "^1.0.5",
         "@types/react": "^19",
-        "@types/react-dom": "^19"
+        "@types/react-dom": "^19",
+        "@types/node": "^20"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
         "tailwindcss": "^4",
@@ -1303,7 +1303,6 @@
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "react-hook-form": "^7.51.5",
     "web-push": "^3.6.6",
     "@types/react": "^19",
-    "@types/react-dom": "^19"
+    "@types/react-dom": "^19",
+    "@types/node": "^20"
   },
   "devDependencies": {
     "typescript": "^5",
-    "@types/node": "^20",
     "@tailwindcss/postcss": "^4",
     "tailwindcss": "^4",
     "eslint": "^9",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "node"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- move @types/react, @types/react-dom, and @types/node into dependencies
- include node types in tsconfig

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bdce2379f8832894c6dadd9780759e