### PR TITLE
Close sidebar when navigating on mobile

### DIFF
--- a/src/components/layout/AppShell.handlers.test.ts
+++ b/src/components/layout/AppShell.handlers.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { closeSidebarOnNavigation } from "./AppShell";
+
+describe("closeSidebarOnNavigation", () => {
+  it("closes the sidebar when not on desktop", () => {
+    const closeSidebar = vi.fn();
+
+    closeSidebarOnNavigation({ isDesktop: false, closeSidebar });
+
+    expect(closeSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the sidebar on desktop", () => {
+    const closeSidebar = vi.fn();
+
+    closeSidebarOnNavigation({ isDesktop: true, closeSidebar });
+
+    expect(closeSidebar).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -28,6 +28,18 @@ const NAVIGATION_LINKS: NavigationLink[] = [
   { href: "/settings", label: "Settings" },
 ];
 
+export function closeSidebarOnNavigation({
+  isDesktop,
+  closeSidebar,
+}: {
+  isDesktop: boolean;
+  closeSidebar: () => void;
+}) {
+  if (!isDesktop) {
+    closeSidebar();
+  }
+}
+
 export default function AppShell({ children }: AppShellProps) {
   const pathname = usePathname();
   const toggleButtonRef = useRef<HTMLButtonElement>(null);
@@ -92,6 +104,23 @@ export default function AppShell({ children }: AppShellProps) {
   const handleToggle = useCallback(() => {
     setSidebarOpen((previous) => !previous);
   }, []);
+
+  const handleNavigationLinkActivation = useCallback(() => {
+    closeSidebarOnNavigation({
+      isDesktop,
+      closeSidebar: () => setSidebarOpen(false),
+    });
+  }, [isDesktop]);
+
+  const handleNavigationLinkKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLAnchorElement>) => {
+      if (event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        handleNavigationLinkActivation();
+      }
+    },
+    [handleNavigationLinkActivation],
+  );
 
   const handleSidebarKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
@@ -227,6 +256,8 @@ export default function AppShell({ children }: AppShellProps) {
                     className={`app-sidebar__link ${isActive ? "app-sidebar__link--active" : ""}`}
                     aria-current={isActive ? "page" : undefined}
                     tabIndex={isSidebarVisible ? 0 : -1}
+                    onClick={handleNavigationLinkActivation}
+                    onKeyDown={handleNavigationLinkKeyDown}
                   >
                     {link.label}
                   </Link>


### PR DESCRIPTION
## Summary
- ensure navigation link activation closes the sidebar on non-desktop layouts while keeping desktop behavior unchanged
- export a reusable helper for the navigation close logic and cover it with unit tests

## Testing
- npx vitest run src/components/layout/AppShell.handlers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce36ee2b2483288a16a45d0655b0f5