### PR TITLE
Fix PostCSS config for Tailwind plugin

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,9 +1,14 @@
-import tailwindcss from '@tailwindcss/postcss';
-
 const isTest = process.env.VITEST === 'true' || process.env.NODE_ENV === 'test';
 
+/**
+ * Next.js expects PostCSS plugins to be provided as either strings or
+ * plugin functions. The object returned by invoking `@tailwindcss/postcss`
+ * triggers a "Malformed PostCSS Configuration" error, so we reference the
+ * plugin by name instead. This keeps Tailwind enabled during regular builds
+ * while allowing tests to run without PostCSS.
+ */
 const config = {
-  plugins: isTest ? [] : [tailwindcss()],
+  plugins: isTest ? {} : { '@tailwindcss/postcss': {} },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- reference the `@tailwindcss/postcss` plugin by name so Next.js treats it as a valid PostCSS plugin
- keep the plugin disabled under test environments to mirror the previous behavior

## Testing
- npm run lint *(fails: repository contains pre-existing lint warnings)*
- npm run typecheck *(fails: repository contains pre-existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7a56e714832883b0c901115ef07e