### PR TITLE
fix: provide JSX namespace

### DIFF
--- a/src/types/jsx.d.ts
+++ b/src/types/jsx.d.ts
@@ -1,0 +1,9 @@
+import type { ReactElement } from 'react';
+
+declare global {
+  namespace JSX {
+    type Element = ReactElement;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- provide global JSX.Element type to satisfy dependencies

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd12d6df08328bcf3d980aad85dae