### PR TITLE
Enhance sidebar with user profile data

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,15 +1,89 @@
 'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import NotificationsBadge from '@/components/notifications-badge';
+import { Avatar } from '@/components/ui/avatar';
+
+type User = {
+  name: string;
+  email: string;
+  avatar?: string | null;
+};
 
 export default function Sidebar() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchUser() {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetch('/api/users/me');
+        if (!response.ok) {
+          throw new Error('Failed to fetch user');
+        }
+        const data = (await response.json()) as User;
+        if (isMounted) {
+          setUser(data);
+        }
+      } catch (fetchError: unknown) {
+        if (isMounted) {
+          const message =
+            fetchError instanceof Error && fetchError.message
+              ? fetchError.message
+              : 'Unable to load user';
+          setError(message);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchUser();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   const navItems = [
     { href: '/dashboard', label: 'Dashboard' },
-    { href: '/tasks', label: 'Tasks' },
-    { href: '/notifications', label: 'Notifications' },
+    { href: '/tasks', label: 'My Tasks' },
+    { href: '/settings', label: 'Settings' },
   ];
+
+  const initials = user?.name
+    ? user.name
+        .split(' ')
+        .map((part) => part[0])
+        .join('')
+        .toUpperCase()
+    : user?.email?.[0]?.toUpperCase();
+
   return (
     <aside className="w-64 border-r border-[var(--color-border)] bg-[var(--color-surface)] p-4 flex flex-col">
+      <div className="mb-6">
+        {loading && <p className="text-sm text-[var(--color-muted)]">Loading user...</p>}
+        {error && !loading && (
+          <p className="text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+        {!loading && !error && user && (
+          <div className="flex items-center gap-3">
+            <Avatar src={user.avatar ?? undefined} fallback={initials} className="h-10 w-10 text-base" />
+            <div>
+              <p className="text-sm font-medium text-[var(--color-text)]">{user.name}</p>
+              <p className="text-xs text-[var(--color-muted)]">{user.email}</p>
+            </div>
+          </div>
+        )}
+      </div>
       <nav className="space-y-2">
         {navItems.map((item) => (
           <Link
@@ -18,7 +92,6 @@ export default function Sidebar() {
             className="flex items-center justify-between rounded px-2 py-1 text-[var(--color-text)] hover:bg-[var(--color-primary)]/10 transition"
           >
             {item.label}
-            {item.href === '/notifications' && <NotificationsBadge />}
           </Link>
         ))}
       </nav>


### PR DESCRIPTION
## Summary
- load the current user's profile in the sidebar when the component mounts
- surface the avatar, name, and email ahead of the navigation menu with graceful loading and error messaging
- simplify the navigation items to dashboard, task, and settings links while retaining styling

## Testing
- npx eslint src/components/layout/sidebar.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cd954f86e88328a45fba2df06e017d