### PR TITLE
fix: improve typing for error handling assignments

### DIFF
--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -37,7 +37,8 @@ export async function completeStep(
       let activated = false;
       loop.sequence.forEach((s: ILoopStep, idx) => {
         if (s.status === 'COMPLETED') return;
-        const deps: Array<number | Types.ObjectId> = s.dependencies ?? [];
+        const deps: Array<number | Types.ObjectId> =
+          (s.dependencies ?? []) as Array<number | Types.ObjectId>;
         const depsMet = deps.every((d) => {
           if (typeof d === 'number') {
             return loop.sequence[d]?.status === 'COMPLETED';
@@ -105,12 +106,12 @@ export async function completeStep(
   if (newlyActiveIndexes.length) {
     const task = await Task.findById(taskId).lean<Pick<ITask, '_id' | 'title' | 'status'>>();
     if (task) {
-      for (const idx of newlyActiveIndexes) {
-        const s = updatedLoop.sequence[idx];
-        const assignee = s.assignedTo as Types.ObjectId;
-        await notifyAssignment([assignee], task, s.description);
-        await notifyLoopStepReady([assignee], task, s.description);
-      }
+        for (const idx of newlyActiveIndexes) {
+          const s = updatedLoop.sequence[idx] as ILoopStep;
+          const assignee = s.assignedTo as Types.ObjectId;
+          await notifyAssignment([assignee], task, s.description);
+          await notifyLoopStepReady([assignee], task, s.description);
+        }
     }
   }
 

--- a/src/lib/serializeTask.ts
+++ b/src/lib/serializeTask.ts
@@ -1,9 +1,10 @@
 import type { ITask } from '@/models/Task';
 import type { TaskResponse } from '@/types/api/task';
+import { Types } from 'mongoose';
 
 export function serializeTask(task: ITask): TaskResponse {
-  return {
-    _id: task._id.toString(),
+    return {
+      _id: (task._id as Types.ObjectId).toString(),
     title: task.title,
     description: task.description,
     createdBy: task.createdBy.toString(),


### PR DESCRIPTION
## Summary
- add explicit casts when working with loop dependencies
- tighten notification settings types and use lean queries
- cast mocked rate limit updates to structured types
- ensure task serializer converts `_id` from ObjectId to string

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4d8c2150832888598a8c1ce729b7