### PR TITLE
Remove simple task creation flow

### DIFF
--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -1,16 +1,9 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import { z } from 'zod';
-
-const simpleSchema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  owner: z.string().min(1, 'Owner is required'),
-});
 
 interface User {
   _id: string;
@@ -27,8 +20,6 @@ interface FlowStep {
 export default function NewTaskPage() {
   const router = useRouter();
   const [users, setUsers] = useState<User[]>([]);
-  const [simple, setSimple] = useState({ title: '', owner: '' });
-  const [simpleError, setSimpleError] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -41,35 +32,6 @@ export default function NewTaskPage() {
     void load();
   }, []);
 
-  const submitSimple = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const res = simpleSchema.safeParse(simple);
-    if (!res.success) {
-      const firstError = res.error.errors[0];
-      setSimpleError(firstError ? firstError.message : 'Invalid input');
-      return;
-    }
-    setSimpleError(null);
-    try {
-      const resp = await fetch('/api/tasks', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ title: simple.title, ownerId: simple.owner }),
-      });
-      if (!resp.ok) {
-        const err = await resp.json().catch(() => ({}));
-        setSimpleError(err.detail || 'Failed to create task');
-        return;
-      }
-      const task = await resp.json();
-      router.push(`/tasks/${task._id}`);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : 'Failed to create task';
-        setSimpleError(message);
-      }
-  };
-
   const [flowTitle, setFlowTitle] = useState('');
   const [steps, setSteps] = useState<FlowStep[]>([
     { title: '', description: '', ownerId: '', due: '' },
@@ -77,7 +39,7 @@ export default function NewTaskPage() {
   const [flowError, setFlowError] = useState<string | null>(null);
 
   const addStep = () =>
-    setSteps([...steps, { title: '', description: '', ownerId: '', due: '' }]);
+    setSteps((prev) => [...prev, { title: '', description: '', ownerId: '', due: '' }]);
 
   const updateStep = (
     index: number,
@@ -115,92 +77,57 @@ export default function NewTaskPage() {
       }
       const task = await resp.json();
       router.push(`/tasks/${task._id}`);
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : 'Failed to create task';
-        setFlowError(message);
-      }
-    };
-
-  const flowContent = (
-    <form onSubmit={submitFlow} className="space-y-4">
-      <Input
-        placeholder="Title"
-        value={flowTitle}
-        onChange={(e) => setFlowTitle(e.target.value)}
-      />
-      {steps.map((step, i) => (
-        <div key={i} className="border p-4 rounded space-y-2">
-          <Input
-            placeholder="Task Name"
-            value={step.title}
-            onChange={(e) => updateStep(i, 'title', e.target.value)}
-          />
-          <Textarea
-            placeholder="Description"
-            value={step.description}
-            onChange={(e) => updateStep(i, 'description', e.target.value)}
-          />
-          <select
-            value={step.ownerId}
-            onChange={(e) => updateStep(i, 'ownerId', e.target.value)}
-            className="flex h-9 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2"
-          >
-            <option value="">Assignee</option>
-            {users.map((u) => (
-              <option key={u._id} value={u._id}>
-                {u.name}
-              </option>
-            ))}
-          </select>
-          <Input
-            type="date"
-            value={step.due}
-            onChange={(e) => updateStep(i, 'due', e.target.value)}
-          />
-        </div>
-      ))}
-      <Button type="button" onClick={addStep}>
-        Create Flow
-      </Button>
-      {flowError && <p className="text-red-600 text-sm">{flowError}</p>}
-      <Button type="submit">Create Task</Button>
-    </form>
-  );
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to create task';
+      setFlowError(message);
+    }
+  };
 
   return (
     <div className="p-4">
-      <Tabs defaultValue="simple">
-        <TabsList className="mb-4">
-          <TabsTrigger value="simple">Simple</TabsTrigger>
-          <TabsTrigger value="flow">Flow</TabsTrigger>
-        </TabsList>
-        <TabsContent value="simple">
-          <form onSubmit={submitSimple} className="space-y-2">
+      <form onSubmit={submitFlow} className="space-y-4">
+        <Input
+          placeholder="Title"
+          value={flowTitle}
+          onChange={(e) => setFlowTitle(e.target.value)}
+        />
+        {steps.map((step, i) => (
+          <div key={i} className="border p-4 rounded space-y-2">
             <Input
-              placeholder="Title"
-              value={simple.title}
-              onChange={(e) => setSimple({ ...simple, title: e.target.value })}
+              placeholder="Task Name"
+              value={step.title}
+              onChange={(e) => updateStep(i, 'title', e.target.value)}
+            />
+            <Textarea
+              placeholder="Description"
+              value={step.description}
+              onChange={(e) => updateStep(i, 'description', e.target.value)}
             />
             <select
-              value={simple.owner}
-              onChange={(e) => setSimple({ ...simple, owner: e.target.value })}
+              value={step.ownerId}
+              onChange={(e) => updateStep(i, 'ownerId', e.target.value)}
               className="flex h-9 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2"
             >
-              <option value="">Owner</option>
+              <option value="">Assignee</option>
               {users.map((u) => (
                 <option key={u._id} value={u._id}>
                   {u.name}
                 </option>
               ))}
             </select>
-            {simpleError && (
-              <p className="text-red-600 text-sm">{simpleError}</p>
-            )}
-            <Button type="submit">Create</Button>
-          </form>
-        </TabsContent>
-        <TabsContent value="flow">{flowContent}</TabsContent>
-      </Tabs>
+            <Input
+              type="date"
+              value={step.due}
+              onChange={(e) => updateStep(i, 'due', e.target.value)}
+            />
+          </div>
+        ))}
+        <Button type="button" onClick={addStep}>
+          Add Step
+        </Button>
+        {flowError && <p className="text-red-600 text-sm">{flowError}</p>}
+        <Button type="submit">Create Task</Button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the simple task creation form and tabs from the new task page so only the flow builder remains
- delete related state and validation logic for the simple flow and clean up unused imports
- rename the add-step action button to "Add Step" to reflect its behavior

## Testing
- npm run lint *(fails: existing repository warnings break the zero-warning lint rule)*
- npm run typecheck *(fails: existing repository type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc727305ec83288d26b07de6d2b6c5