### PR TITLE
Add global ESLint ignore configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,17 +10,16 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
-    // Ignore generated directories and files
     ignores: [
-      "**/node_modules/**",
       "**/.next/**",
+      "next-env.d.ts",
       "**/out/**",
       "**/build/**",
-      "**/next-env.d.ts",
+      "**/node_modules/**",
     ],
   },
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
     files: ["**/*.{ts,tsx,cts,mts}"],
     languageOptions: {


### PR DESCRIPTION
## Summary
- add a leading ESLint flat config block that globally ignores build and generated outputs
- ensure the compatibility-based Next.js config continues to apply after the ignore block

## Testing
- `npm run lint` *(fails due to existing lint errors in tracked source files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc59c571848328b58169099608e686