### PR TITLE
feat: switch app typography to Poppins

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,20 +31,31 @@
   --color-background: var(--surface-page);
   --color-surface: var(--surface-card);
   --color-text-secondary: var(--color-text-muted);
+  --font-geist-sans: var(--font-poppins);
 }
 
 @theme inline {
   --color-background: var(--surface-page);
   --color-foreground: var(--color-text);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(
+    --font-poppins,
+    "Poppins",
+    "Inter",
+    "SF Pro Text",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif
+  );
+  --font-mono: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 body {
   background: var(--surface-page);
   color: var(--color-text);
-  font-family: var(--font-geist-sans), 'Inter', 'SF Pro Text', -apple-system,
-    BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-poppins), "Poppins", "Inter", "SF Pro Text",
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.6;
   letter-spacing: -0.01em;
   margin: 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,14 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Poppins } from "next/font/google";
 import AppShell from '@/components/layout/AppShell';
 import LoopBuilder from '@/components/loop-builder';
 import PushNotificationInitializer from '@/components/PushNotificationInitializer';
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const poppins = Poppins({
+  variable: "--font-poppins",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 export const metadata: Metadata = {
@@ -27,7 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--color-background)]`}>
+      <body className={`${poppins.variable} antialiased bg-[var(--color-background)]`}>
         <AppShell>{children}</AppShell>
         <LoopBuilder />
         <PushNotificationInitializer />


### PR DESCRIPTION
## Summary
- replace the previous Geist font setup with the Poppins family in the root layout
- update global theme variables and body font stack to prefer Poppins with sensible fallbacks
- provide a legacy alias so any references to the old Geist variable still resolve

## Testing
- npm run lint *(fails: existing warnings for console usage and unsafe assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1576f248328b337e3f19ab2fb87