### PR TITLE
Remove duplicate expiresAt index on refresh token schema

### DIFF
--- a/src/models/RefreshToken.ts
+++ b/src/models/RefreshToken.ts
@@ -15,7 +15,7 @@ const refreshTokenSchema = new Schema(
   {
     user: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
     hashedToken: { type: String, required: true, unique: true },
-    expiresAt: { type: Date, required: true, index: true },
+    expiresAt: { type: Date, required: true },
     client: {
       ip: { type: String },
       userAgent: { type: String },


### PR DESCRIPTION
## Summary
- remove inline index definition from the refresh token schema `expiresAt` field
- keep TTL index defined via `refreshTokenSchema.index`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce4e186e848328a319da6d4321cfdf