### PR TITLE
refactor: stabilize mongoose model exports and runtime

### DIFF
--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -1,6 +1,6 @@
 import dbConnect from '@/lib/db';
-import User, { type IUser } from '@/models/User';
-import Notification, { type INotification } from '@/models/Notification';
+import { User, type IUser } from '@/models/User';
+import { Notification, type INotification } from '@/models/Notification';
 import type { FilterQuery } from 'mongoose';
 import { Resend } from 'resend';
 import path from 'path';

--- a/scripts/seed.test.ts
+++ b/scripts/seed.test.ts
@@ -11,14 +11,14 @@ const orgCreate = vi.fn().mockResolvedValue([
 ]);
 vi.mock('@/models/Organization', () => ({
   __esModule: true,
-  default: { deleteMany: orgDeleteMany, create: orgCreate },
+  Organization: { deleteMany: orgDeleteMany, create: orgCreate },
 }));
 
 const teamDeleteMany = vi.fn().mockResolvedValue(undefined);
 const teamCreate = vi.fn().mockResolvedValue({ _id: 'team1', name: 'Team' });
 vi.mock('@/models/Team', () => ({
   __esModule: true,
-  default: { deleteMany: teamDeleteMany, create: teamCreate },
+  Team: { deleteMany: teamDeleteMany, create: teamCreate },
 }));
 
 const userDeleteMany = vi.fn().mockResolvedValue(undefined);
@@ -30,14 +30,14 @@ const userCreate = vi.fn().mockResolvedValue([
 ]);
 vi.mock('@/models/User', () => ({
   __esModule: true,
-  default: { deleteMany: userDeleteMany, create: userCreate },
+  User: { deleteMany: userDeleteMany, create: userCreate },
 }));
 
 const taskDeleteMany = vi.fn().mockResolvedValue(undefined);
 const taskCreate = vi.fn().mockResolvedValue({ _id: 't1' });
 vi.mock('@/models/Task', () => ({
   __esModule: true,
-  default: { deleteMany: taskDeleteMany, create: taskCreate },
+  Task: { deleteMany: taskDeleteMany, create: taskCreate },
 }));
 
 import { seed } from './seed';

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,8 +1,8 @@
 import dbConnect from '@/lib/db';
-import Organization from '@/models/Organization';
-import Team from '@/models/Team';
-import User from '@/models/User';
-import Task from '@/models/Task';
+import { Organization } from '@/models/Organization';
+import { Team } from '@/models/Team';
+import { User } from '@/models/User';
+import { Task } from '@/models/Task';
 
 export async function seed() {
   await dbConnect();

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -1,7 +1,7 @@
 import agenda, { initAgenda, DEFAULT_TZ } from '@/lib/agenda';
-import User from '@/models/User';
-import Team, { type ITeam } from '@/models/Team';
-import Task from '@/models/Task';
+import { User } from '@/models/User';
+import { Team, type ITeam } from '@/models/Team';
+import { Task } from '@/models/Task';
 import type { ITask } from '@/models/Task';
 import { notifyDueSoon, notifyDueNow, notifyOverdue } from '@/lib/notify';
 import { Types } from 'mongoose';

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { verifyAndConsumeOtp } from '@/lib/otp';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 import { signIn } from '@/lib/auth';
 import bcrypt from 'bcrypt';
 
@@ -52,6 +52,13 @@ export async function POST(req: NextRequest) {
     },
     { upsert: true }
   );
-    await signIn('credentials', { email, otpVerified: true, callbackUrl: '/tasks', redirect: false });
-    return NextResponse.redirect(new URL('/tasks', req.url));
-  }
+  await signIn('credentials', {
+    email,
+    otpVerified: true,
+    callbackUrl: '/tasks',
+    redirect: false,
+  });
+  return NextResponse.redirect(new URL('/tasks', req.url));
+}
+
+export const runtime = 'nodejs';

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -4,9 +4,9 @@ import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
 import { auth } from '@/lib/auth';
 import { canReadTask } from '@/lib/access';
-import Comment, { type IComment } from '@/models/Comment';
-import Task from '@/models/Task';
-import ActivityLog from '@/models/ActivityLog';
+import { Comment, type IComment } from '@/models/Comment';
+import { Task } from '@/models/Task';
+import { ActivityLog } from '@/models/ActivityLog';
 import { emitCommentCreated } from '@/lib/ws';
 import { problem } from '@/lib/http';
 
@@ -22,6 +22,8 @@ const listQuerySchema = z.object({
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/dashboard/daily/route.ts
+++ b/src/app/api/dashboard/daily/route.ts
@@ -2,8 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Objective, { type IObjective } from '@/models/Objective';
-import Task, { type ITask } from '@/models/Task';
+import { Objective, type IObjective } from '@/models/Objective';
+import { Task, type ITask } from '@/models/Task';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -11,6 +11,8 @@ const querySchema = z.object({
   date: z.string(),
   teamId: z.string(),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/invitations/accept/route.ts
+++ b/src/app/api/invitations/accept/route.ts
@@ -2,8 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
-import Invitation, { type IInvitation } from '@/models/Invitation';
-import User from '@/models/User';
+import { Invitation, type IInvitation } from '@/models/Invitation';
+import { User } from '@/models/User';
 import { problem } from '@/lib/http';
 import { Types } from 'mongoose';
 
@@ -12,6 +12,8 @@ const acceptSchema = z.object({
   name: z.string(),
   password: z.string(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   let body: z.infer<typeof acceptSchema>;

--- a/src/app/api/invitations/route.ts
+++ b/src/app/api/invitations/route.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import dbConnect from '@/lib/db';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
-import Invitation from '@/models/Invitation';
+import { Invitation } from '@/models/Invitation';
 import { sendInvitationEmail } from '@/lib/email';
 import { Types } from 'mongoose';
 
@@ -12,6 +12,8 @@ const inviteSchema = z.object({
   email: z.string().email(),
   role: z.enum(['ADMIN', 'USER']).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/loop-templates/route.ts
+++ b/src/app/api/loop-templates/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import LoopTemplate from '@/models/LoopTemplate';
+import { LoopTemplate } from '@/models/LoopTemplate';
 import { problem } from '@/lib/http';
 
 const stepSchema = z.object({
@@ -15,6 +15,8 @@ const templateSchema = z.object({
   name: z.string(),
   steps: z.array(stepSchema),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET() {
   await dbConnect();

--- a/src/app/api/notifications/[id]/read/route.test.ts
+++ b/src/app/api/notifications/[id]/read/route.test.ts
@@ -21,7 +21,7 @@ const auth = vi.fn();
 vi.mock('@/lib/auth', () => ({ auth }));
 
 const findOneAndUpdate = vi.fn();
-vi.mock('@/models/Notification', () => ({ default: { findOneAndUpdate } }));
+vi.mock('@/models/Notification', () => ({ Notification: { findOneAndUpdate } }));
 
 import { POST } from './route';
 

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Notification from '@/models/Notification';
+import { Notification } from '@/models/Notification';
 import { auth } from '@/lib/auth';
 
 export async function POST(
@@ -43,3 +43,5 @@ export async function POST(
 
   return NextResponse.json(notification);
 }
+
+export const runtime = 'nodejs';

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import Notification, { type INotification } from '@/models/Notification';
+import { Notification, type INotification } from '@/models/Notification';
 import { auth } from '@/lib/auth';
 import { Types, type FilterQuery } from 'mongoose';
 
@@ -16,6 +16,8 @@ const querySchema = z.object({
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/notifications/unread-count/route.ts
+++ b/src/app/api/notifications/unread-count/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
-import Notification from '@/models/Notification';
+import { Notification } from '@/models/Notification';
 import { auth } from '@/lib/auth';
 
 export async function GET() {
@@ -15,3 +15,5 @@ export async function GET() {
   });
   return NextResponse.json({ count });
 }
+
+export const runtime = 'nodejs';

--- a/src/app/api/objectives/[id]/route.ts
+++ b/src/app/api/objectives/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
-import Objective from '@/models/Objective';
+import { Objective } from '@/models/Objective';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -26,4 +26,6 @@ export async function PATCH(
   await objective.save();
   return NextResponse.json(objective);
 }
+
+export const runtime = 'nodejs';
 

--- a/src/app/api/objectives/objectives.test.ts
+++ b/src/app/api/objectives/objectives.test.ts
@@ -32,7 +32,7 @@ interface TaskQuery {
 const tasks = new Map<string, Task>();
 
 vi.mock('@/models/Objective', () => ({
-  default: {
+  Objective: {
     create: vi.fn(async (doc: unknown) => {
       const _id = doc._id || new Types.ObjectId();
       const objective = { ...doc, _id };
@@ -61,7 +61,7 @@ vi.mock('@/models/Objective', () => ({
 }));
 
 vi.mock('@/models/Task', () => ({
-  default: {
+  Task: {
     find: vi.fn(async (filter: TaskQuery): Promise<Task[]> => {
       return Array.from(tasks.values()).filter((t) => {
         const due =

--- a/src/app/api/objectives/route.ts
+++ b/src/app/api/objectives/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Objective from '@/models/Objective';
+import { Objective } from '@/models/Objective';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -15,6 +15,8 @@ const upsertSchema = z.object({
   linkedTaskIds: z.array(z.string()).optional(),
   status: z.enum(['OPEN', 'DONE']).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/db';
-import Organization from '@/models/Organization';
+import { Organization } from '@/models/Organization';
 
 export async function GET() {
   await dbConnect();
   const organizations = await Organization.find({}, 'name').lean();
   return NextResponse.json(organizations);
 }
+
+export const runtime = 'nodejs';

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { auth } from '@/lib/auth';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 import { sendPushToUser } from '@/lib/push';
 
 const bodySchema = z.object({
@@ -10,6 +10,8 @@ const bodySchema = z.object({
   title: z.string(),
   body: z.string(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { auth } from '@/lib/auth';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 
 const subscriptionSchema = z.object({
   endpoint: z.string(),
@@ -16,6 +16,8 @@ const subscriptionSchema = z.object({
 const bodySchema = z.object({
   subscription: subscriptionSchema,
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -2,8 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Organization from '@/models/Organization';
-import User from '@/models/User';
+import { Organization } from '@/models/Organization';
+import { User } from '@/models/User';
 import { problem } from '@/lib/http';
 
 const registerSchema = z.object({
@@ -13,6 +13,8 @@ const registerSchema = z.object({
   organizationId: z.string().optional(),
   organizationName: z.string().optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   let body: z.infer<typeof registerSchema>;

--- a/src/app/api/search/global/route.ts
+++ b/src/app/api/search/global/route.ts
@@ -2,9 +2,9 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
-import TaskLoop from '@/models/TaskLoop';
-import Comment from '@/models/Comment';
+import { Task } from '@/models/Task';
+import { TaskLoop } from '@/models/TaskLoop';
+import { Comment } from '@/models/Comment';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -14,6 +14,8 @@ const querySchema = z.object({
   page: z.coerce.number().min(1).default(1),
   sort: z.enum(['recent', 'oldest']).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/search/saved/[id]/route.ts
+++ b/src/app/api/search/saved/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import SavedSearch from '@/models/SavedSearch';
+import { SavedSearch } from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
 
 interface Params {
@@ -13,6 +13,8 @@ const bodySchema = z.object({
   name: z.string().optional(),
   query: z.string().optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET(_req: NextRequest, context: Params) {
   const { params } = context;

--- a/src/app/api/search/saved/route.ts
+++ b/src/app/api/search/saved/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import SavedSearch from '@/models/SavedSearch';
+import { SavedSearch } from '@/models/SavedSearch';
 import { auth } from '@/lib/auth';
 import { getPresets } from '@/app/search/filters';
 
@@ -9,6 +9,8 @@ const bodySchema = z.object({
   name: z.string(),
   query: z.string(),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET() {
   const session = await auth();

--- a/src/app/api/search/suggestions/route.ts
+++ b/src/app/api/search/suggestions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { Types, type PipelineStage } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
+import { Task } from '@/models/Task';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -79,4 +79,6 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({ suggestions: Array.from(suggestions).slice(0, 10) });
 }
+
+export const runtime = 'nodejs';
 

--- a/src/app/api/search/tasks/route.ts
+++ b/src/app/api/search/tasks/route.ts
@@ -2,9 +2,9 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types, type FilterQuery, type PipelineStage } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task, { type ITask } from '@/models/Task';
-import Comment from '@/models/Comment';
-import TaskLoop from '@/models/TaskLoop';
+import { Task, type ITask } from '@/models/Task';
+import { Comment } from '@/models/Comment';
+import { TaskLoop } from '@/models/TaskLoop';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 import { meta } from '@/lib/mongo';
@@ -59,6 +59,8 @@ const querySchema = z.object({
   page: z.coerce.number().min(1).default(1),
   limit: z.coerce.number().min(1).max(100).default(20),
 });
+
+export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -4,8 +4,8 @@ import { Types } from 'mongoose';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import dbConnect from '@/lib/db';
-import Attachment from '@/models/Attachment';
-import Task from '@/models/Task';
+import { Attachment } from '@/models/Attachment';
+import { Task } from '@/models/Task';
 import { canReadTask, canWriteTask } from '@/lib/access';
 import { problem } from '@/lib/http';
 import { withOrganization } from '@/lib/middleware/withOrganization';
@@ -17,7 +17,7 @@ export const GET = withOrganization(
     session: Session
   ) => {
     const { params } = context;
-    const { id } = await params;
+const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
@@ -73,6 +73,8 @@ export const POST = withOrganization(
     return NextResponse.json(attachment, { status: 201 });
   }
 );
+
+export const runtime = 'nodejs';
 
 export const DELETE = withOrganization(
   async (

--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
-import ActivityLog from '@/models/ActivityLog';
+import { Task } from '@/models/Task';
+import { ActivityLog } from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { canReadTask } from '@/lib/access';
 import { problem } from '@/lib/http';
@@ -50,4 +50,6 @@ export async function GET(
 
   return NextResponse.json(events);
 }
+
+export const runtime = 'nodejs';
 

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -3,8 +3,8 @@ import type { Session } from 'next-auth';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
-import LoopHistory from '@/models/LoopHistory';
+import { Task } from '@/models/Task';
+import { LoopHistory } from '@/models/LoopHistory';
 import { canReadTask } from '@/lib/access';
 import { problem } from '@/lib/http';
 import { withOrganization } from '@/lib/middleware/withOrganization';
@@ -13,6 +13,8 @@ const querySchema = z.object({
   page: z.coerce.number().int().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export const GET = withOrganization(
   async (

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -12,13 +12,13 @@ vi.mock('@/lib/notify', () => ({ notifyAssignment, notifyLoopStepReady }));
 
 interface Task { _id: Types.ObjectId; organizationId: Types.ObjectId }
 const findTaskById = vi.fn<[string], Promise<Task | null>>();
-vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
+vi.mock('@/models/Task', () => ({ Task: { findById: findTaskById } }));
 
 const findLoop = vi.fn();
-vi.mock('@/models/TaskLoop', () => ({ default: { findOne: findLoop } }));
+vi.mock('@/models/TaskLoop', () => ({ TaskLoop: { findOne: findLoop } }));
 
 const findUsers = vi.fn();
-vi.mock('@/models/User', () => ({ default: { find: findUsers } }));
+vi.mock('@/models/User', () => ({ User: { find: findUsers } }));
 
 vi.mock('@/lib/access', () => ({ canWriteTask: () => true }));
 

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -3,11 +3,10 @@ import type { Session } from 'next-auth';
 import { z } from 'zod';
 import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
-import type { ITask } from '@/models/Task';
-import TaskLoop, { type ITaskLoop } from '@/models/TaskLoop';
-import LoopHistory from '@/models/LoopHistory';
-import User, { type IUser } from '@/models/User';
+import { Task, type ITask } from '@/models/Task';
+import { TaskLoop, type ITaskLoop } from '@/models/TaskLoop';
+import { LoopHistory } from '@/models/LoopHistory';
+import { User, type IUser } from '@/models/User';
 import { canWriteTask } from '@/lib/access';
 import { problem } from '@/lib/http';
 import { withOrganization } from '@/lib/middleware/withOrganization';
@@ -56,6 +55,8 @@ const loopPatchSchema = z.object({
   parallel: z.boolean().optional(),
   sequence: z.array(loopPatchStepSchema).optional(),
 });
+
+export const runtime = 'nodejs';
 
 type LoopPatchStep = z.infer<typeof loopPatchStepSchema>;
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,10 +3,10 @@ import type { Session } from 'next-auth';
 import { z } from 'zod';
 import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
+import { Task } from '@/models/Task';
 import type { ITask } from '@/models/Task';
-import ActivityLog from '@/models/ActivityLog';
-import User from '@/models/User';
+import { ActivityLog } from '@/models/ActivityLog';
+import { User } from '@/models/User';
 import { canReadTask, canWriteTask } from '@/lib/access';
 import { scheduleTaskJobs } from '@/lib/agenda';
 import { emitTaskUpdated } from '@/lib/ws';
@@ -39,6 +39,8 @@ const patchSchema: z.ZodType<Partial<TaskPayload>> = z
     steps: z.array(stepSchema).optional(),
     currentStepIndex: z.number().int().optional(),
   });
+
+export const runtime = 'nodejs';
 
 const putSchema: z.ZodType<TaskPayload> = z
   .object({

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -2,8 +2,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import { Types, startSession } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task, { type IStep } from '@/models/Task';
-import ActivityLog from '@/models/ActivityLog';
+import { Task, type IStep } from '@/models/Task';
+import { ActivityLog } from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { emitTaskTransition } from '@/lib/ws';
 import { diff } from '@/lib/diff';
@@ -21,6 +21,8 @@ import type { ITask } from '@/models/Task';
 const bodySchema = z.object({
   action: z.enum(['START', 'SEND_FOR_REVIEW', 'REQUEST_CHANGES', 'DONE']),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(
   req: NextRequest,

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { Types, type FilterQuery } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
+import { Task } from '@/models/Task';
 import type { ITask, TaskStatus } from '@/models/Task';
-import ActivityLog from '@/models/ActivityLog';
-import User from '@/models/User';
+import { ActivityLog } from '@/models/ActivityLog';
+import { User } from '@/models/User';
 import { notifyAssignment, notifyMention } from '@/lib/notify';
 import { scheduleTaskJobs } from '@/lib/agenda';
 import { problem } from '@/lib/http';
@@ -33,6 +33,8 @@ const createTaskSchema: z.ZodType<TaskPayload> = z
     dueDate: z.coerce.date().optional(),
     steps: z.array(stepSchema).optional(),
   });
+
+export const runtime = 'nodejs';
 
 export const POST = withOrganization(async (req, session) => {
   let body: TaskPayload;

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -36,7 +36,7 @@ interface Task {
 const tasks = new Map<string, Task>();
 
 vi.mock('@/models/Task', () => ({
-  default: {
+  Task: {
     findById: vi.fn(async (id: string): Promise<Task | null> => {
       const doc = tasks.get(id);
       if (!doc) return null;
@@ -52,7 +52,7 @@ vi.mock('@/models/Task', () => ({
 }));
 
 vi.mock('@/models/ActivityLog', () => ({
-  default: { create: vi.fn() },
+  ActivityLog: { create: vi.fn() },
 }));
 
 let currentUserId = '';

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 
 export async function GET(
   _req: NextRequest,
@@ -40,3 +40,5 @@ export async function DELETE(
   await User.findByIdAndDelete(id);
   return NextResponse.json({ ok: true });
 }
+
+export const runtime = 'nodejs';

--- a/src/app/api/users/me/notifications/route.ts
+++ b/src/app/api/users/me/notifications/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 import { NotificationType } from '@/lib/notify';
@@ -47,6 +47,8 @@ const updateSchema = z.object({
     })
     .optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function PUT(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -27,6 +27,8 @@ const updateSchema = z.object({
   avatar: z.string().url().optional(),
   timezone: z.string().optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function PUT(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { Types, type FilterQuery } from 'mongoose';
 import { z } from 'zod';
 import dbConnect from '@/lib/db';
-import User, { type IUser } from '@/models/User';
+import { User, type IUser } from '@/models/User';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
 
@@ -44,6 +44,8 @@ const createUserSchema = z.object({
   avatar: z.string().optional(),
   permissions: z.array(z.string()).optional(),
 });
+
+export const runtime = 'nodejs';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,7 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import { signIn as signInBase } from 'next-auth/react';
 import bcrypt from 'bcrypt';
 import dbConnect from '@/lib/db';
-import User from '@/models/User';
+import { User } from '@/models/User';
 
 interface AuthUser {
   id: string;

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -8,14 +8,14 @@ const notifyAssignment = vi.fn();
 vi.mock('@/lib/notify', () => ({ notifyLoopStepReady, notifyAssignment }));
 
 const findOne = vi.fn();
-vi.mock('@/models/TaskLoop', () => ({ default: { findOne } }));
+vi.mock('@/models/TaskLoop', () => ({ TaskLoop: { findOne } }));
 
 interface Task { _id: Types.ObjectId }
 const findTaskById = vi.fn<[string], Promise<Task | null>>();
-vi.mock('@/models/Task', () => ({ default: { findById: findTaskById } }));
+vi.mock('@/models/Task', () => ({ Task: { findById: findTaskById } }));
 
 const createHistory = vi.fn();
-vi.mock('@/models/LoopHistory', () => ({ default: { create: createHistory } }));
+vi.mock('@/models/LoopHistory', () => ({ LoopHistory: { create: createHistory } }));
 
 import { completeStep } from './loop';
 

--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -1,9 +1,9 @@
 import mongoose, { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import Task from '@/models/Task';
+import { Task } from '@/models/Task';
 import type { ITask } from '@/models/Task';
-import TaskLoop, { type ILoopStep, type ITaskLoop } from '@/models/TaskLoop';
-import LoopHistory from '@/models/LoopHistory';
+import { TaskLoop, type ILoopStep, type ITaskLoop } from '@/models/TaskLoop';
+import { LoopHistory } from '@/models/LoopHistory';
 import { notifyAssignment, notifyLoopStepReady } from '@/lib/notify';
 
 export async function completeStep(

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,9 +1,9 @@
 import { Types } from 'mongoose';
 import { Resend } from 'resend';
-import Notification from '@/models/Notification';
-import User from '@/models/User';
+import { Notification } from '@/models/Notification';
+import { User } from '@/models/User';
 import dbConnect from '@/lib/db';
-import RateLimit from '@/models/RateLimit';
+import { RateLimit } from '@/models/RateLimit';
 import { emitNotification } from '@/lib/ws';
 import path from 'path';
 import { promises as fs } from 'fs';

--- a/src/lib/otp.test.ts
+++ b/src/lib/otp.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/lib/db', () => ({ default: vi.fn() }));
 
 const tokens: unknown[] = [];
 vi.mock('@/models/OtpToken', () => ({
-  default: {
+  OtpToken: {
     findOne: vi.fn(async (query: unknown) =>
       tokens
         .filter((t) => t.email === query.email)
@@ -32,7 +32,7 @@ vi.mock('@/models/OtpToken', () => ({
 
 const rates = new Map<string, unknown>();
 vi.mock('@/models/RateLimit', () => ({
-  default: {
+  RateLimit: {
     findOne: vi.fn(async ({ key }: unknown) => rates.get(key) || null),
     updateOne: vi.fn(async ({ key }: unknown, update: unknown, opts?: unknown) => {
       const record = rates.get(key);

--- a/src/lib/otp.ts
+++ b/src/lib/otp.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
-import OtpToken from '@/models/OtpToken';
-import RateLimit from '@/models/RateLimit';
+import { OtpToken } from '@/models/OtpToken';
+import { RateLimit } from '@/models/RateLimit';
 
 const OTP_EXPIRY_MINUTES = 10;
 const RESEND_COOLDOWN = 60; // seconds

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -1,5 +1,5 @@
 import dbConnect from '@/lib/db';
-import RateLimit from '@/models/RateLimit';
+import { RateLimit } from '@/models/RateLimit';
 import type { Types } from 'mongoose';
 
 interface MetaWebSocket extends WebSocket {

--- a/src/models/ActivityLog.ts
+++ b/src/models/ActivityLog.ts
@@ -1,14 +1,13 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface IActivityLog extends Document {
-  taskId: Types.ObjectId;
-  actorId: Types.ObjectId;
-  type: string;
-  payload: unknown;
-  createdAt: Date;
-}
-
-const activityLogSchema = new Schema<IActivityLog>(
+const activityLogSchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true, index: true },
     actorId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
@@ -18,4 +17,9 @@ const activityLogSchema = new Schema<IActivityLog>(
   { timestamps: { createdAt: true, updatedAt: false } }
 );
 
-export default models.ActivityLog || model<IActivityLog>('ActivityLog', activityLogSchema);
+export type IActivityLog = InferSchemaType<typeof activityLogSchema>;
+
+export const ActivityLog: Model<IActivityLog> =
+  (models.ActivityLog as Model<IActivityLog>) ??
+  model<IActivityLog>('ActivityLog', activityLogSchema);
+

--- a/src/models/Attachment.ts
+++ b/src/models/Attachment.ts
@@ -1,14 +1,13 @@
-import { Schema, model, models, type Document, Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  Types,
+} from 'mongoose';
 
-export interface IAttachment extends Document {
-  taskId: Types.ObjectId;
-  userId: Types.ObjectId;
-  filename: string;
-  url: string;
-  createdAt: Date;
-}
-
-const attachmentSchema = new Schema<IAttachment>(
+const attachmentSchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
@@ -20,4 +19,9 @@ const attachmentSchema = new Schema<IAttachment>(
 
 attachmentSchema.index({ taskId: 1, createdAt: -1 });
 
-export default models.Attachment || model<IAttachment>('Attachment', attachmentSchema);
+export type IAttachment = InferSchemaType<typeof attachmentSchema>;
+
+export const Attachment: Model<IAttachment> =
+  (models.Attachment as Model<IAttachment>) ??
+  model<IAttachment>('Attachment', attachmentSchema);
+

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -1,13 +1,13 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface IComment extends Document {
-  taskId: Types.ObjectId;
-  userId: Types.ObjectId;
-  content: string;
-  parentId?: Types.ObjectId;
-}
-
-const commentSchema = new Schema<IComment>(
+const commentSchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
@@ -22,4 +22,9 @@ commentSchema.index({ updatedAt: -1 });
 commentSchema.index({ userId: 1 });
 commentSchema.index({ content: 'text' });
 
-export default models.Comment || model<IComment>('Comment', commentSchema);
+export type IComment = InferSchemaType<typeof commentSchema>;
+
+export const Comment: Model<IComment> =
+  (models.Comment as Model<IComment>) ??
+  model<IComment>('Comment', commentSchema);
+

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -1,15 +1,6 @@
-import { Schema, model, models, type Model, type Types } from 'mongoose';
+import { Schema, model, models, type InferSchemaType, type Model } from 'mongoose';
 
-export interface IInvitation {
-  email: string;
-  organizationId: Types.ObjectId;
-  tokenHash: string;
-  role: 'ADMIN' | 'USER';
-  expiresAt: Date;
-  used: boolean;
-}
-
-const invitationSchema = new Schema<IInvitation>(
+const invitationSchema = new Schema(
   {
     email: { type: String, required: true, lowercase: true },
     organizationId: {
@@ -27,7 +18,8 @@ const invitationSchema = new Schema<IInvitation>(
 
 invitationSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-const Invitation: Model<IInvitation> =
-  models.Invitation || model<IInvitation>('Invitation', invitationSchema);
+export type IInvitation = InferSchemaType<typeof invitationSchema>;
 
-export default Invitation;
+export const Invitation: Model<IInvitation> =
+  (models.Invitation as Model<IInvitation>) ??
+  model<IInvitation>('Invitation', invitationSchema);

--- a/src/models/LoopHistory.ts
+++ b/src/models/LoopHistory.ts
@@ -1,14 +1,13 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface ILoopHistory extends Document {
-  taskId: Types.ObjectId;
-  stepIndex: number;
-  action: 'CREATE' | 'UPDATE' | 'COMPLETE' | 'REASSIGN';
-  userId: Types.ObjectId;
-  createdAt: Date;
-}
-
-const loopHistorySchema = new Schema<ILoopHistory>(
+const loopHistorySchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true, index: true },
     stepIndex: { type: Number, required: true },
@@ -22,4 +21,9 @@ const loopHistorySchema = new Schema<ILoopHistory>(
   { timestamps: { createdAt: true, updatedAt: false } }
 );
 
-export default models.LoopHistory || model<ILoopHistory>('LoopHistory', loopHistorySchema);
+export type ILoopHistory = InferSchemaType<typeof loopHistorySchema>;
+
+export const LoopHistory: Model<ILoopHistory> =
+  (models.LoopHistory as Model<ILoopHistory>) ??
+  model<ILoopHistory>('LoopHistory', loopHistorySchema);
+

--- a/src/models/LoopTemplate.ts
+++ b/src/models/LoopTemplate.ts
@@ -1,20 +1,13 @@
-import { Schema, model, models, type Document, Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  Types,
+} from 'mongoose';
 
-export interface ILoopStep {
-  assignedTo: Types.ObjectId;
-  description: string;
-  estimatedTime?: number;
-  dependencies?: number[];
-}
-
-export interface ILoopTemplate extends Document {
-  name: string;
-  steps: ILoopStep[];
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-const loopStepSchema = new Schema<ILoopStep>(
+const loopStepSchema = new Schema(
   {
     assignedTo: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     description: { type: String, required: true },
@@ -24,7 +17,7 @@ const loopStepSchema = new Schema<ILoopStep>(
   { _id: false }
 );
 
-const loopTemplateSchema = new Schema<ILoopTemplate>(
+const loopTemplateSchema = new Schema(
   {
     name: { type: String, required: true },
     steps: [loopStepSchema],
@@ -32,4 +25,10 @@ const loopTemplateSchema = new Schema<ILoopTemplate>(
   { timestamps: true }
 );
 
-export default models.LoopTemplate || model<ILoopTemplate>('LoopTemplate', loopTemplateSchema);
+export type ILoopStep = InferSchemaType<typeof loopStepSchema>;
+export type ILoopTemplate = InferSchemaType<typeof loopTemplateSchema>;
+
+export const LoopTemplate: Model<ILoopTemplate> =
+  (models.LoopTemplate as Model<ILoopTemplate>) ??
+  model<ILoopTemplate>('LoopTemplate', loopTemplateSchema);
+

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -1,16 +1,13 @@
-import { Schema, model, models, type Document, type Types, type Model } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface INotification extends Document {
-  userId: Types.ObjectId;
-  type: string;
-  message: string;
-  taskId?: Types.ObjectId;
-  read: boolean;
-  readAt?: Date | null;
-  createdAt: Date;
-}
-
-const notificationSchema = new Schema<INotification>(
+const notificationSchema = new Schema(
   {
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     type: { type: String, required: true },
@@ -30,4 +27,7 @@ const NotificationModel =
   (models.Notification as Model<INotification>) ||
   model<INotification>('Notification', notificationSchema);
 
-export default NotificationModel;
+export type INotification = InferSchemaType<typeof notificationSchema>;
+
+export const Notification: Model<INotification> = NotificationModel;
+

--- a/src/models/Objective.ts
+++ b/src/models/Objective.ts
@@ -1,17 +1,15 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
 export type ObjectiveStatus = 'OPEN' | 'DONE';
 
-export interface IObjective extends Document {
-  date: string;
-  teamId: Types.ObjectId;
-  title: string;
-  ownerId: Types.ObjectId;
-  linkedTaskIds: Types.ObjectId[];
-  status: ObjectiveStatus;
-}
-
-const objectiveSchema = new Schema<IObjective>(
+const objectiveSchema = new Schema(
   {
     date: { type: String, required: true },
     teamId: { type: Schema.Types.ObjectId, ref: 'Team', required: true },
@@ -23,4 +21,9 @@ const objectiveSchema = new Schema<IObjective>(
   { timestamps: true }
 );
 
-export default models.Objective || model<IObjective>('Objective', objectiveSchema);
+export type IObjective = InferSchemaType<typeof objectiveSchema>;
+
+export const Objective: Model<IObjective> =
+  (models.Objective as Model<IObjective>) ??
+  model<IObjective>('Objective', objectiveSchema);
+

--- a/src/models/Organization.ts
+++ b/src/models/Organization.ts
@@ -1,12 +1,12 @@
-import { Schema, model, models, type Document, type Model } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+} from 'mongoose';
 
-export interface IOrganization extends Document {
-  name: string;
-  domain: string;
-  settings?: unknown;
-}
-
-const organizationSchema = new Schema<IOrganization>(
+const organizationSchema = new Schema(
   {
     name: { type: String, required: true },
     domain: { type: String, required: true, unique: true, index: true, lowercase: true },
@@ -15,8 +15,9 @@ const organizationSchema = new Schema<IOrganization>(
   { timestamps: true }
 );
 
-const OrganizationModel =
-  (models.Organization as Model<IOrganization>) ||
+export type IOrganization = InferSchemaType<typeof organizationSchema>;
+
+export const Organization: Model<IOrganization> =
+  (models.Organization as Model<IOrganization>) ??
   model<IOrganization>('Organization', organizationSchema);
 
-export default OrganizationModel;

--- a/src/models/OtpToken.ts
+++ b/src/models/OtpToken.ts
@@ -1,15 +1,12 @@
-import { Schema, model, models, type Document } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+} from 'mongoose';
 
-export interface IOtpToken extends Document {
-  email: string;
-  codeHash: string;
-  attempts: number;
-  ip: string;
-  createdAt: Date;
-  expiresAt: Date;
-}
-
-const otpTokenSchema = new Schema<IOtpToken>(
+const otpTokenSchema = new Schema(
   {
     email: { type: String, required: true, lowercase: true, index: true },
     codeHash: { type: String, required: true },
@@ -23,4 +20,9 @@ const otpTokenSchema = new Schema<IOtpToken>(
 
 otpTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
-export default models.OtpToken || model<IOtpToken>('OtpToken', otpTokenSchema);
+export type IOtpToken = InferSchemaType<typeof otpTokenSchema>;
+
+export const OtpToken: Model<IOtpToken> =
+  (models.OtpToken as Model<IOtpToken>) ??
+  model<IOtpToken>('OtpToken', otpTokenSchema);
+

--- a/src/models/RateLimit.ts
+++ b/src/models/RateLimit.ts
@@ -1,12 +1,12 @@
-import { Schema, model, models, type Document } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+} from 'mongoose';
 
-export interface IRateLimit extends Document {
-  key: string;
-  count: number;
-  windowEndsAt: Date;
-}
-
-const rateLimitSchema = new Schema<IRateLimit>(
+const rateLimitSchema = new Schema(
   {
     key: { type: String, required: true, index: true },
     count: { type: Number, default: 0 },
@@ -17,4 +17,9 @@ const rateLimitSchema = new Schema<IRateLimit>(
 
 rateLimitSchema.index({ windowEndsAt: 1 }, { expireAfterSeconds: 0 });
 
-export default models.RateLimit || model<IRateLimit>('RateLimit', rateLimitSchema);
+export type IRateLimit = InferSchemaType<typeof rateLimitSchema>;
+
+export const RateLimit: Model<IRateLimit> =
+  (models.RateLimit as Model<IRateLimit>) ??
+  model<IRateLimit>('RateLimit', rateLimitSchema);
+

--- a/src/models/SavedSearch.ts
+++ b/src/models/SavedSearch.ts
@@ -1,13 +1,13 @@
-import { Schema, model, models, type Document, type Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface ISavedSearch extends Document {
-  userId: Types.ObjectId;
-  name: string;
-  query: string;
-  createdAt: Date;
-}
-
-const savedSearchSchema = new Schema<ISavedSearch>(
+const savedSearchSchema = new Schema(
   {
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
     name: { type: String, required: true },
@@ -16,4 +16,9 @@ const savedSearchSchema = new Schema<ISavedSearch>(
   { timestamps: { createdAt: true, updatedAt: false } }
 );
 
-export default models.SavedSearch || model<ISavedSearch>('SavedSearch', savedSearchSchema);
+export type ISavedSearch = InferSchemaType<typeof savedSearchSchema>;
+
+export const SavedSearch: Model<ISavedSearch> =
+  (models.SavedSearch as Model<ISavedSearch>) ??
+  model<ISavedSearch>('SavedSearch', savedSearchSchema);
+

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,4 +1,11 @@
-import { Schema, model, models, type Document, Types, type Model } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  Types,
+} from 'mongoose';
 
 export type TaskStatus =
   | 'OPEN'
@@ -13,33 +20,10 @@ export type TaskVisibility = 'PRIVATE' | 'TEAM';
 export interface IStep {
   title: string;
   ownerId: Types.ObjectId;
-  description?: string | undefined;
-  dueAt?: Date | undefined;
+  description?: string;
+  dueAt?: Date;
   status: 'OPEN' | 'DONE';
-  completedAt?: Date | undefined;
-}
-
-export interface ITask extends Document {
-  _id: Types.ObjectId;
-  title: string;
-  description?: string | undefined;
-  createdBy: Types.ObjectId;
-  ownerId?: Types.ObjectId | undefined;
-  helpers?: Types.ObjectId[] | undefined;
-  mentions?: Types.ObjectId[] | undefined;
-  organizationId: Types.ObjectId;
-  teamId?: Types.ObjectId | undefined;
-  status: TaskStatus;
-  priority: TaskPriority;
-  tags?: string[] | undefined;
-  visibility?: TaskVisibility | undefined;
-  dueDate?: Date | undefined;
-  steps?: IStep[] | undefined;
-  currentStepIndex?: number | undefined;
-  participantIds?: Types.ObjectId[] | undefined;
-  custom?: Record<string, unknown> | undefined;
-  createdAt: Date;
-  updatedAt: Date;
+  completedAt?: Date;
 }
 
 const stepSchema = new Schema<IStep>(
@@ -54,7 +38,7 @@ const stepSchema = new Schema<IStep>(
   { _id: false }
 );
 
-const taskSchema = new Schema<ITask>(
+const taskSchema = new Schema(
   {
     title: { type: String, required: true },
     description: String,
@@ -105,6 +89,8 @@ taskSchema.pre('save', function (next) {
   next();
 });
 
-const TaskModel = (models.Task as Model<ITask>) || model<ITask>('Task', taskSchema);
+export type ITask = InferSchemaType<typeof taskSchema>;
 
-export default TaskModel;
+export const Task: Model<ITask> =
+  (models.Task as Model<ITask>) ?? model<ITask>('Task', taskSchema);
+

--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -1,28 +1,13 @@
-import { Schema, model, models, type Document, Types } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  Types,
+} from 'mongoose';
 
-export interface ILoopStep {
-  taskId: Types.ObjectId;
-  assignedTo: Types.ObjectId;
-  description: string;
-  status: 'PENDING' | 'ACTIVE' | 'COMPLETED' | 'BLOCKED';
-  estimatedTime?: number;
-  actualTime?: number;
-  completedAt?: Date;
-  comments?: string;
-  dependencies?: Types.ObjectId[];
-}
-
-export interface ITaskLoop extends Document {
-  taskId: Types.ObjectId;
-  sequence: ILoopStep[];
-  currentStep: number;
-  isActive: boolean;
-  parallel: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-const loopStepSchema = new Schema<ILoopStep>(
+const loopStepSchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     assignedTo: { type: Schema.Types.ObjectId, ref: 'User', required: true },
@@ -55,7 +40,7 @@ const loopStepSchema = new Schema<ILoopStep>(
   }
 );
 
-const taskLoopSchema = new Schema<ITaskLoop>(
+const taskLoopSchema = new Schema(
   {
     taskId: { type: Schema.Types.ObjectId, ref: 'Task', required: true },
     sequence: [loopStepSchema],
@@ -72,4 +57,10 @@ taskLoopSchema.index({ 'sequence.description': 'text' });
 taskLoopSchema.index({ createdAt: -1 });
 taskLoopSchema.index({ updatedAt: -1 });
 
-export default models.TaskLoop || model<ITaskLoop>('TaskLoop', taskLoopSchema);
+export type ILoopStep = InferSchemaType<typeof loopStepSchema>;
+export type ITaskLoop = InferSchemaType<typeof taskLoopSchema>;
+
+export const TaskLoop: Model<ITaskLoop> =
+  (models.TaskLoop as Model<ITaskLoop>) ??
+  model<ITaskLoop>('TaskLoop', taskLoopSchema);
+

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,12 +1,13 @@
-import { Schema, model, models, type Types, type Model } from 'mongoose';
+import {
+  Schema,
+  model,
+  models,
+  type InferSchemaType,
+  type Model,
+  type Types,
+} from 'mongoose';
 
-export interface ITeam {
-  _id: Types.ObjectId;
-  name: string;
-  timezone: string;
-}
-
-const teamSchema = new Schema<ITeam>(
+const teamSchema = new Schema(
   {
     name: { type: String, required: true },
     timezone: { type: String, default: 'Asia/Kolkata' },
@@ -14,6 +15,8 @@ const teamSchema = new Schema<ITeam>(
   { timestamps: true }
 );
 
-const TeamModel = (models.Team as Model<ITeam>) || model<ITeam>('Team', teamSchema);
+export type ITeam = InferSchemaType<typeof teamSchema> & { _id: Types.ObjectId };
 
-export default TeamModel;
+export const Team: Model<ITeam> =
+  (models.Team as Model<ITeam>) ?? model<ITeam>('Team', teamSchema);
+


### PR DESCRIPTION
## Summary
- refactor all Mongoose models to export single named `Model<T>` instances with concrete schema-derived types
- enforce Node runtime and shared `dbConnect` usage across API routes
- update imports, tests, and scripts to consume new model exports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7341cdc83288421fedfc679cbf1