### PR TITLE
fix: ensure mongoose models typed

### DIFF
--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,4 +1,4 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import { Schema, model, models, type Document, type Types, type Model } from 'mongoose';
 
 export interface INotification extends Document {
   userId: Types.ObjectId;
@@ -26,4 +26,8 @@ notificationSchema.index({ userId: 1, read: 1 });
 notificationSchema.index({ createdAt: -1 });
 notificationSchema.index({ type: 1 });
 
-export default models.Notification || model<INotification>('Notification', notificationSchema);
+const NotificationModel =
+  (models.Notification as Model<INotification>) ||
+  model<INotification>('Notification', notificationSchema);
+
+export default NotificationModel;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,6 +4,7 @@ import {
   models,
   type HydratedDocument,
   type Types,
+  type Model,
 } from 'mongoose';
 import bcrypt from 'bcrypt';
 
@@ -110,4 +111,6 @@ userSchema.pre('save', async function (this: UserDocument) {
   }
 });
 
-export default models.User || model<IUser>('User', userSchema);
+const UserModel = (models.User as Model<IUser>) || model<IUser>('User', userSchema);
+
+export default UserModel;


### PR DESCRIPTION
## Summary
- fix union typing by explicitly casting mongoose models
- type query filters in digest script for stricter usage

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bddc49ab988328887ebabb5b2a77d3