### PR TITLE
Resolve invite params via React use

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { use } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 
@@ -8,7 +9,12 @@ interface FormData {
   password: string;
 }
 
-export default function AcceptInvitePage({ params }: { params: { token: string } }) {
+export default function AcceptInvitePage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = use(params);
   const {
     register,
     handleSubmit,
@@ -22,7 +28,7 @@ export default function AcceptInvitePage({ params }: { params: { token: string }
       const res = await fetch('/api/invitations/accept', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: params.token, ...data }),
+        body: JSON.stringify({ token, ...data }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => null);


### PR DESCRIPTION
## Summary
- update the invite acceptance page to accept an async params prop
- resolve the params via React's `use` hook and use the extracted token in the form submission

## Testing
- `npx eslint src/app/invite/[token]/page.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cc602265b48328ab8f77aeae1ae72b