### PR TITLE
refactor: handle unknown json data safely

### DIFF
--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -104,15 +104,15 @@ export async function completeStep(
   if (!updatedLoop) return null;
 
   if (newlyActiveIndexes.length) {
-    const task = await Task.findById(taskId).lean<Pick<ITask, '_id' | 'title' | 'status'>>();
-    if (task) {
+      const task = await Task.findById(taskId).lean<Pick<ITask, '_id' | 'title' | 'status'>>();
+      if (task) {
         for (const idx of newlyActiveIndexes) {
-          const s = updatedLoop.sequence[idx] as ILoopStep;
+          const s = updatedLoop.sequence[idx];
           const assignee = s.assignedTo as Types.ObjectId;
           await notifyAssignment([assignee], task, s.description);
           await notifyLoopStepReady([assignee], task, s.description);
         }
-    }
+      }
   }
 
   return updatedLoop;


### PR DESCRIPTION
## Summary
- handle API JSON responses as `unknown` before type assertion
- simplify loop step processing in loop update notification

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68be5097b9088328806a28960e8bf127