### PR TITLE
feat: refresh global palette and typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,28 +1,28 @@
 @import "tailwindcss";
 
 :root {
-  --color-primary: #5a58fa;
-  --color-secondary: #2c3dbf;
+  --color-primary: #4f46e5;
+  --color-secondary: #3730a3;
 
-  --surface-page: #f6f6ff;
+  --surface-page: #f5f7ff;
   --surface-card: #ffffff;
 
-  --color-text-strong: #1b1747;
-  --color-text: #2d2964;
-  --color-text-muted: #6c6aa0;
+  --color-text-strong: #111827;
+  --color-text: #1f2937;
+  --color-text-muted: #6b7280;
 
-  --color-border: #d7daff;
-  --color-border-strong: #adb4ff;
+  --color-border: #dfe4ff;
+  --color-border-strong: #c7cffd;
 
-  --shadow-soft: 0 6px 16px rgba(90, 88, 250, 0.08);
+  --shadow-soft: 0 6px 16px rgba(79, 70, 229, 0.12);
 
-  --status-todo: #5a58fa;
-  --status-inprogress: #c6cbff;
-  --status-done: #36b37e;
+  --status-todo: #4f46e5;
+  --status-inprogress: #a5b4fc;
+  --status-done: #22c55e;
 
-  --priority-high: #ff5630;
-  --priority-medium: #ffab00;
-  --priority-low: #36b37e;
+  --priority-high: #ef4444;
+  --priority-medium: #f59e0b;
+  --priority-low: #22c55e;
 
   --layout-header-height: 4.5rem;
   --layout-footer-height: 3.5rem;
@@ -31,15 +31,14 @@
   --color-background: var(--surface-page);
   --color-surface: var(--surface-card);
   --color-text-secondary: var(--color-text-muted);
-  --font-geist-sans: var(--font-poppins);
+  --font-geist-sans: var(--font-inter);
 }
 
 @theme inline {
   --color-background: var(--surface-page);
   --color-foreground: var(--color-text);
   --font-sans: var(
-    --font-poppins,
-    "Poppins",
+    --font-inter,
     "Inter",
     "SF Pro Text",
     -apple-system,
@@ -54,8 +53,8 @@
 body {
   background: var(--surface-page);
   color: var(--color-text);
-  font-family: var(--font-poppins), "Poppins", "Inter", "SF Pro Text",
-    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--font-inter), "Inter", "SF Pro Text", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.6;
   letter-spacing: -0.01em;
   margin: 0;
@@ -111,12 +110,12 @@ body {
 }
 
 .app-header__toggle:hover {
-  background: rgba(90, 88, 250, 0.08);
-  border-color: rgba(90, 88, 250, 0.4);
+  background: rgba(79, 70, 229, 0.08);
+  border-color: rgba(79, 70, 229, 0.4);
 }
 
 .app-header__toggle:focus-visible {
-  outline: 2px solid rgba(90, 88, 250, 0.5);
+  outline: 2px solid rgba(79, 70, 229, 0.5);
   outline-offset: 3px;
 }
 
@@ -141,10 +140,10 @@ body {
   width: 2rem;
   height: 2rem;
   border-radius: 0.75rem;
-  background: radial-gradient(circle at 20% 20%, #c6cbff, #5a58fa);
+  background: radial-gradient(circle at 20% 20%, #c7d2fe, #4f46e5);
   color: #fff;
   font-size: 1.125rem;
-  box-shadow: 0 4px 16px rgba(90, 88, 250, 0.25);
+  box-shadow: 0 4px 16px rgba(79, 70, 229, 0.25);
 }
 
 .app-header__name {
@@ -165,7 +164,7 @@ body {
   right: 0;
   bottom: var(--layout-footer-height);
   left: 0;
-  background: rgba(90, 88, 250, 0.2);
+  background: rgba(79, 70, 229, 0.2);
   z-index: 35;
 }
 
@@ -182,7 +181,7 @@ body {
   padding: 1.75rem 1.5rem;
   background: var(--surface-card);
   border-right: 1px solid var(--color-border-strong);
-  box-shadow: 8px 0 24px rgba(90, 88, 250, 0.08);
+  box-shadow: 8px 0 24px rgba(79, 70, 229, 0.08);
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   z-index: 40;
@@ -219,7 +218,7 @@ body {
 }
 
 .app-sidebar__profile-avatar:focus-visible {
-  outline: 2px solid rgba(90, 88, 250, 0.5);
+  outline: 2px solid rgba(79, 70, 229, 0.5);
   outline-offset: 4px;
 }
 
@@ -254,17 +253,17 @@ body {
 }
 
 .app-sidebar__link:hover {
-  background: rgba(90, 88, 250, 0.08);
+  background: rgba(79, 70, 229, 0.08);
   color: var(--color-text);
 }
 
 .app-sidebar__link:focus-visible {
-  outline: 2px solid rgba(90, 88, 250, 0.5);
+  outline: 2px solid rgba(79, 70, 229, 0.5);
   outline-offset: 3px;
 }
 
 .app-sidebar__link--active {
-  background: rgba(90, 88, 250, 0.15);
+  background: rgba(79, 70, 229, 0.15);
   color: var(--color-text-strong);
 }
 
@@ -288,12 +287,12 @@ body {
 }
 
 .app-sidebar__logout:hover {
-  background: rgba(90, 88, 250, 0.08);
+  background: rgba(79, 70, 229, 0.08);
   color: var(--color-text);
 }
 
 .app-sidebar__logout:focus-visible {
-  outline: 2px solid rgba(90, 88, 250, 0.5);
+  outline: 2px solid rgba(79, 70, 229, 0.5);
   outline-offset: 3px;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
-import { Poppins } from "next/font/google";
+import { Inter } from "next/font/google";
 import AppShell from '@/components/layout/AppShell';
 import LoopBuilder from '@/components/loop-builder';
 import PushNotificationInitializer from '@/components/PushNotificationInitializer';
 import "./globals.css";
 
-const poppins = Poppins({
-  variable: "--font-poppins",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
   weight: ["400", "500", "700"],
 });
@@ -23,7 +23,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${poppins.variable} antialiased bg-[var(--color-background)]`}>
+      <body className={`${inter.variable} antialiased bg-[var(--color-background)]`}>
         <AppShell>{children}</AppShell>
         <LoopBuilder />
         <PushNotificationInitializer />


### PR DESCRIPTION
## Summary
- update the global CSS tokens to the refreshed indigo-driven palette and adjust dependent styles
- move the application typography to the Inter font family and expose the font variable for styling

## Testing
- npm run lint *(fails: existing warnings about console statements and unsafe any assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb89c693c8328be907d6006c31607