### PR TITLE
Stop shifting layout when sidebar opens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,16 +227,6 @@ body {
 }
 
 @media (min-width: 1024px) {
-  .app-shell--sidebar-open .app-shell__content {
-    margin-left: var(--sidebar-width);
-  }
-
-  .app-shell--sidebar-open .app-header,
-  .app-shell--sidebar-open .app-footer {
-    padding-left: calc(var(--sidebar-width) + 1.5rem);
-    padding-right: 1.5rem;
-  }
-
   .app-sidebar {
     bottom: var(--layout-footer-height);
     box-shadow: none;


### PR DESCRIPTION
## Summary
- remove the layout margin and padding overrides that triggered when the sidebar opened at large breakpoints
- ensure the fixed sidebar continues to appear without pushing the main shell content

## Testing
- npm run lint *(fails: existing lint warnings in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2f549c3c8328aa305c72362f2b41