### PR TITLE
refactor: remove unused Types imports

### DIFF
--- a/src/models/ActivityLog.ts
+++ b/src/models/ActivityLog.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 const activityLogSchema = new Schema(

--- a/src/models/Attachment.ts
+++ b/src/models/Attachment.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  Types,
 } from 'mongoose';
 
 const attachmentSchema = new Schema(

--- a/src/models/Comment.ts
+++ b/src/models/Comment.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 const commentSchema = new Schema(

--- a/src/models/LoopHistory.ts
+++ b/src/models/LoopHistory.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 const loopHistorySchema = new Schema(

--- a/src/models/LoopTemplate.ts
+++ b/src/models/LoopTemplate.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  Types,
 } from 'mongoose';
 
 const loopStepSchema = new Schema(

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 const notificationSchema = new Schema(

--- a/src/models/Objective.ts
+++ b/src/models/Objective.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 export type ObjectiveStatus = 'OPEN' | 'DONE';

--- a/src/models/SavedSearch.ts
+++ b/src/models/SavedSearch.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  type Types,
 } from 'mongoose';
 
 const savedSearchSchema = new Schema(

--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -4,7 +4,6 @@ import {
   models,
   type InferSchemaType,
   type Model,
-  Types,
 } from 'mongoose';
 
 const loopStepSchema = new Schema(

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -5,7 +5,6 @@ import {
   type InferSchemaType,
   type HydratedDocument,
   type Model,
-  type Types,
 } from 'mongoose';
 import bcrypt from 'bcrypt';
 


### PR DESCRIPTION
## Summary
- remove unused `Types` imports from mongoose models

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be48bd52ac83289cd5bc1723e76a09