### PR TITLE
Ensure AppShell closes sidebar after navigation

### DIFF
--- a/src/components/layout/AppShell.handlers.test.ts
+++ b/src/components/layout/AppShell.handlers.test.ts
@@ -11,11 +11,11 @@ describe("closeSidebarOnNavigation", () => {
     expect(closeSidebar).toHaveBeenCalledTimes(1);
   });
 
-  it("does not close the sidebar on desktop", () => {
+  it("closes the sidebar on desktop", () => {
     const closeSidebar = vi.fn();
 
     closeSidebarOnNavigation({ isDesktop: true, closeSidebar });
 
-    expect(closeSidebar).not.toHaveBeenCalled();
+    expect(closeSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -35,9 +35,7 @@ export function closeSidebarOnNavigation({
   isDesktop: boolean;
   closeSidebar: () => void;
 }) {
-  if (!isDesktop) {
-    closeSidebar();
-  }
+  closeSidebar();
 }
 
 export default function AppShell({ children }: AppShellProps) {


### PR DESCRIPTION
## Summary
- ensure the AppShell navigation handler always closes the sidebar
- update the closeSidebarOnNavigation unit test to expect closing on desktop as well

## Testing
- npm test *(fails: existing vitest suites due to Playwright and mocking setup errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ce398798a083289dcaaf56caf2cd26