### PR TITLE
feat: add useAuth hook and update auth-aware components

### DIFF
--- a/src/app/admin/admin-users/new/page.tsx
+++ b/src/app/admin/admin-users/new/page.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { SessionProvider, useSession } from 'next-auth/react';
+import { SessionProvider } from 'next-auth/react';
+import useAuth from '@/hooks/useAuth';
 
 function NewAdminForm() {
-  const { data: session } = useSession();
+  const { user } = useAuth();
   const [form, setForm] = useState({
     name: '',
     email: '',
@@ -30,7 +31,7 @@ function NewAdminForm() {
     const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, organizationId: session?.organizationId, role: 'ADMIN' }),
+      body: JSON.stringify({ ...form, organizationId: user?.organizationId, role: 'ADMIN' }),
     });
     if (!res.ok) {
       const data = (await res

--- a/src/app/admin/users/new/page.tsx
+++ b/src/app/admin/users/new/page.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { SessionProvider, useSession } from 'next-auth/react';
+import { SessionProvider } from 'next-auth/react';
+import useAuth from '@/hooks/useAuth';
 
 function NewUserForm() {
-  const { data: session } = useSession();
+  const { user } = useAuth();
   const [form, setForm] = useState({
     name: '',
     email: '',
@@ -30,7 +31,7 @@ function NewUserForm() {
     const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, organizationId: session?.organizationId }),
+      body: JSON.stringify({ ...form, organizationId: user?.organizationId }),
     });
     if (!res.ok) {
       const data = (await res

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { SessionProvider, useSession } from 'next-auth/react';
+import { SessionProvider } from 'next-auth/react';
 import { motion } from 'framer-motion';
 import TaskKanbanColumn from '@/components/task-kanban-column';
 import type { TaskResponse as Task } from '@/types/api/task';
+import useAuth from '@/hooks/useAuth';
 
 const statusTabs = [
   { value: 'OPEN', label: 'Open', query: ['OPEN'] },
@@ -17,7 +18,7 @@ const statusTabs = [
 ];
 
 function DashboardInner() {
-  const { data: session } = useSession();
+  const { user, status } = useAuth();
   const [tasks, setTasks] = useState<Record<string, Task[]>>({
     OPEN: [],
     IN_PROGRESS: [],
@@ -55,6 +56,14 @@ function DashboardInner() {
     void loadTasks();
   }, [loadTasks]);
 
+  if (status === 'loading') {
+    return <div className="p-4 md:p-6">Loading dashboard…</div>;
+  }
+
+  if (status === 'unauthenticated') {
+    return null;
+  }
+
   return (
     <div className="p-4 md:p-6">
       <motion.h1
@@ -62,7 +71,7 @@ function DashboardInner() {
         animate={{ opacity: 1, y: 0 }}
         className="text-xl font-semibold text-slate-800"
       >
-        Hi, {session?.user?.name || session?.user?.email || 'there'}
+        Hi, {user?.name || user?.email || 'there'}
       </motion.h1>
       <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {statusTabs.map((s) => {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -4,7 +4,7 @@ import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import FilterBuilder from '@/components/filter-builder';
-import { useSession } from 'next-auth/react';
+import useAuth from '@/hooks/useAuth';
 import { getPresets } from './filters';
 import type {
   SearchItem,
@@ -16,8 +16,8 @@ import type {
 export default function GlobalSearchPage() {
   const params = useSearchParams();
   const router = useRouter();
-  const { data: session } = useSession();
-  const presets = getPresets(session?.userId);
+  const { user } = useAuth();
+  const presets = getPresets(user?.userId);
   const [data, setData] = useState<GlobalSearchResponse>();
   const [saved, setSaved] = useState<SavedSearch[]>([]);
   const [q, setQ] = useState(params.get('q') ?? '');

--- a/src/app/search/tasks/page.tsx
+++ b/src/app/search/tasks/page.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import FilterBuilder from '@/components/filter-builder';
-import { useSession } from 'next-auth/react';
+import useAuth from '@/hooks/useAuth';
 import { getPresets } from '../filters';
 import {
   SearchTasksResponseSchema,
@@ -15,8 +15,8 @@ import {
 export default function TaskSearchPage() {
   const params = useSearchParams();
   const router = useRouter();
-  const { data: session } = useSession();
-  const presets = getPresets(session?.userId);
+  const { user } = useAuth();
+  const presets = getPresets(user?.userId);
   const [data, setData] = useState<SearchTasksResponse>();
   const [saved, setSaved] = useState<SavedSearch[]>([]);
 

--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import { useSession } from 'next-auth/react';
+import useAuth from '@/hooks/useAuth';
 import useTyping from '@/hooks/useTyping';
 import useRealtime from '@/hooks/useRealtime';
 
@@ -31,8 +31,8 @@ export default function CommentThread({
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyContent, setReplyContent] = useState('');
 
-  const { data: session } = useSession();
-  const { typingUsers, emit } = useTyping(taskId, session?.userId, !parentId);
+  const { user } = useAuth();
+  const { typingUsers, emit } = useTyping(taskId, user?.userId, !parentId);
   const typingTimeout = useRef<NodeJS.Timeout | null>(null);
   const { enqueue } = useRealtime();
 
@@ -86,14 +86,19 @@ export default function CommentThread({
                 emit();
               }, 300);
             }}
-            placeholder="Add a comment..."
+            placeholder={user ? 'Add a comment...' : 'Sign in to comment'}
+            disabled={!user}
           />
           {typingUsers.map((u) => (
             <p key={u._id} className="mt-1 text-xs text-gray-500">
               {`${u.name ?? 'Someone'} is typing...`}
             </p>
           ))}
-          <Button className="mt-1 text-xs" onClick={() => void handleCreate(null)}>
+          <Button
+            className="mt-1 text-xs"
+            onClick={() => void handleCreate(null)}
+            disabled={!user || !newContent.trim()}
+          >
             Comment
           </Button>
         </div>
@@ -118,6 +123,7 @@ export default function CommentThread({
               <Button
                 className="mt-1 text-xs"
                 onClick={() => void handleCreate(c._id)}
+                disabled={!user || !replyContent.trim()}
               >
                 Submit
               </Button>

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSession } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { openLoopBuilder } from "@/lib/loopBuilder";
 import LoopVisualizer, { type StepWithStatus, type UserMap } from "@/components/loop-visualizer";
@@ -9,6 +8,7 @@ import LoopProgress from "@/components/loop-progress";
 import useRealtime, { type RealtimeMessage } from "@/hooks/useRealtime";
 import usePresence from "@/hooks/usePresence";
 import { Avatar } from "@/components/ui/avatar";
+import useAuth from "@/hooks/useAuth";
 
 interface User {
   _id: string;
@@ -51,7 +51,7 @@ export default function TaskDetail({ id, canEdit: canEditProp }: { id: string; c
   const [taskVersion, setTaskVersion] = useState(0);
   const [loopVersion, setLoopVersion] = useState(0);
   const viewers = usePresence(id);
-  const { data: session } = useSession();
+  const { user } = useAuth();
 
   const refreshTask = useCallback(async () => {
     const res = await fetch(`/api/tasks/${id}`);
@@ -175,9 +175,9 @@ export default function TaskDetail({ id, canEdit: canEditProp }: { id: string; c
 
   const canEdit = useMemo(() => {
     if (typeof canEditProp === "boolean") return canEditProp;
-    if (!session?.userId || !task) return false;
-    return session.userId === task.createdBy || session.userId === task.ownerId;
-  }, [canEditProp, session?.userId, task]);
+    if (!user?.userId || !task) return false;
+    return user.userId === task.createdBy || user.userId === task.ownerId;
+  }, [canEditProp, task, user?.userId]);
 
   const updateField = async (field: keyof Task, value: string) => {
     if (!task || !canEdit) return;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { signIn, signOut, useSession } from 'next-auth/react';
+import type { Session } from 'next-auth';
+
+type BaseUser = NonNullable<Session['user']>;
+
+type AuthUser = BaseUser & {
+  userId?: string;
+  organizationId?: string;
+  teamId?: string;
+  role?: string;
+  accessToken?: string;
+  accessTokenExpires?: number;
+  refreshToken?: string;
+};
+
+type LoginFn = typeof signIn;
+type LogoutFn = typeof signOut;
+
+interface UseAuthResult {
+  status: ReturnType<typeof useSession>['status'];
+  user: AuthUser | null;
+  isLoading: boolean;
+  error: string | null;
+  login: (...args: Parameters<LoginFn>) => ReturnType<LoginFn>;
+  logout: (...args: Parameters<LogoutFn>) => ReturnType<LogoutFn>;
+}
+
+export default function useAuth(): UseAuthResult {
+  const { data, status } = useSession();
+
+  const user = useMemo<AuthUser | null>(() => {
+    if (!data) return null;
+    const baseUser = data.user ?? ({} as BaseUser);
+    return {
+      ...baseUser,
+      email: data.email ?? baseUser.email,
+      userId: data.userId,
+      organizationId: data.organizationId,
+      teamId: data.teamId,
+      role: data.role,
+      accessToken: data.accessToken,
+      accessTokenExpires: data.accessTokenExpires,
+      refreshToken: data.refreshToken,
+    };
+  }, [data]);
+
+  const login = useCallback(
+    (...args: Parameters<LoginFn>) => signIn(...args),
+    []
+  );
+
+  const logout = useCallback(
+    (...args: Parameters<LogoutFn>) => signOut(...args),
+    []
+  );
+
+  return {
+    status,
+    user,
+    isLoading: status === 'loading',
+    error: data?.error ?? null,
+    login,
+    logout,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useAuth` hook that augments the NextAuth session with helper metadata and login/logout handlers
- refactor comment thread, dashboard, task surfaces, search pages, and admin creation forms to consume `useAuth`
- gate protected pages and interactions behind the new auth state checks and improve unauthenticated UX

## Testing
- npm run lint *(fails: existing repo warnings exceed eslint max-warnings=0)*
- npm run typecheck *(fails: repository already has widespread TypeScript issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4a87ad1883288e27f3551b21f1cb