### PR TITLE
Default tasks to low priority

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -87,7 +87,7 @@ export const POST = withOrganization(async (req, session) => {
     organizationId: new Types.ObjectId(session.organizationId),
     teamId: body.teamId ? new Types.ObjectId(body.teamId) : undefined,
     status,
-    priority: body.priority ?? 'MEDIUM',
+    priority: body.priority ?? 'LOW',
     tags: body.tags ?? [],
     visibility: body.visibility ?? 'PRIVATE',
     dueDate: body.dueDate,

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -53,7 +53,7 @@ const taskSchema = new Schema(
       enum: ['OPEN', 'IN_PROGRESS', 'IN_REVIEW', 'REVISIONS', 'FLOW_IN_PROGRESS', 'DONE'],
       default: 'OPEN',
     },
-    priority: { type: String, enum: ['LOW', 'MEDIUM', 'HIGH'], default: 'MEDIUM' },
+    priority: { type: String, enum: ['LOW', 'MEDIUM', 'HIGH'], default: 'LOW' },
     tags: [{ type: String }],
     visibility: { type: String, enum: ['PRIVATE', 'TEAM'], default: 'PRIVATE' },
     dueDate: Date,


### PR DESCRIPTION
## Summary
- set the Task schema default priority to LOW
- ensure API task creation falls back to LOW when no priority is provided

## Testing
- npm run lint *(fails: pre-existing warnings trigger the max warning limit)*

------
https://chatgpt.com/codex/tasks/task_e_68cd98a0dbc48328969535d3b69e74aa