### PR TITLE
Add responsive sidebar navigation to app shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,8 +38,15 @@ body {
 }
 
 .app-shell {
+  --sidebar-width: 18rem;
   min-height: 100vh;
   background: var(--color-background);
+}
+
+.app-shell__content {
+  position: relative;
+  min-height: 100vh;
+  transition: margin-left 0.3s ease;
 }
 
 .app-header {
@@ -56,6 +63,42 @@ body {
   border-bottom: 1px solid var(--color-border);
   box-shadow: 0 6px 12px rgba(15, 23, 42, 0.06);
   z-index: 40;
+}
+
+.app-header__start {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-header__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.app-header__toggle:hover {
+  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(37, 99, 235, 0.4);
+}
+
+.app-header__toggle:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 3px;
+}
+
+.app-header__toggle-icon {
+  width: 1.5rem;
+  height: 1.5rem;
 }
 
 .app-header__branding {
@@ -92,6 +135,87 @@ body {
   min-height: 2.5rem;
 }
 
+.app-shell__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 35;
+}
+
+.app-shell__overlay[hidden] {
+  display: none;
+}
+
+.app-sidebar {
+  position: fixed;
+  top: var(--layout-header-height);
+  left: 0;
+  bottom: 0;
+  width: var(--sidebar-width);
+  padding: 1.75rem 1.5rem;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  box-shadow: 8px 0 24px rgba(15, 23, 42, 0.08);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  overflow-y: auto;
+  padding-bottom: calc(1.75rem + var(--layout-footer-height));
+}
+
+.app-shell--sidebar-open .app-sidebar {
+  transform: translateX(0);
+}
+
+.app-sidebar__title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.app-sidebar__nav {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.app-sidebar__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.75rem;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.app-sidebar__link:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+}
+
+.app-sidebar__link:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 3px;
+}
+
+.app-sidebar__link--active {
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--color-text);
+}
+
 .app-main {
   position: relative;
   margin: var(--layout-header-height) auto var(--layout-footer-height);
@@ -99,6 +223,30 @@ body {
   width: min(1100px, 100%);
   min-height: calc(100vh - var(--layout-header-height) - var(--layout-footer-height));
   overflow-y: auto;
+  transition: margin-left 0.3s ease;
+}
+
+@media (min-width: 1024px) {
+  .app-shell--sidebar-open .app-shell__content {
+    margin-left: var(--sidebar-width);
+  }
+
+  .app-shell--sidebar-open .app-header,
+  .app-shell--sidebar-open .app-footer {
+    padding-left: calc(var(--sidebar-width) + 1.5rem);
+    padding-right: 1.5rem;
+  }
+
+  .app-sidebar {
+    bottom: var(--layout-footer-height);
+    box-shadow: none;
+  }
+}
+
+@media (max-width: 1023px) {
+  .app-header__actions {
+    display: none;
+  }
 }
 
 .app-footer {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import AppShell from '@/components/layout/AppShell';
 import LoopBuilder from '@/components/loop-builder';
 import PushNotificationInitializer from '@/components/PushNotificationInitializer';
 import "./globals.css";
@@ -27,19 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--color-background)]`}>
-        <div className="app-shell">
-          <header className="app-header">
-            <div className="app-header__branding">
-              <span className="app-header__logo" aria-hidden>⬡</span>
-              <span className="app-header__name">LoopTask</span>
-            </div>
-            <div className="app-header__actions" aria-label="Global navigation" />
-          </header>
-          <main className="app-main">{children}</main>
-          <footer className="app-footer">
-            <p>© {new Date().getFullYear()} LoopTask. All rights reserved.</p>
-          </footer>
-        </div>
+        <AppShell>{children}</AppShell>
         <LoopBuilder />
         <PushNotificationInitializer />
       </body>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type AppShellProps = {
+  children: React.ReactNode;
+};
+
+type NavigationLink = {
+  href: string;
+  label: string;
+};
+
+const NAVIGATION_LINKS: NavigationLink[] = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/tasks", label: "Tasks" },
+  { href: "/settings", label: "Settings" },
+];
+
+export default function AppShell({ children }: AppShellProps) {
+  const pathname = usePathname();
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
+  const firstLinkRef = useRef<HTMLAnchorElement>(null);
+  const previousOpenRef = useRef(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+  const navId = "app-shell-sidebar";
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setIsDesktop(event.matches);
+      if (event.matches) {
+        setSidebarOpen(true);
+      } else {
+        setSidebarOpen(false);
+      }
+    };
+
+    setIsDesktop(mediaQuery.matches);
+    setSidebarOpen(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handleMediaChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktop) {
+      setSidebarOpen(false);
+    }
+  }, [pathname, isDesktop]);
+
+  useEffect(() => {
+    if (!isDesktop && sidebarOpen && !previousOpenRef.current) {
+      firstLinkRef.current?.focus();
+    }
+
+    if (!isDesktop && !sidebarOpen && previousOpenRef.current) {
+      toggleButtonRef.current?.focus();
+    }
+
+    previousOpenRef.current = sidebarOpen;
+  }, [sidebarOpen, isDesktop]);
+
+  const handleToggle = useCallback(() => {
+    setSidebarOpen((previous) => !previous);
+  }, []);
+
+  const handleSidebarKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Escape" && !isDesktop) {
+        event.preventDefault();
+        setSidebarOpen(false);
+      }
+    },
+    [isDesktop],
+  );
+
+  const navigationLinks = useMemo(() => NAVIGATION_LINKS, []);
+  const isSidebarVisible = sidebarOpen;
+
+  return (
+    <div className={`app-shell ${sidebarOpen ? "app-shell--sidebar-open" : ""}`}>
+      <header className="app-header">
+        <div className="app-header__start">
+          <button
+            ref={toggleButtonRef}
+            type="button"
+            className="app-header__toggle"
+            aria-expanded={sidebarOpen}
+            aria-controls={navId}
+            aria-label={sidebarOpen ? "Hide navigation" : "Show navigation"}
+            onClick={handleToggle}
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              className="app-header__toggle-icon"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M4 7h16M4 12h16M4 17h16"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+          <div className="app-header__branding">
+            <span className="app-header__logo" aria-hidden>
+              ⬡
+            </span>
+            <span className="app-header__name">LoopTask</span>
+          </div>
+        </div>
+        <div className="app-header__actions" aria-label="Global navigation" />
+      </header>
+
+      <div
+        className="app-shell__overlay"
+        role="presentation"
+        hidden={!sidebarOpen || isDesktop}
+        onClick={() => setSidebarOpen(false)}
+      />
+
+      <nav
+        id={navId}
+        className="app-sidebar"
+        aria-hidden={!isSidebarVisible}
+        aria-label="Primary"
+        onKeyDown={handleSidebarKeyDown}
+      >
+        <p className="app-sidebar__title" id="app-sidebar-title">
+          Navigation
+        </p>
+        <ul className="app-sidebar__nav" aria-labelledby="app-sidebar-title">
+          {navigationLinks.map((link, index) => {
+            const isActive = pathname?.startsWith(link.href);
+
+            return (
+              <li key={link.href}>
+                <Link
+                  ref={index === 0 ? firstLinkRef : undefined}
+                  href={link.href}
+                  className={`app-sidebar__link ${isActive ? "app-sidebar__link--active" : ""}`}
+                  aria-current={isActive ? "page" : undefined}
+                  tabIndex={isSidebarVisible ? 0 : -1}
+                >
+                  {link.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="app-shell__content">
+        <main className="app-main">{children}</main>
+        <footer className="app-footer">
+          <p>© {new Date().getFullYear()} LoopTask. All rights reserved.</p>
+        </footer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract a client-side AppShell wrapper that manages sidebar visibility and renders the header, sidebar, main content, and footer
- add an accessible navigation sidebar with links to dashboard, tasks, and settings that supports keyboard and mobile interactions
- update global styles to support the responsive sidebar layout and toggle affordances

## Testing
- npm run lint *(fails: pre-existing warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2356ee7c832885e196ea78124101