### PR TITLE
Add user avatar to app shell header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,15 +173,6 @@ body {
   transform: translateX(0);
 }
 
-.app-sidebar__title {
-  margin: 0;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
-}
-
 .app-sidebar__nav {
   list-style: none;
   margin: 0;
@@ -189,6 +180,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin-top: 1.75rem;
 }
 
 .app-sidebar__link {


### PR DESCRIPTION
## Summary
- load the current user in the app shell to expose profile data for layout components
- render the avatar in the header action area with initials fallback derived from the user name
- remove the sidebar navigation heading and adjust sidebar spacing styles to compensate

## Testing
- npm run lint *(fails: existing warnings across unrelated files)*
- npx eslint src/components/layout/AppShell.tsx src/app/globals.css *(warns: CSS file ignored by config)*

------
https://chatgpt.com/codex/tasks/task_e_68ce34697cac832890c4fabdbacfab1f