### PR TITLE
Ignore Next.js build output in ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+# Ignore Next.js build output
+.next
+out
+build
+node_modules


### PR DESCRIPTION
## Summary
- ignore `.next`, `out`, and other build directories to prevent require-style import errors during linting

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be462d2400832896ba9c8ce8d7a3dc