### PR TITLE
refactor: ensure typed loop sequence

### DIFF
--- a/src/lib/loop.ts
+++ b/src/lib/loop.ts
@@ -106,8 +106,9 @@ export async function completeStep(
   if (newlyActiveIndexes.length) {
       const task = await Task.findById(taskId).lean<Pick<ITask, '_id' | 'title' | 'status'>>();
       if (task) {
+        const sequence = updatedLoop.sequence as ILoopStep[];
         for (const idx of newlyActiveIndexes) {
-          const s = updatedLoop.sequence[idx];
+          const s = sequence[idx];
           const assignee = s.assignedTo as Types.ObjectId;
           await notifyAssignment([assignee], task, s.description);
           await notifyLoopStepReady([assignee], task, s.description);


### PR DESCRIPTION
## Summary
- type loop step sequence before iterating to avoid unsafe assignments

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68be586bc3c48328a0d09f55c9940fc1