### PR TITLE
fix: provide JSX namespace

### DIFF
--- a/src/types/jsx.d.ts
+++ b/src/types/jsx.d.ts
@@ -1,0 +1,10 @@
+import type { JSX as ReactJSX } from 'react';
+
+declare global {
+  namespace JSX {
+    type Element = ReactJSX.Element;
+    interface IntrinsicElements extends ReactJSX.IntrinsicElements {}
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- map global JSX.Element and JSX.IntrinsicElements to React types to satisfy dependencies

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd12d6df08328bcf3d980aad85dae