### PR TITLE
Set login as home and redirect authenticated users

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,5 @@
 export { default } from 'next-auth/middleware';
 
 export const config = {
-  matcher: ['/((?!api/auth|signin|login).*)'],
+  matcher: ['/((?!api/auth|signin|login).+)'],
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,68 +1,23 @@
-'use client';
+import { redirect } from 'next/navigation';
+import LoginForm from '@/components/auth/LoginForm';
+import { auth } from '@/lib/auth';
 
-import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
-import { signIn } from 'next-auth/react';
+export default async function LoginPage() {
+  const session = await auth();
 
-type FormData = {
-  email: string;
-  password: string;
-};
-
-export default function LoginPage() {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isSubmitting },
-    setError,
-  } = useForm<FormData>();
-  const router = useRouter();
-
-  const onSubmit = async (data: FormData) => {
-    const res = await signIn('credentials', {
-      redirect: false,
-      email: data.email,
-      password: data.password,
-    });
-
-    if (res?.error) {
-      setError('root', { message: res.error });
-      return;
-    }
-
-    router.push('/');
-  };
+  if (session) {
+    redirect('/dashboard');
+  }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-2 p-4">
-      <input
-        type="email"
-        placeholder="Email"
-        className="border p-2"
-        {...register('email', {
-          required: 'Email is required',
-          pattern: {
-            value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-            message: 'Invalid email address',
-          },
-        })}
-      />
-      {errors.email && <p className="text-red-500">{errors.email.message}</p>}
-      <input
-        type="password"
-        placeholder="Password"
-        className="border p-2"
-        {...register('password', { required: 'Password is required' })}
-      />
-      {errors.password && <p className="text-red-500">{errors.password.message}</p>}
-      {errors.root && <p className="text-red-500">{errors.root.message}</p>}
-      <button
-        type="submit"
-        className="bg-blue-500 text-white p-2"
-        disabled={isSubmitting}
-      >
-        {isSubmitting ? 'Loading...' : 'Login'}
-      </button>
-    </form>
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-6">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-2xl font-semibold text-gray-900">Welcome back</h1>
+        <p className="text-sm text-gray-600">
+          Sign in with your credentials to access your dashboard.
+        </p>
+        <LoginForm />
+      </div>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,23 @@
-import Image from "next/image";
+import { redirect } from 'next/navigation';
+import LoginForm from '@/components/auth/LoginForm';
+import { auth } from '@/lib/auth';
 
-export default function Home() {
+export default async function Home() {
+  const session = await auth();
+
+  if (session) {
+    redirect('/dashboard');
+  }
+
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-6">
+      <div className="w-full max-w-md space-y-6 text-center">
+        <h1 className="text-3xl font-semibold text-gray-900">Sign in to LoopTask</h1>
+        <p className="text-sm text-gray-600">
+          Manage your objectives, tasks, and notifications from a single dashboard.
+        </p>
+        <LoginForm />
+      </div>
     </div>
   );
 }

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+export type LoginFormData = {
+  email: string;
+  password: string;
+};
+
+export default function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<LoginFormData>();
+  const router = useRouter();
+
+  const onSubmit = async (data: LoginFormData) => {
+    const res = await signIn('credentials', {
+      redirect: false,
+      email: data.email,
+      password: data.password,
+    });
+
+    if (res?.error) {
+      setError('root', { message: res.error });
+      return;
+    }
+
+    router.push('/dashboard');
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full max-w-sm flex-col gap-3 rounded-md border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <div className="flex flex-col gap-1">
+        <label htmlFor="email" className="text-sm font-medium text-gray-700">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          placeholder="you@example.com"
+          className="rounded border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+              message: 'Invalid email address',
+            },
+          })}
+        />
+        {errors.email && (
+          <p className="text-xs text-red-500">{errors.email.message}</p>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <label htmlFor="password" className="text-sm font-medium text-gray-700">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          placeholder="********"
+          className="rounded border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-200"
+          {...register('password', { required: 'Password is required' })}
+        />
+        {errors.password && (
+          <p className="text-xs text-red-500">{errors.password.message}</p>
+        )}
+      </div>
+      {errors.root && <p className="text-xs text-red-500">{errors.root.message}</p>}
+      <button
+        type="submit"
+        className="mt-2 rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+        disabled={isSubmitting}
+      >
+        {isSubmitting ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the default landing page with the login experience and reuse the login form component
- redirect authenticated visitors of the home or login routes straight to the dashboard
- update auth middleware so the home page stays public while protected routes still require a session

## Testing
- npm run lint *(fails: pre-existing lint warnings across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5cb8b9ec8328be602eba939ff4e4