### PR TITLE
Scope TypeScript lint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,9 @@ const eslintConfig = [
       "**/build/**",
       "**/next-env.d.ts",
     ],
+  },
+  {
+    files: ["**/*.{ts,tsx,cts,mts}"],
     languageOptions: {
       parserOptions: {
         project: "./tsconfig.json",


### PR DESCRIPTION
## Summary
- separate ignore list from TypeScript-specific configuration in the ESLint flat config
- scope TypeScript parserOptions and rules to TypeScript file patterns to avoid global application

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5924b05483288964fc92d91690c5