### PR TITLE
Implement explicit public route middleware

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+import { getToken } from 'next-auth/jwt';
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}));
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.mocked(getToken).mockReset();
+  });
+
+  const createRequest = (pathname: string) =>
+    new NextRequest(new URL(`https://example.com${pathname}`));
+
+  it('allows public register page without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/register'));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('allows public register api without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/api/register'));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('redirects to login when hitting a protected page without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/dashboard'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/login');
+  });
+
+  it('lets authenticated users access protected pages', async () => {
+    vi.mocked(getToken).mockResolvedValue({ sub: 'user' });
+
+    const response = await middleware(createRequest('/dashboard'));
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,50 @@
-export { default } from 'next-auth/middleware';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+const PUBLIC_ROUTES = new Set([
+  '/',
+  '/login',
+  '/signin',
+  '/register',
+  '/forgot-password',
+  '/terms',
+  '/privacy',
+  '/api/register',
+]);
+
+const PUBLIC_PREFIXES = ['/api/auth'];
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const isAsset =
+    pathname.startsWith('/_next/') ||
+    pathname.startsWith('/static/') ||
+    pathname.startsWith('/favicon.ico');
+
+  const isPublicRoute =
+    isAsset ||
+    PUBLIC_ROUTES.has(pathname) ||
+    PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+
+  if (isPublicRoute) {
+    return NextResponse.next();
+  }
+
+  const session = await getToken({ req: request });
+
+  if (session) {
+    return NextResponse.next();
+  }
+
+  const loginUrl = request.nextUrl.clone();
+  loginUrl.pathname = '/login';
+  loginUrl.searchParams.set('callbackUrl', request.nextUrl.pathname + request.nextUrl.search);
+
+  return NextResponse.redirect(loginUrl);
+}
 
 export const config = {
-  matcher: ['/((?!api/auth|signin|login).+)'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## Summary
- replace the NextAuth default middleware with an explicit allowlist of public routes and prefixes
- ensure authenticated sessions are required for protected paths and redirect unauthenticated users to the login page
- add middleware unit tests that cover public route access and protected route redirects

## Testing
- npm run test *(fails: existing suites rely on Playwright configuration and database mocking outside the scope of this change)*
- npx vitest run middleware.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce538a2cfc8328870d38bd6422d10b