### PR TITLE
Refactor tasks page into kanban layout

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import TaskCard from '@/components/task-card';
 import { SessionProvider, useSession } from 'next-auth/react';
 import type { TaskResponse as Task } from '@/types/api/task';
+import TaskCard from '@/components/task-card';
 
 const statusTabs = [
   { value: 'OPEN', label: 'Open', query: ['OPEN'] },
@@ -141,28 +140,28 @@ function TasksPageInner() {
   }, [searchInput]);
 
   return (
-    <div className="p-4">
-      <div className="mb-4 flex items-center">
-        <h1 className="text-xl">Tasks</h1>
+    <div className="p-4 md:p-6">
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h1 className="text-xl font-semibold text-slate-800">Tasks</h1>
         <input
           type="text"
           placeholder="Search"
-          className="ml-4 border p-1"
+          className="w-full max-w-xs rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
         />
         <Link
           href="/tasks/new"
-          className="ml-auto bg-blue-500 text-white px-2 py-1"
+          className="ml-auto inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
         >
           Create Task
         </Link>
       </div>
-      <div className="mb-4 flex flex-wrap gap-4">
+      <div className="mb-6 flex flex-wrap gap-4">
         <div>
-          <label className="block text-sm mb-1">Sort By</label>
+          <label className="mb-1 block text-sm font-medium text-slate-600">Sort By</label>
           <select
-            className="border p-1"
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={filters.sort}
             onChange={(e) => setFilters((f) => ({ ...f, sort: e.target.value }))}
           >
@@ -174,9 +173,9 @@ function TasksPageInner() {
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Assignee</label>
+          <label className="mb-1 block text-sm font-medium text-slate-600">Assignee</label>
           <select
-            className="border p-1"
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={filters.assignee}
             onChange={(e) =>
               setFilters((f) => ({ ...f, assignee: e.target.value }))
@@ -187,9 +186,9 @@ function TasksPageInner() {
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">Priority</label>
+          <label className="mb-1 block text-sm font-medium text-slate-600">Priority</label>
           <select
-            className="border p-1"
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={filters.priority}
             onChange={(e) =>
               setFilters((f) => ({ ...f, priority: e.target.value }))
@@ -202,10 +201,10 @@ function TasksPageInner() {
           </select>
         </div>
         <div>
-          <label className="block text-sm mb-1">From</label>
+          <label className="mb-1 block text-sm font-medium text-slate-600">From</label>
           <input
             type="date"
-            className="border p-1"
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={filters.dueFrom}
             onChange={(e) =>
               setFilters((f) => ({ ...f, dueFrom: e.target.value }))
@@ -213,10 +212,10 @@ function TasksPageInner() {
           />
         </div>
         <div>
-          <label className="block text-sm mb-1">To</label>
+          <label className="mb-1 block text-sm font-medium text-slate-600">To</label>
           <input
             type="date"
-            className="border p-1"
+            className="rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={filters.dueTo}
             onChange={(e) =>
               setFilters((f) => ({ ...f, dueTo: e.target.value }))
@@ -224,66 +223,79 @@ function TasksPageInner() {
           />
         </div>
       </div>
-      <Tabs defaultValue="OPEN">
-        <TabsList>
-          {statusTabs.map((s) => (
-            <TabsTrigger key={s.value} value={s.value}>
-              {s.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-        {statusTabs.map((s) => (
-          <TabsContent key={s.value} value={s.value}>
-            {loading ? (
-              <ul className="space-y-2">
-                {[...Array(3)].map((_, i) => (
-                  <li
-                    key={i}
-                    className="h-24 rounded bg-gray-200 animate-pulse"
-                  />
-                ))}
-              </ul>
-            ) : tasks[s.value]?.length ? (
-              <>
-                <ul className="space-y-2">
-                  {tasks[s.value]?.map((t) => (
-                    <motion.li
-                      key={t._id}
-                      initial={{ opacity: 0, y: 4 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: 4 }}
-                    >
-                      <TaskCard
-                        task={{
-                          _id: t._id,
-                          title: t.title,
-                          assignee: t.assignee || t.ownerId,
-                          dueDate: t.dueDate,
-                          priority: t.priority,
-                          status: t.status,
-                        }}
-                        onChange={loadTasks}
-                      />
-                    </motion.li>
-                  ))}
-                </ul>
-                {hasMore[s.value] && (
-                  <button
-                    className="mt-4 border px-4 py-2"
-                    onClick={() => void loadMore(s.value)}
-                  >
-                    Load more
-                  </button>
-                )}
-              </>
-            ) : (
-              <div className="p-4 text-center text-sm text-gray-500">
-                No tasks found.
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {statusTabs.map((s) => {
+          const columnTasks = tasks[s.value] ?? [];
+          const isInitialLoading =
+            loading && columnTasks.length === 0 && pages[s.value] === 1;
+          return (
+            <section
+              key={s.value}
+              className="flex flex-col overflow-hidden rounded-xl border bg-slate-50 shadow-sm md:max-h-[70vh]"
+            >
+              <header className="flex items-center justify-between border-b bg-white px-4 py-3">
+                <div className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+                  {s.label}
+                </div>
+                <span className="text-xs text-slate-400">{columnTasks.length}</span>
+              </header>
+              <div className="flex-1 overflow-hidden">
+                <div className="flex h-full flex-col px-4 py-3 md:overflow-y-auto">
+                  {isInitialLoading ? (
+                    <ul className="space-y-3">
+                      {[...Array(3)].map((_, i) => (
+                        <li
+                          key={i}
+                          className="h-24 rounded-lg bg-slate-200/70 animate-pulse"
+                        />
+                      ))}
+                    </ul>
+                  ) : columnTasks.length ? (
+                    <div className="space-y-3">
+                      {columnTasks.map((t) => (
+                        <motion.div
+                          key={t._id}
+                          initial={{ opacity: 0, y: 6 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: 6 }}
+                        >
+                          <TaskCard
+                            task={{
+                              _id: t._id,
+                              title: t.title,
+                              assignee: t.assignee || t.ownerId,
+                              dueDate: t.dueDate,
+                              priority: t.priority,
+                              status: t.status,
+                            }}
+                            href={`/tasks/${t._id}`}
+                            onChange={loadTasks}
+                          />
+                        </motion.div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="py-6 text-center text-sm text-slate-400">
+                      No tasks found.
+                    </div>
+                  )}
+                </div>
               </div>
-            )}
-          </TabsContent>
-        ))}
-      </Tabs>
+              {hasMore[s.value] && (
+                <div className="border-t bg-white px-4 py-3">
+                  <button
+                    className="w-full rounded-md border border-slate-200 bg-slate-100 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+                    onClick={() => void loadMore(s.value)}
+                    disabled={loading}
+                  >
+                    {loading ? 'Loading…' : 'Load more'}
+                  </button>
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import Link from 'next/link';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -17,9 +18,10 @@ export interface TaskCardProps {
     status: string;
   };
   onChange?: () => void;
+  href?: string;
 }
 
-export default function TaskCard({ task, onChange }: TaskCardProps) {
+export default function TaskCard({ task, onChange, href }: TaskCardProps) {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   const handleMarkComplete = async () => {
@@ -49,24 +51,51 @@ export default function TaskCard({ task, onChange }: TaskCardProps) {
   };
 
   return (
-    <div className="rounded border p-4 flex flex-col gap-2 bg-white">
-      <div className="flex items-center gap-3">
-        {task.assignee && (
-          <Avatar
-            src={task.assigneeAvatar}
-            fallback={task.assignee.charAt(0)}
-          />
-        )}
-        <div className="flex flex-col">
-          <span className="text-sm font-medium text-gray-700">{task.title}</span>
-          <div className="text-xs text-gray-500 flex gap-2">
-            {task.assignee && <span>{task.assignee}</span>}
-            {task.dueDate && <span>Due {task.dueDate}</span>}
-            {task.priority && <span>{task.priority}</span>}
-            <Badge>{task.status}</Badge>
+    <div className="flex flex-col gap-2 rounded-lg border bg-white p-4 shadow-sm">
+      {href ? (
+        <Link
+          href={href}
+          className="flex w-full items-center gap-3 transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+        >
+          {task.assignee && (
+            <Avatar
+              src={task.assigneeAvatar}
+              fallback={task.assignee.charAt(0)}
+            />
+          )}
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-gray-700">
+              {task.title}
+            </span>
+            <div className="flex flex-wrap gap-2 text-xs text-gray-500">
+              {task.assignee && <span>{task.assignee}</span>}
+              {task.dueDate && <span>Due {task.dueDate}</span>}
+              {task.priority && <span>{task.priority}</span>}
+              <Badge>{task.status}</Badge>
+            </div>
+          </div>
+        </Link>
+      ) : (
+        <div className="flex w-full items-center gap-3">
+          {task.assignee && (
+            <Avatar
+              src={task.assigneeAvatar}
+              fallback={task.assignee.charAt(0)}
+            />
+          )}
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-gray-700">
+              {task.title}
+            </span>
+            <div className="flex flex-wrap gap-2 text-xs text-gray-500">
+              {task.assignee && <span>{task.assignee}</span>}
+              {task.dueDate && <span>Due {task.dueDate}</span>}
+              {task.priority && <span>{task.priority}</span>}
+              <Badge>{task.status}</Badge>
+            </div>
           </div>
         </div>
-      </div>
+      )}
       <div className="mt-2">
         <div className="hidden sm:flex gap-2">
           <Button onClick={() => void handleMarkComplete()} className="text-xs">


### PR DESCRIPTION
## Summary
- replace the tasks tabbed layout with responsive kanban columns, maintaining pagination controls per status bucket
- refresh the filters/search presentation so the new kanban board matches the updated styling
- update the task card to support linking to individual task pages by wrapping the details in a Next.js Link

## Testing
- npm run lint *(fails: existing repository lint warnings about console usage and unsafe assignments)*
- npm run typecheck *(fails: pre-existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68ce28ad544083289c81eeabf89d06ab