### PR TITLE
Fix floating promises and related lint errors

### DIFF
--- a/e2e/signin-flow.spec.ts
+++ b/e2e/signin-flow.spec.ts
@@ -2,13 +2,13 @@ import { test, expect } from '@playwright/test';
 
 test('signin with otp navigates to tasks', async ({ page }) => {
   const captured = '123456';
-  await page.route('**/api/auth/otp/request', (route) => {
-    route.fulfill({ json: { ok: true, code: captured } });
+  await page.route('**/api/auth/otp/request', async (route) => {
+    await route.fulfill({ json: { ok: true, code: captured } });
   });
-  await page.route('**/api/auth/otp/verify', (route) => {
+  await page.route('**/api/auth/otp/verify', async (route) => {
     const data = JSON.parse(route.request().postData() || '{}') as unknown;
     expect((data as { code: string }).code).toBe(captured);
-    route.fulfill({ json: { ok: true } });
+    await route.fulfill({ json: { ok: true } });
   });
   await page.goto('about:blank');
   await page.evaluate(async () => {

--- a/scripts/sanity.ts
+++ b/scripts/sanity.ts
@@ -5,4 +5,7 @@ import dbConnect from '@/lib/db';
   await dbConnect();
   console.log(mongoose.modelNames());
   await mongoose.disconnect();
-})();
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/worker.ts
+++ b/scripts/worker.ts
@@ -109,4 +109,7 @@ agenda.define('dashboard.dailySnapshot', async (job: Job<JobAttributesData>) => 
     );
   }
   console.log('Worker started');
-})();
+})().catch((error) => {
+  console.error('Worker failed', error);
+  process.exitCode = 1;
+});

--- a/src/app/api/tasks/[id]/loop/patch.test.ts
+++ b/src/app/api/tasks/[id]/loop/patch.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/lib/access', () => ({ canWriteTask: () => true }));
 
 const startSession = vi.fn();
 vi.mock('mongoose', async () => {
-  const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+  const actual = await vi.importActual('mongoose');
   return { ...actual, startSession };
 });
 

--- a/src/app/api/tasks/transitions.test.ts
+++ b/src/app/api/tasks/transitions.test.ts
@@ -3,7 +3,7 @@ import { POST } from './[id]/transition/route';
 
 // mock mongoose before import
 vi.mock('mongoose', async () => {
-  const actual = await vi.importActual<typeof import('mongoose')>('mongoose');
+  const actual = await vi.importActual('mongoose');
   return {
     ...actual,
     startSession: vi.fn(async () => ({

--- a/src/app/organization/members/page.tsx
+++ b/src/app/organization/members/page.tsx
@@ -94,7 +94,7 @@ export default function MembersPage() {
         setLoading(false);
       }
     };
-    load();
+    void load();
   }, []);
 
   const handleUpdated = (updated: User) => {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -41,7 +41,7 @@ export default function ProfilePage() {
         setLoading(false);
       }
     };
-    loadUser();
+    void loadUser();
   }, [reset]);
 
   const onSubmit = async (data: FormData) => {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -45,7 +45,7 @@ export default function RegisterPage() {
         setOrgLoading(false);
       }
     };
-    loadOrganizations();
+    void loadOrganizations();
   }, []);
 
   const onSubmit = async (data: FormData) => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -76,7 +76,7 @@ export default function SettingsPage() {
         setLoading(false);
       }
     };
-    load();
+    void load();
   }, [resetTimezone, resetNotifications]);
 
   const onPasswordSubmit = async (data: PasswordFormData) => {

--- a/src/hooks/usePresence.ts
+++ b/src/hooks/usePresence.ts
@@ -28,7 +28,7 @@ export default function usePresence(taskId: string) {
           if (!viewersRef.current[uid]) {
             viewersRef.current[uid] = { _id: uid };
             update();
-            (async () => {
+            void (async () => {
               try {
                 const res = await fetch(`/api/users/${uid}`);
                 if (!res.ok) return;

--- a/src/hooks/useTyping.ts
+++ b/src/hooks/useTyping.ts
@@ -31,7 +31,7 @@ export default function useTyping(
           if (!uid || uid === userId) return;
           if (!usersRef.current[uid]) {
             usersRef.current[uid] = { _id: uid };
-            (async () => {
+            void (async () => {
               try {
                 const res = await fetch(`/api/users/${uid}`);
                 if (!res.ok) return;

--- a/src/lib/serializeTask.ts
+++ b/src/lib/serializeTask.ts
@@ -1,10 +1,10 @@
 import type { ITask } from '@/models/Task';
 import type { TaskResponse } from '@/types/api/task';
-import { Types } from 'mongoose';
+import type { ObjectId } from 'mongoose';
 
 export function serializeTask(task: ITask): TaskResponse {
     return {
-      _id: (task._id as Types.ObjectId).toString(),
+      _id: (task._id as ObjectId).toString(),
     title: task.title,
     description: task.description,
     createdBy: task.createdBy.toString(),


### PR DESCRIPTION
## Summary
- ensure async calls in useEffect hooks are explicitly voided across register, profile, settings, and members pages
- guard presence/typing background fetches and script entrypoints against unhandled promise rejections
- await Playwright route handlers and adjust Vitest mocks to satisfy no-floating-promises/consistent-type-imports

## Testing
- `npm run lint` *(fails: exits due to existing lint warnings with --max-warnings=0)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5a73eabc83288ac784eba1993b71