### PR TITLE
Fix optional types for exactOptionalPropertyTypes

### DIFF
--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -15,7 +15,7 @@ interface Task {
   dueDate: Date;
   participantIds: mongoose.Types.ObjectId[];
   visibility?: string;
-  teamId?: mongoose.Types.ObjectId;
+  teamId?: mongoose.Types.ObjectId | undefined;
 }
 
 interface TaskQuery {

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -3,8 +3,8 @@ import type { ITask } from '@/models/Task';
 
 type UserLike = {
   _id: Types.ObjectId | string;
-  organizationId?: Types.ObjectId | string;
-  teamId?: Types.ObjectId | string;
+  organizationId?: Types.ObjectId | string | undefined;
+  teamId?: Types.ObjectId | string | undefined;
 };
 
 export function canReadTask(user: UserLike, task: ITask): boolean {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,9 +10,9 @@ import User from '@/models/User';
 interface AuthUser {
   id: string;
   email: string;
-  organizationId?: string;
-  teamId?: string;
-  role?: string;
+  organizationId?: string | undefined;
+  teamId?: string | undefined;
+  role?: string | undefined;
 }
 
 export const authOptions: NextAuthOptions = {

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -13,31 +13,31 @@ export type TaskVisibility = 'PRIVATE' | 'TEAM';
 export interface IStep {
   title: string;
   ownerId: Types.ObjectId;
-  description?: string;
-  dueAt?: Date;
+  description?: string | undefined;
+  dueAt?: Date | undefined;
   status: 'OPEN' | 'DONE';
-  completedAt?: Date;
+  completedAt?: Date | undefined;
 }
 
 export interface ITask extends Document {
   _id: Types.ObjectId;
   title: string;
-  description?: string;
+  description?: string | undefined;
   createdBy: Types.ObjectId;
-  ownerId?: Types.ObjectId;
-  helpers?: Types.ObjectId[];
-  mentions?: Types.ObjectId[];
+  ownerId?: Types.ObjectId | undefined;
+  helpers?: Types.ObjectId[] | undefined;
+  mentions?: Types.ObjectId[] | undefined;
   organizationId: Types.ObjectId;
-  teamId?: Types.ObjectId;
+  teamId?: Types.ObjectId | undefined;
   status: TaskStatus;
   priority: TaskPriority;
-  tags?: string[];
-  visibility?: TaskVisibility;
-  dueDate?: Date;
-  steps?: IStep[];
-  currentStepIndex?: number;
-  participantIds?: Types.ObjectId[];
-  custom?: Record<string, unknown>;
+  tags?: string[] | undefined;
+  visibility?: TaskVisibility | undefined;
+  dueDate?: Date | undefined;
+  steps?: IStep[] | undefined;
+  currentStepIndex?: number | undefined;
+  participantIds?: Types.ObjectId[] | undefined;
+  custom?: Record<string, unknown> | undefined;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -24,17 +24,17 @@ export interface IUser {
   username: string;
   password: string;
   organizationId: Types.ObjectId;
-  teamId?: Types.ObjectId;
+  teamId?: Types.ObjectId | undefined;
   timezone: string;
   isActive: boolean;
   role: 'ADMIN' | 'USER';
-  avatar?: string;
+  avatar?: string | undefined;
   permissions: string[];
   notificationSettings: {
     email: boolean;
     push: boolean;
     digestFrequency: 'immediate' | 'daily' | 'weekly';
-    lastDigestAt?: Date;
+    lastDigestAt?: Date | undefined;
     types: {
       ASSIGNMENT: boolean;
       LOOP_STEP_READY: boolean;

--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -3,71 +3,71 @@ import type { TaskPriority, TaskStatus, TaskVisibility } from '@/models/Task';
 export interface TaskStepPayload {
   title: string;
   ownerId: string;
-  description?: string;
-  dueAt?: Date;
-  status?: 'OPEN' | 'DONE';
-  completedAt?: Date;
+  description?: string | undefined;
+  dueAt?: Date | undefined;
+  status?: 'OPEN' | 'DONE' | undefined;
+  completedAt?: Date | undefined;
 }
 
 export interface TaskPayload {
   title: string;
-  description?: string;
-  ownerId?: string;
-  helpers?: string[];
-  mentions?: string[];
-  teamId?: string;
-  status?: TaskStatus;
-  priority?: TaskPriority;
-  tags?: string[];
-  visibility?: TaskVisibility;
-  dueDate?: Date;
-  steps?: TaskStepPayload[];
-  currentStepIndex?: number;
+  description?: string | undefined;
+  ownerId?: string | undefined;
+  helpers?: string[] | undefined;
+  mentions?: string[] | undefined;
+  teamId?: string | undefined;
+  status?: TaskStatus | undefined;
+  priority?: TaskPriority | undefined;
+  tags?: string[] | undefined;
+  visibility?: TaskVisibility | undefined;
+  dueDate?: Date | undefined;
+  steps?: TaskStepPayload[] | undefined;
+  currentStepIndex?: number | undefined;
 }
 
 export interface TaskListQuery {
-  ownerId?: string;
-  createdBy?: string;
-  status?: TaskStatus[];
-  dueFrom?: Date;
-  dueTo?: Date;
-  priority?: TaskPriority[];
-  tag?: string[];
-  visibility?: TaskVisibility;
-  teamId?: string;
-  q?: string;
-  sort?: 'dueDate' | 'priority' | 'createdAt' | 'title';
-  limit?: number;
-  page?: number;
+  ownerId?: string | undefined;
+  createdBy?: string | undefined;
+  status?: TaskStatus[] | undefined;
+  dueFrom?: Date | undefined;
+  dueTo?: Date | undefined;
+  priority?: TaskPriority[] | undefined;
+  tag?: string[] | undefined;
+  visibility?: TaskVisibility | undefined;
+  teamId?: string | undefined;
+  q?: string | undefined;
+  sort?: 'dueDate' | 'priority' | 'createdAt' | 'title' | undefined;
+  limit?: number | undefined;
+  page?: number | undefined;
 }
 
 export interface TaskStep {
   title: string;
   ownerId: string;
-  description?: string;
-  dueAt?: string;
+  description?: string | undefined;
+  dueAt?: string | undefined;
   status: 'OPEN' | 'DONE';
-  completedAt?: string;
+  completedAt?: string | undefined;
 }
 
 export interface TaskResponse {
   _id: string;
   title: string;
-  description?: string;
+  description?: string | undefined;
   createdBy: string;
-  ownerId?: string;
-  helpers?: string[];
-  mentions?: string[];
+  ownerId?: string | undefined;
+  helpers?: string[] | undefined;
+  mentions?: string[] | undefined;
   organizationId: string;
-  teamId?: string;
+  teamId?: string | undefined;
   status: TaskStatus;
   priority: TaskPriority;
-  tags?: string[];
+  tags?: string[] | undefined;
   visibility: TaskVisibility;
-  dueDate?: string;
-  steps?: TaskStep[];
-  currentStepIndex?: number;
-  participantIds?: string[];
+  dueDate?: string | undefined;
+  steps?: TaskStep[] | undefined;
+  currentStepIndex?: number | undefined;
+  participantIds?: string[] | undefined;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- include `undefined` in UserLike, AuthUser, and task-related types
- allow undefined on optional fields in Task and User models

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3e47c748328ab11db93f8be08cb