### PR TITLE
Redesign app shell header and sidebar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,7 +82,7 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 0 1.5rem;
-  background: var(--surface-card);
+  background: #ffffff;
   border-bottom: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-soft);
   z-index: 40;
@@ -153,9 +153,161 @@ body {
 .app-header__actions {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
   min-width: 3rem;
   min-height: 2.5rem;
+  margin-left: auto;
+}
+
+.app-header__search {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 16rem;
+  padding: 0.5rem 1rem 0.5rem 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  background: #f3f4f6;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-header__search:focus-within {
+  border-color: #4f46e5;
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+}
+
+.app-header__search-icon {
+  position: absolute;
+  left: 0.9rem;
+  display: inline-flex;
+  width: 1.1rem;
+  height: 1.1rem;
+  color: #6b7280;
+}
+
+.app-header__search-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.app-header__search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: var(--color-text);
+  outline: none;
+}
+
+.app-header__filters {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border-radius: 9999px;
+  background: #eef2ff;
+}
+
+.app-header__filter {
+  border: none;
+  background: transparent;
+  color: #4338ca;
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-header__filter:hover {
+  background: rgba(79, 70, 229, 0.1);
+}
+
+.app-header__filter--active {
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.25);
+}
+
+.app-header__tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border-radius: 9999px;
+  background: #eef2ff;
+}
+
+.app-header__tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 1.1rem;
+  border-radius: 9999px;
+  color: #4338ca;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-header__tab:hover {
+  background: rgba(79, 70, 229, 0.12);
+}
+
+.app-header__tab--active {
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.25);
+}
+
+.app-header__team {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding-left: 0.5rem;
+}
+
+.app-header__team-avatars {
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-header__team-avatar {
+  border: 2px solid #ffffff;
+  box-shadow: 0 4px 10px rgba(79, 70, 229, 0.15);
+}
+
+.app-header__team-avatars .app-header__team-avatar + .app-header__team-avatar {
+  margin-left: -0.55rem;
+}
+
+.app-header__team-invite {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  border: 1px solid #c7cffd;
+  background: #ffffff;
+  color: #4f46e5;
+  font-weight: 600;
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.app-header__team-invite:hover {
+  background: #eef2ff;
+  border-color: #a5b4fc;
+}
+
+.app-header__team-invite:focus-visible {
+  outline: 2px solid rgba(79, 70, 229, 0.4);
+  outline-offset: 3px;
 }
 
 .app-shell__overlay {
@@ -179,7 +331,7 @@ body {
   bottom: var(--layout-footer-height);
   width: var(--sidebar-width);
   padding: 1.75rem 1.5rem;
-  background: var(--surface-card);
+  background: #f3f4f6;
   border-right: 1px solid var(--color-border-strong);
   box-shadow: 8px 0 24px rgba(79, 70, 229, 0.08);
   transform: translateX(-100%);
@@ -244,17 +396,17 @@ body {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.75rem;
-  color: var(--color-text-muted);
-  font-weight: 500;
+  padding: 0.625rem 0.85rem;
+  border-radius: 9999px;
+  color: #4b5563;
+  font-weight: 600;
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-sidebar__link:hover {
-  background: rgba(79, 70, 229, 0.08);
-  color: var(--color-text);
+  background: #e0e7ff;
+  color: #312e81;
 }
 
 .app-sidebar__link:focus-visible {
@@ -263,8 +415,52 @@ body {
 }
 
 .app-sidebar__link--active {
+  background: #4f46e5;
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
+}
+
+.app-sidebar__link-icon {
+  display: inline-flex;
+  width: 1.15rem;
+  height: 1.15rem;
+  color: currentColor;
+}
+
+.app-sidebar__link-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.app-sidebar__link-label {
+  flex: 1;
+}
+
+.app-sidebar__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
   background: rgba(79, 70, 229, 0.15);
-  color: var(--color-text-strong);
+  color: #3730a3;
+}
+
+.app-sidebar__badge--accent {
+  background: #f59e0b;
+  color: #ffffff;
+}
+
+.app-sidebar__link--active .app-sidebar__badge {
+  background: rgba(255, 255, 255, 0.25);
+  color: #eef2ff;
+}
+
+.app-sidebar__link--active .app-sidebar__badge--accent {
+  background: #fbbf24;
+  color: #1f2937;
 }
 
 .app-sidebar__logout {

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -11,9 +11,16 @@ type AppShellProps = {
   children: React.ReactNode;
 };
 
+type NavigationBadge = {
+  label: string;
+  tone?: "neutral" | "accent";
+};
+
 type NavigationLink = {
   href: string;
   label: string;
+  icon: React.ReactNode;
+  badge?: NavigationBadge;
 };
 
 type User = {
@@ -22,11 +29,108 @@ type User = {
   avatar?: string | null;
 };
 
+const DashboardIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M4 4h6v6H4zM14 4h6v10h-6zM4 14h6v6H4zM14 18h6v2h-6z"
+      fill="currentColor"
+      fillRule="evenodd"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+const TasksIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M6 12h5M6 16h3M6 8h9M15.5 14.5l1.5 1.5 3-3"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const ReportsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M5 5h14v14H5z"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9 14l2-2 2 2 3-3"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const PortfoliosIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M7 7V5a2 2 0 012-2h6a2 2 0 012 2v2"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x={3}
+      y={7}
+      width={18}
+      height={12}
+      rx={2}
+      stroke="currentColor"
+      strokeWidth={1.5}
+    />
+    <path
+      d="M3 12h18"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const GoalsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <circle cx={12} cy={12} r={9} stroke="currentColor" strokeWidth={1.5} />
+    <path
+      d="M12 7v5l3 2"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const NAVIGATION_LINKS: NavigationLink[] = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/tasks", label: "Tasks" },
-  { href: "/profile", label: "Profile" },
-  { href: "/settings", label: "Settings" },
+  { href: "/dashboard", label: "Dashboard", icon: <DashboardIcon /> },
+  {
+    href: "/tasks",
+    label: "My Tasks",
+    icon: <TasksIcon />,
+    badge: { label: "12" },
+  },
+  {
+    href: "/reports",
+    label: "Reports",
+    icon: <ReportsIcon />,
+    badge: { label: "3" },
+  },
+  {
+    href: "/portfolios",
+    label: "Portfolios",
+    icon: <PortfoliosIcon />,
+    badge: { label: "New", tone: "accent" },
+  },
+  { href: "/goals", label: "Goals", icon: <GoalsIcon /> },
 ];
 
 const AUTH_ROUTES = new Set(["/signin", "/signin/verify", "/login", "/"]);
@@ -259,7 +363,71 @@ function AuthenticatedAppShell({
             <span className="app-header__name">LoopTask</span>
           </div>
         </div>
-        <div className="app-header__actions" aria-label="User menu" />
+        <div className="app-header__actions" aria-label="Workspace actions">
+          <form
+            className="app-header__search"
+            role="search"
+            onSubmit={(event) => {
+              event.preventDefault();
+            }}
+          >
+            <span className="app-header__search-icon" aria-hidden>
+              <svg viewBox="0 0 24 24" focusable="false">
+                <path
+                  d="M11 5a6 6 0 104.472 10.11l3.859 3.86 1.06-1.061-3.86-3.86A6 6 0 0011 5zm0 1.5a4.5 4.5 0 110 9 4.5 4.5 0 010-9z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+            <input
+              type="search"
+              name="q"
+              className="app-header__search-input"
+              placeholder="Search tasks, projects, people..."
+              aria-label="Search"
+            />
+          </form>
+
+          <div className="app-header__filters" role="group" aria-label="Quick filters">
+            <button type="button" className="app-header__filter app-header__filter--active">
+              All workspaces
+            </button>
+            <button type="button" className="app-header__filter">
+              Priority
+            </button>
+            <button type="button" className="app-header__filter">
+              Due this week
+            </button>
+          </div>
+
+          <nav className="app-header__tabs" aria-label="Primary navigation">
+            {navigationLinks.map((link) => {
+              const isActive = pathname?.startsWith(link.href);
+              return (
+                <Link
+                  key={`header-${link.href}`}
+                  href={link.href}
+                  className={`app-header__tab ${isActive ? "app-header__tab--active" : ""}`}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className="app-header__team" aria-label="Team members">
+            <div className="app-header__team-avatars">
+              <Avatar fallback="AL" className="app-header__team-avatar" />
+              <Avatar fallback="RM" className="app-header__team-avatar" />
+              <Avatar fallback="TS" className="app-header__team-avatar" />
+              <Avatar fallback="JD" className="app-header__team-avatar" />
+            </div>
+            <button type="button" className="app-header__team-invite" aria-label="Invite teammates">
+              +
+            </button>
+          </div>
+        </div>
       </header>
 
       <div
@@ -306,7 +474,19 @@ function AuthenticatedAppShell({
                     onClick={handleNavigationLinkActivation}
                     onKeyDown={handleNavigationLinkKeyDown}
                   >
-                    {link.label}
+                    <span className="app-sidebar__link-icon" aria-hidden>
+                      {link.icon}
+                    </span>
+                    <span className="app-sidebar__link-label">{link.label}</span>
+                    {link.badge ? (
+                      <span
+                        className={`app-sidebar__badge ${
+                          link.badge.tone === "accent" ? "app-sidebar__badge--accent" : ""
+                        }`}
+                      >
+                        {link.badge.label}
+                      </span>
+                    ) : null}
                   </Link>
                 </li>
               );


### PR DESCRIPTION
## Summary
- redesign the app shell header to include search, filters, navigation tabs, and team avatars inside the action bar
- expand sidebar navigation metadata with icons and badges while updating the markup to render them
- refresh header and sidebar styling to match new background colors, indigo hover/active states, and pill indicators

## Testing
- npm run lint *(fails: existing repository warnings about console usage and unsafe assignments)*
- npx eslint src/components/layout/AppShell.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cfbe0ab1d88328bb3ddc5b65b6ae7c