### PR TITLE
Gate sidebar auto-close on non-desktop detection

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -24,6 +24,7 @@ export default function AppShell({ children }: AppShellProps) {
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
   const previousOpenRef = useRef(false);
+  const hasDetectedNonDesktopRef = useRef(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isDesktop, setIsDesktop] = useState(false);
   const navId = "app-shell-sidebar";
@@ -35,17 +36,22 @@ export default function AppShell({ children }: AppShellProps) {
 
     const mediaQuery = window.matchMedia("(min-width: 1024px)");
 
-    const handleMediaChange = (event: MediaQueryListEvent) => {
-      setIsDesktop(event.matches);
-      if (event.matches) {
+    const applyLayoutFromMatch = (matches: boolean) => {
+      setIsDesktop(matches);
+      if (matches) {
+        hasDetectedNonDesktopRef.current = false;
         setSidebarOpen(true);
       } else {
+        hasDetectedNonDesktopRef.current = true;
         setSidebarOpen(false);
       }
     };
 
-    setIsDesktop(mediaQuery.matches);
-    setSidebarOpen(mediaQuery.matches);
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      applyLayoutFromMatch(event.matches);
+    };
+
+    applyLayoutFromMatch(mediaQuery.matches);
     mediaQuery.addEventListener("change", handleMediaChange);
 
     return () => {
@@ -54,7 +60,7 @@ export default function AppShell({ children }: AppShellProps) {
   }, []);
 
   useEffect(() => {
-    if (!isDesktop) {
+    if (!isDesktop && hasDetectedNonDesktopRef.current) {
       setSidebarOpen(false);
     }
   }, [pathname, isDesktop]);


### PR DESCRIPTION
## Summary
- track when the layout has confirmed a non-desktop viewport via a ref
- gate the route-change sidebar auto-close logic on that ref so desktop layouts remain open on first load

## Testing
- npm run lint (fails: existing repository warnings unrelated to change)
- npx eslint src/components/layout/AppShell.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce31c63b108328b23c64173ea668c5