### PR TITLE
feat: augment agenda Processor type

### DIFF
--- a/src/types/agenda.d.ts
+++ b/src/types/agenda.d.ts
@@ -1,0 +1,5 @@
+declare module 'agenda' {
+  type Processor<T extends JobAttributesData> =
+    ((job: Job<T>) => Promise<void>) |
+    ((job: Job<T>, done: () => void) => void);
+}


### PR DESCRIPTION
## Summary
- extend local Agenda types to accept done callback or promise processor

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd5c99fec8328a427d2b9dc64d9ba