### PR TITLE
chore: ignore generated directories in eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-# Ignore Next.js build output
-.next
-out
-build
-node_modules

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,12 +12,13 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
+    // Ignore generated directories and files
     ignores: [
-      "node_modules/**",
-      ".next/**",
-      "out/**",
-      "build/**",
-      "next-env.d.ts",
+      "**/node_modules/**",
+      "**/.next/**",
+      "**/out/**",
+      "**/build/**",
+      "**/next-env.d.ts",
     ],
     languageOptions: {
       parserOptions: {


### PR DESCRIPTION
## Summary
- ignore build output directories in ESLint flat config for cross-platform compatibility
- remove legacy `.eslintignore` file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68be547675c083289c412e359d0044e3