### PR TITLE
Adjust sidebar overlay spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -137,7 +137,10 @@ body {
 
 .app-shell__overlay {
   position: fixed;
-  inset: 0;
+  top: var(--layout-header-height);
+  right: 0;
+  bottom: var(--layout-footer-height);
+  left: 0;
   background: rgba(15, 23, 42, 0.35);
   z-index: 35;
 }
@@ -150,7 +153,7 @@ body {
   position: fixed;
   top: var(--layout-header-height);
   left: 0;
-  bottom: 0;
+  bottom: var(--layout-footer-height);
   width: var(--sidebar-width);
   padding: 1.75rem 1.5rem;
   background: var(--color-surface);
@@ -228,7 +231,6 @@ body {
 
 @media (min-width: 1024px) {
   .app-sidebar {
-    bottom: var(--layout-footer-height);
     box-shadow: none;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the sidebar respects the footer clearance at every breakpoint
- limit the overlay backdrop to the space between the header and footer so both stay visible while the menu is open

## Testing
- npm run lint *(fails: existing warnings unrelated to this change)*
- manual verification at 800px viewport width with the sidebar open

------
https://chatgpt.com/codex/tasks/task_e_68ce3018bbac8328ab363b4a5fcbdeff