### PR TITLE
Fix seed script type error and add regression test

### DIFF
--- a/scripts/seed.test.ts
+++ b/scripts/seed.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+const orgDeleteMany = vi.fn().mockResolvedValue(undefined);
+const orgCreate = vi.fn().mockResolvedValue([
+  { _id: 'org1', name: 'Acme', domain: 'acme.com' },
+]);
+vi.mock('@/models/Organization', () => ({
+  __esModule: true,
+  default: { deleteMany: orgDeleteMany, create: orgCreate },
+}));
+
+const teamDeleteMany = vi.fn().mockResolvedValue(undefined);
+const teamCreate = vi.fn().mockResolvedValue({ _id: 'team1', name: 'Team' });
+vi.mock('@/models/Team', () => ({
+  __esModule: true,
+  default: { deleteMany: teamDeleteMany, create: teamCreate },
+}));
+
+const userDeleteMany = vi.fn().mockResolvedValue(undefined);
+const userCreate = vi.fn().mockResolvedValue([
+  { _id: 'u1' },
+  { _id: 'u2' },
+  { _id: 'u3' },
+  { _id: 'u4' },
+]);
+vi.mock('@/models/User', () => ({
+  __esModule: true,
+  default: { deleteMany: userDeleteMany, create: userCreate },
+}));
+
+const taskDeleteMany = vi.fn().mockResolvedValue(undefined);
+const taskCreate = vi.fn().mockResolvedValue({ _id: 't1' });
+vi.mock('@/models/Task', () => ({
+  __esModule: true,
+  default: { deleteMany: taskDeleteMany, create: taskCreate },
+}));
+
+import { seed } from './seed';
+
+describe('seed script', () => {
+  it('clears collections before seeding', async () => {
+    await seed();
+    expect(orgDeleteMany).toHaveBeenCalledWith({});
+    expect(teamDeleteMany).toHaveBeenCalledWith({});
+    expect(userDeleteMany).toHaveBeenCalledWith({});
+    expect(taskDeleteMany).toHaveBeenCalledWith({});
+  });
+});
+

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -4,7 +4,7 @@ import Team from '@/models/Team';
 import User from '@/models/User';
 import Task from '@/models/Task';
 
-async function run() {
+export async function seed() {
   await dbConnect();
   await Promise.all([
     Organization.deleteMany({}),
@@ -85,10 +85,13 @@ async function run() {
   }
 
   console.log('Seeding complete');
-  process.exit(0);
 }
 
-run().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  seed()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/src/models/Organization.ts
+++ b/src/models/Organization.ts
@@ -1,4 +1,4 @@
-import { Schema, model, models, type Document } from 'mongoose';
+import { Schema, model, models, type Document, type Model } from 'mongoose';
 
 export interface IOrganization extends Document {
   name: string;
@@ -15,4 +15,8 @@ const organizationSchema = new Schema<IOrganization>(
   { timestamps: true }
 );
 
-export default models.Organization || model<IOrganization>('Organization', organizationSchema);
+const OrganizationModel =
+  (models.Organization as Model<IOrganization>) ||
+  model<IOrganization>('Organization', organizationSchema);
+
+export default OrganizationModel;

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,4 +1,4 @@
-import { Schema, model, models, type Document, Types } from 'mongoose';
+import { Schema, model, models, type Document, Types, type Model } from 'mongoose';
 
 export type TaskStatus =
   | 'OPEN'
@@ -105,4 +105,6 @@ taskSchema.pre('save', function (next) {
   next();
 });
 
-export default models.Task || model<ITask>('Task', taskSchema);
+const TaskModel = (models.Task as Model<ITask>) || model<ITask>('Task', taskSchema);
+
+export default TaskModel;

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,4 +1,4 @@
-import { Schema, model, models, type Types } from 'mongoose';
+import { Schema, model, models, type Types, type Model } from 'mongoose';
 
 export interface ITeam {
   _id: Types.ObjectId;
@@ -14,4 +14,6 @@ const teamSchema = new Schema<ITeam>(
   { timestamps: true }
 );
 
-export default models.Team || model<ITeam>('Team', teamSchema);
+const TeamModel = (models.Team as Model<ITeam>) || model<ITeam>('Team', teamSchema);
+
+export default TeamModel;


### PR DESCRIPTION
## Summary
- type Mongoose model exports to avoid deleteMany union errors
- expose seed script as function and guard direct execution
- add unit test ensuring all collections are cleared before seeding

## Testing
- `npm install` (fails: 403 Forbidden for @dnd-kit/core)
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')
- `npx tsc -p tsconfig.json --noEmit` (fails: Cannot find type definition file for 'node')

------
https://chatgpt.com/codex/tasks/task_e_68bddea00e108328951cab6455caccd6