### PR TITLE
fix: correct lean query typings

### DIFF
--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -22,7 +22,7 @@ async function main() {
     'notificationSettings.digestFrequency': { $ne: 'immediate' },
     'notificationSettings.email': { $ne: false },
   };
-  const users = await User.find(userQuery).lean<IUser>();
+  const users = await User.find(userQuery).lean();
 
   for (const user of users) {
     const prefs: Partial<IUser['notificationSettings']> =
@@ -37,7 +37,7 @@ async function main() {
       read: false,
       createdAt: { $gt: last },
     };
-    const notifications = await Notification.find(notificationQuery).lean<INotification>();
+    const notifications = await Notification.find(notificationQuery).lean();
     if (!notifications.length) continue;
 
     const listItems = notifications


### PR DESCRIPTION
## Summary
- fix digest script to iterate over queried users and notifications by removing incorrect lean generics

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdddc5c1d0832884688518cc69b076