### PR TITLE
Add logout control to sidebar navigation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,6 +173,14 @@ body {
   transform: translateX(0);
 }
 
+.app-sidebar__nav-container {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  gap: 1.5rem;
+}
+
 .app-sidebar__nav {
   list-style: none;
   margin: 0;
@@ -209,6 +217,35 @@ body {
 .app-sidebar__link--active {
   background: rgba(37, 99, 235, 0.15);
   color: var(--color-text);
+}
+
+.app-sidebar__logout {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  font-size: 1rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.app-sidebar__logout:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--color-text);
+}
+
+.app-sidebar__logout:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.45);
+  outline-offset: 3px;
 }
 
 .app-main {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -213,25 +214,37 @@ export default function AppShell({ children }: AppShellProps) {
         aria-label="Primary"
         onKeyDown={handleSidebarKeyDown}
       >
-        <ul className="app-sidebar__nav" aria-label="Primary navigation">
-          {navigationLinks.map((link, index) => {
-            const isActive = pathname?.startsWith(link.href);
+        <div className="app-sidebar__nav-container">
+          <ul className="app-sidebar__nav" aria-label="Primary navigation">
+            {navigationLinks.map((link, index) => {
+              const isActive = pathname?.startsWith(link.href);
 
-            return (
-              <li key={link.href}>
-                <Link
-                  ref={index === 0 ? firstLinkRef : undefined}
-                  href={link.href}
-                  className={`app-sidebar__link ${isActive ? "app-sidebar__link--active" : ""}`}
-                  aria-current={isActive ? "page" : undefined}
-                  tabIndex={isSidebarVisible ? 0 : -1}
-                >
-                  {link.label}
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+              return (
+                <li key={link.href}>
+                  <Link
+                    ref={index === 0 ? firstLinkRef : undefined}
+                    href={link.href}
+                    className={`app-sidebar__link ${isActive ? "app-sidebar__link--active" : ""}`}
+                    aria-current={isActive ? "page" : undefined}
+                    tabIndex={isSidebarVisible ? 0 : -1}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+          <button
+            type="button"
+            className="app-sidebar__logout"
+            onClick={() => {
+              void signOut();
+            }}
+            tabIndex={isSidebarVisible ? 0 : -1}
+          >
+            Log out
+          </button>
+        </div>
       </nav>
 
       <div className="app-shell__content">


### PR DESCRIPTION
## Summary
- wrap the sidebar navigation in a flex container and append a logout control wired to next-auth signOut
- adjust global sidebar styles to support the new container and keep the logout button pinned to the bottom while matching existing focus/hover patterns

## Testing
- npm run lint *(fails: existing warnings trigger the max-warnings=0 threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68ce354d5d60832894748e59b7f8205e