### PR TITLE
fix: type JSON responses to avoid unsafe any usage

### DIFF
--- a/src/app/admin/admin-users/new/page.tsx
+++ b/src/app/admin/admin-users/new/page.tsx
@@ -33,8 +33,10 @@ function NewAdminForm() {
       body: JSON.stringify({ ...form, organizationId: session?.organizationId, role: 'ADMIN' }),
     });
     if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      setError(data.detail || 'Failed to create user');
+      const data = (await res
+        .json()
+        .catch(() => ({}))) as { detail?: string };
+      setError(data.detail ?? 'Failed to create user');
       return;
     }
     router.push('/admin/users');

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -21,15 +21,15 @@ export default function EditUserPage() {
   useEffect(() => {
     const load = async () => {
       const res = await fetch('/api/users/' + id);
-      const data = await res.json();
+      const data = (await res.json()) as Partial<typeof form>;
       setForm({
-        name: data.name || '',
-        email: data.email || '',
-        username: data.username || '',
+        name: data.name ?? '',
+        email: data.email ?? '',
+        username: data.username ?? '',
         password: '',
-        organizationId: data.organizationId || '',
-        teamId: data.teamId || '',
-        role: data.role || 'USER',
+        organizationId: data.organizationId ?? '',
+        teamId: data.teamId ?? '',
+        role: data.role ?? 'USER',
       });
     };
     if (id) void load();
@@ -54,8 +54,10 @@ export default function EditUserPage() {
         body: JSON.stringify(body),
       });
       if (!res.ok) {
-        const err = await res.json().catch(() => null);
-        throw new Error(err?.detail || 'Failed to save');
+        const err = (await res.json().catch(() => null)) as
+          | { detail?: string }
+          | null;
+        throw new Error(err?.detail ?? 'Failed to save');
       }
       setStatus({ success: 'Saved' });
     } catch (e: unknown) {

--- a/src/app/admin/users/new/page.tsx
+++ b/src/app/admin/users/new/page.tsx
@@ -33,8 +33,10 @@ function NewUserForm() {
       body: JSON.stringify({ ...form, organizationId: session?.organizationId }),
     });
     if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      setError(data.detail || 'Failed to create user');
+      const data = (await res
+        .json()
+        .catch(() => ({}))) as { detail?: string };
+      setError(data.detail ?? 'Failed to create user');
       return;
     }
     router.push('/admin/users');

--- a/src/app/api/auth/otp/request/route.ts
+++ b/src/app/api/auth/otp/request/route.ts
@@ -3,7 +3,7 @@ import { generateOtp, createOtpToken, checkRateLimit } from '@/lib/otp';
 import { sendOtpEmail } from '@/lib/email';
 
 export async function POST(req: NextRequest) {
-  const { email } = await req.json();
+  const { email } = (await req.json()) as { email?: string };
   if (!email) {
     return NextResponse.json(
       {

--- a/src/app/api/auth/otp/verify/route.ts
+++ b/src/app/api/auth/otp/verify/route.ts
@@ -8,7 +8,10 @@ import bcrypt from 'bcrypt';
 const SALT_ROUNDS = 10;
 
 export async function POST(req: NextRequest) {
-  const { email, code } = await req.json();
+  const { email, code } = (await req.json()) as {
+    email?: string;
+    code?: string;
+  };
   if (!email || !code) {
     return NextResponse.json(
       {

--- a/src/app/api/notifications/[id]/read/route.ts
+++ b/src/app/api/notifications/[id]/read/route.ts
@@ -20,7 +20,7 @@ export async function POST(
 
   let read = true;
   try {
-    const body = await request.json();
+    const body = (await request.json()) as { read?: unknown };
     if (typeof body.read === 'boolean') {
       read = body.read;
     }


### PR DESCRIPTION
## Summary
- type API and form JSON parsing to avoid unsafe any assignments
- refine error handling for user and OTP routes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68be564b7cac8328ae30404145902334