### PR TITLE
fix: narrow task type for notifications

### DIFF
--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -27,7 +27,7 @@ interface TaskJobData extends JobAttributesData {
 
 agenda.define('task.dueSoon', async (job: Job<TaskJobData>) => {
   const { taskId, stepId } = job.attrs.data;
-  const task = await Task.findById(taskId).lean<ITask>();
+  const task = await Task.findById(taskId).lean<ITask & { _id: Types.ObjectId }>();
   if (!task) return;
   let recipients: Types.ObjectId[] = [];
   if (stepId) {
@@ -38,14 +38,18 @@ agenda.define('task.dueSoon', async (job: Job<TaskJobData>) => {
     recipients = task.participantIds ?? [];
   }
   if (recipients.length) {
-    const t = task as Pick<ITask, '_id' | 'title' | 'status'>;
+    const t: Pick<ITask, '_id' | 'title' | 'status'> = {
+      _id: task._id,
+      title: task.title,
+      status: task.status,
+    };
     await notifyDueSoon(recipients, t);
   }
 });
 
 agenda.define('task.dueNow', async (job: Job<TaskJobData>) => {
   const { taskId, stepId } = job.attrs.data;
-  const task = await Task.findById(taskId).lean<ITask>();
+  const task = await Task.findById(taskId).lean<ITask & { _id: Types.ObjectId }>();
   if (!task) return;
   let recipients: Types.ObjectId[] = [];
   if (stepId) {
@@ -56,7 +60,11 @@ agenda.define('task.dueNow', async (job: Job<TaskJobData>) => {
     recipients = task.participantIds ?? [];
   }
   if (recipients.length) {
-    const t = task as Pick<ITask, '_id' | 'title' | 'status'>;
+    const t: Pick<ITask, '_id' | 'title' | 'status'> = {
+      _id: task._id,
+      title: task.title,
+      status: task.status,
+    };
     await notifyDueNow(recipients, t);
     await notifyOverdue(recipients, t);
   }


### PR DESCRIPTION
## Summary
- adjust worker to include `_id` when fetching task data
- pass only task fields needed for notifications

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint scripts/worker.ts` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@dnd-kit%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68bde9eeb2f88328b1a7615f631cbee5