### PR TITLE
Refine task page layout

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -14,6 +14,7 @@ import type { TimelineEvent } from "@/components/timeline/timeline";
 import Timeline from "@/components/timeline/timeline";
 import DeleteTaskModal from '@/components/delete-task-modal';
 import type { TaskStatus } from '@/models/Task';
+import { Button } from '@/components/ui/button';
 
 interface Task {
   _id: string;
@@ -270,111 +271,162 @@ function TaskPageContent({ id }: { id: string }) {
   const actions = ACTIONS[task.status];
 
   return (
-    <div className="p-4">
-      <Link
-        href="/tasks"
-        className="text-blue-500 underline mb-4 inline-block"
-      >
-        &larr; Back to Tasks
-      </Link>
-      <div className="flex gap-8">
-        <div className="flex-1 flex flex-col gap-4">
-          <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold">{task.title}</h1>
-            <StatusBadge status={task.status} />
-          </div>
-          {canEdit ? (
-            <div className="flex gap-2">
-              {actions.map((a) => (
-                <button
-                  key={a.action}
-                  onClick={() => void handleTransition(a.action)}
-                  className="border rounded px-2 py-1 text-sm"
-                >
-                  {a.label}
-                </button>
-              ))}
-              <DeleteTaskModal onConfirm={deleteTask}>
-                <button className="border rounded px-2 py-1 text-sm text-red-600">
-                  Delete Task
-                </button>
-              </DeleteTaskModal>
+    <div className="min-h-screen bg-[#F9FAFB]">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-4 pb-12 pt-6 lg:px-8">
+        <Link
+          href="/tasks"
+          className="mb-4 inline-flex items-center text-sm font-medium text-[#4F46E5] transition hover:text-[#4338CA]"
+        >
+          &larr; Back to Tasks
+        </Link>
+        <div className="sticky top-0 z-20 -mx-4 -mt-2 border-b border-gray-200 bg-[#F9FAFB]/80 px-4 py-4 backdrop-blur supports-[backdrop-filter]:bg-[#F9FAFB]/60 lg:-mx-8 lg:px-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-semibold text-[#111827]">{task.title}</h1>
+              <StatusBadge status={task.status} />
             </div>
-          ) : null}
-          <div className="flex items-center gap-2">
-            <span className="text-sm">Owner:</span>
             {canEdit ? (
-              <div className="relative flex-1">
-                <input
-                  className="border rounded px-2 py-1 text-sm w-full"
-                  value={userQuery}
-                  onChange={(e) => setUserQuery(e.target.value)}
-                  placeholder={ownerName || 'Search users'}
-                />
-                {ownerErrors.ownerId ? (
-                  <span className="text-xs text-red-600">
-                    {ownerErrors.ownerId.message}
-                  </span>
-                ) : null}
-                {users.length ? (
-                  <ul className="absolute z-10 bg-white border mt-1 w-full max-h-40 overflow-auto">
-                    {users.map((u) => (
-                      <li
-                        key={u._id}
-                        className="p-1 cursor-pointer hover:bg-gray-100"
-                        onClick={() => void handleOwnerSelect(u)}
-                      >
-                        {u.name || u.email}
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
+              <div className="flex flex-wrap items-center gap-2">
+                {actions.map((a, index) => (
+                  <Button
+                    key={a.action}
+                    onClick={() => void handleTransition(a.action)}
+                    variant={index === 0 ? 'default' : 'outline'}
+                  >
+                    {a.label}
+                  </Button>
+                ))}
+                <DeleteTaskModal onConfirm={deleteTask}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700"
+                  >
+                    Delete Task
+                  </Button>
+                </DeleteTaskModal>
               </div>
-            ) : (
-              <span className="text-sm font-medium">
-                {ownerName || 'Unassigned'}
-              </span>
-            )}
-          </div>
-          <TaskDetail key={task.ownerId} id={id} canEdit={canEdit} />
-          <div className="flex flex-col gap-2">
-            <h2 className="font-semibold">Attachments</h2>
-            {canEdit ? (
-              <form onSubmit={submitUpload(onUploadSubmit)} className="flex flex-col gap-2">
-                <input type="file" {...registerUpload('file')} />
-                {uploadErrors.file ? (
-                  <span className="text-xs text-red-600">
-                    {uploadErrors.file.message as string}
-                  </span>
-                ) : null}
-                <button type="submit" className="border rounded px-2 py-1 text-sm">
-                  Upload
-                </button>
-              </form>
             ) : null}
-            <ul className="list-disc pl-4">
-              {attachments.map((a) => (
-                <li key={a._id} className="flex items-center gap-2">
-                  <a href={a.url} target="_blank" rel="noreferrer" className="underline">
-                    {a.filename}
-                  </a>
-                  {canEdit ? (
-                    <button
-                      onClick={() => void handleDelete(a._id)}
-                      className="text-xs text-red-600"
-                    >
-                      delete
-                    </button>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
           </div>
-          <CommentThread taskId={id} />
         </div>
-        <aside className="w-64">
-          <Timeline events={history} />
-        </aside>
+        <div className="mt-6 grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="flex flex-col gap-6">
+            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-[#111827]">Task Information</h2>
+              </div>
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm font-medium text-[#374151]">Owner</span>
+                  {canEdit ? (
+                    <div className="relative">
+                      <input
+                        className="h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30"
+                        value={userQuery}
+                        onChange={(e) => setUserQuery(e.target.value)}
+                        placeholder={ownerName || 'Search users'}
+                      />
+                      {ownerErrors.ownerId ? (
+                        <span className="mt-1 block text-xs text-red-600">
+                          {ownerErrors.ownerId.message}
+                        </span>
+                      ) : null}
+                      {users.length ? (
+                        <ul className="absolute z-10 mt-2 max-h-48 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                          {users.map((u) => (
+                            <li
+                              key={u._id}
+                              className="cursor-pointer px-3 py-2 text-sm text-[#111827] hover:bg-[#EEF2FF]"
+                              onClick={() => void handleOwnerSelect(u)}
+                            >
+                              {u.name || u.email}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <span className="rounded-full bg-[#EEF2FF] px-3 py-1 text-sm font-medium text-[#4338CA]">
+                      {ownerName || 'Unassigned'}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </section>
+            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-[#111827]">Task Details</h2>
+              <div className="mt-4">
+                <TaskDetail key={task.ownerId} id={id} canEdit={canEdit} />
+              </div>
+            </section>
+            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-[#111827]">Attachments</h2>
+              <div className="mt-4 flex flex-col gap-4">
+                {canEdit ? (
+                  <form onSubmit={submitUpload(onUploadSubmit)} className="flex flex-col gap-3 rounded-lg border border-dashed border-[#C7D2FE] bg-[#EEF2FF]/40 p-4">
+                    <label className="text-sm font-medium text-[#4338CA]">
+                      Upload new file
+                      <input
+                        type="file"
+                        {...registerUpload('file')}
+                        className="mt-2 block w-full text-sm text-[#4B5563]"
+                      />
+                    </label>
+                    {uploadErrors.file ? (
+                      <span className="text-xs text-red-600">
+                        {uploadErrors.file.message as string}
+                      </span>
+                    ) : null}
+                    <div className="flex justify-end">
+                      <Button type="submit">Upload</Button>
+                    </div>
+                  </form>
+                ) : null}
+                <ul className="flex flex-col gap-3">
+                  {attachments.map((a) => (
+                    <li
+                      key={a._id}
+                      className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-[#111827]"
+                    >
+                      <a
+                        href={a.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-medium text-[#4F46E5] hover:text-[#4338CA]"
+                      >
+                        {a.filename}
+                      </a>
+                      {canEdit ? (
+                        <button
+                          onClick={() => void handleDelete(a._id)}
+                          className="text-xs font-medium text-red-600 hover:text-red-700"
+                        >
+                          Remove
+                        </button>
+                      ) : null}
+                    </li>
+                  ))}
+                  {!attachments.length ? (
+                    <li className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-[#6B7280]">
+                      No attachments yet.
+                    </li>
+                  ) : null}
+                </ul>
+              </div>
+            </section>
+          </div>
+          <aside className="flex flex-col gap-6">
+            <section className="sticky top-24 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-[#111827]">Activity</h2>
+              <div className="mt-4 space-y-6">
+                <Timeline events={history} />
+                <div className="border-t border-gray-200 pt-6">
+                  <CommentThread taskId={id} />
+                </div>
+              </div>
+            </section>
+          </aside>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap the task page in a soft gray background and center the content within a responsive two-column grid
- add a sticky task header with status badge plus primary and secondary styled action buttons
- reorganize task details into card-based sections and move timeline/comments into a dedicated right column activity card

## Testing
- npm run lint *(fails: existing repository warnings about console usage and any-typed assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68d01ad0d8748328aa150b18e7ea94da