### PR TITLE
Add SessionProvider layout for search routes

### DIFF
--- a/src/app/search/layout.tsx
+++ b/src/app/search/layout.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import type { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function SearchLayout({ children }: Props) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add a client layout for the search routes that wraps content in `SessionProvider`

## Testing
- npm run lint *(fails: existing repository warnings about `no-console` and `@typescript-eslint/no-unsafe-assignment`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc65e503508328a028af6a5ae2a083