### PR TITLE
Use JobAttributesData generic for simple Agenda jobs

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -17,13 +17,6 @@ interface TaskJobData extends JobAttributesData {
   stepId?: string;
 }
 
-interface UserJobData extends JobAttributesData {
-  userId: string;
-}
-
-interface TeamJobData extends JobAttributesData {
-  teamId: string;
-}
 
 agenda.define('task.dueSoon', async (job: Job<TaskJobData>) => {
   const { taskId, stepId } = job.attrs.data;
@@ -62,11 +55,11 @@ agenda.define('task.dueNow', async (job: Job<TaskJobData>) => {
   }
 });
 
-agenda.define('task.overdueDigest', async (job: Job<UserJobData>) => {
+agenda.define('task.overdueDigest', async (job: Job<JobAttributesData>) => {
   console.log('task.overdueDigest', job.attrs.data);
 });
 
-agenda.define('dashboard.dailySnapshot', async (job: Job<TeamJobData>) => {
+agenda.define('dashboard.dailySnapshot', async (job: Job<JobAttributesData>) => {
   console.log('dashboard.dailySnapshot', job.attrs.data);
 });
 


### PR DESCRIPTION
## Summary
- import `JobAttributesData` from Agenda and apply it to simple job handlers

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*
- `npm install` *(fails: 403 Forbidden for @dnd-kit/core)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd84aa0748328ba4444c823bf7dfc