### PR TITLE
Redesign task activity panel and comment thread

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -415,13 +415,17 @@ function TaskPageContent({ id }: { id: string }) {
               </div>
             </section>
           </div>
-          <aside className="flex flex-col gap-6">
-            <section className="sticky top-24 rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-[#111827]">Activity</h2>
-              <div className="mt-4 space-y-6">
-                <Timeline events={history} />
-                <div className="border-t border-gray-200 pt-6">
-                  <CommentThread taskId={id} />
+          <aside className="flex flex-col gap-6 lg:sticky lg:top-24">
+            <section className="flex max-h-[calc(100vh-8rem)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+              <div className="border-b border-gray-200 px-6 py-4">
+                <h2 className="text-lg font-semibold text-[#111827]">Activity</h2>
+              </div>
+              <div className="flex flex-1 flex-col overflow-hidden">
+                <div className="flex flex-1 flex-col overflow-y-auto px-6 py-4">
+                  <div className="flex flex-1 flex-col gap-8">
+                    <Timeline events={history} />
+                    <CommentThread taskId={id} className="flex-1" />
+                  </div>
                 </div>
               </div>
             </section>

--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { Textarea } from '@/components/ui/textarea';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Avatar } from '@/components/ui/avatar';
 import useAuth from '@/hooks/useAuth';
 import useTyping from '@/hooks/useTyping';
 import useRealtime from '@/hooks/useRealtime';
+import { cn } from '@/lib/utils';
 
 interface EnqueueResponse {
   ok?: boolean;
@@ -16,17 +17,49 @@ interface Comment {
   _id: string;
   content: string;
   taskId: string;
+  userId: string;
+  createdAt: string;
   parentId?: string | null;
+}
+
+interface CommentUser {
+  _id: string;
+  name?: string;
+  email?: string;
+  avatar?: string;
+}
+
+function isComment(value: unknown): value is Comment {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj._id === 'string' &&
+    typeof obj.content === 'string' &&
+    typeof obj.taskId === 'string' &&
+    typeof obj.userId === 'string' &&
+    typeof obj.createdAt === 'string'
+  );
+}
+
+function isCommentUser(value: unknown): value is CommentUser {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj._id === 'string';
+}
+
+interface CommentThreadProps {
+  taskId: string;
+  parentId?: string;
+  className?: string;
 }
 
 export default function CommentThread({
   taskId,
   parentId,
-}: {
-  taskId: string;
-  parentId?: string;
-}) {
+  className,
+}: CommentThreadProps) {
   const [comments, setComments] = useState<Comment[]>([]);
+  const [userMap, setUserMap] = useState<Record<string, CommentUser>>({});
   const [newContent, setNewContent] = useState('');
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyContent, setReplyContent] = useState('');
@@ -35,13 +68,53 @@ export default function CommentThread({
   const { typingUsers, emit } = useTyping(taskId, user?.userId, !parentId);
   const typingTimeout = useRef<NodeJS.Timeout | null>(null);
   const { enqueue } = useRealtime();
+  const userMapRef = useRef(userMap);
+
+  useEffect(() => {
+    userMapRef.current = userMap;
+  }, [userMap]);
+
+  const fetchUsers = useCallback(async (ids: string[]) => {
+    const unique = Array.from(new Set(ids.filter(Boolean)));
+    if (!unique.length) return;
+    try {
+      const res = await fetch(`/api/users?${unique.map((id) => `id=${id}`).join('&')}`);
+      if (!res.ok) return;
+      const json: unknown = await res.json();
+      if (!Array.isArray(json)) return;
+      const map = json
+        .filter(isCommentUser)
+        .reduce<Record<string, CommentUser>>((acc, u) => {
+          acc[u._id] = u;
+          return acc;
+        }, {});
+      if (Object.keys(map).length) {
+        setUserMap((prev) => ({ ...prev, ...map }));
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
 
   const load = useCallback(async () => {
     const params = new URLSearchParams({ taskId });
     if (parentId) params.set('parentId', parentId);
     const res = await fetch(`/api/comments?${params.toString()}`);
-    if (res.ok) setComments(await res.json());
-  }, [taskId, parentId]);
+    if (!res.ok) return;
+    const json: unknown = await res.json();
+    if (!Array.isArray(json)) {
+      setComments([]);
+      return;
+    }
+    const parsed = json.filter(isComment);
+    setComments(parsed);
+    const missing = parsed
+      .map((comment) => comment.userId)
+      .filter((id) => id && !userMapRef.current[id]);
+    if (missing.length) {
+      void fetchUsers(missing);
+    }
+  }, [taskId, parentId, fetchUsers]);
 
   useEffect(() => {
     void load();
@@ -53,85 +126,184 @@ export default function CommentThread({
     };
   }, []);
 
-  const handleCreate = async (pid?: string | null) => {
-    const content = pid ? replyContent : newContent;
-    const res: EnqueueResponse = await enqueue('/api/comments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ taskId, content, parentId: pid ?? undefined }),
-    });
-    if (res.ok || res.offline) {
-      if (pid) {
-        setReplyContent('');
-        setReplyingTo(null);
-      } else {
-        setNewContent('');
+  const displayUsers = useMemo(
+    () =>
+      typingUsers.map((u) => {
+        const known = userMapRef.current[u._id];
+        return {
+          ...u,
+          name: known?.name || known?.email || u.name || 'Someone',
+        };
+      }),
+    [typingUsers]
+  );
+
+  const handleCreate = useCallback(
+    async (pid?: string | null) => {
+      const content = (pid ? replyContent : newContent).trim();
+      if (!content) return;
+      const res: EnqueueResponse = await enqueue('/api/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskId, content, parentId: pid ?? undefined }),
+      });
+      if (res.ok || res.offline) {
+        if (pid) {
+          setReplyContent('');
+          setReplyingTo(null);
+        } else {
+          setNewContent('');
+        }
       }
+      if (res.ok) {
+        await load();
+      }
+    },
+    [enqueue, load, newContent, replyContent, taskId]
+  );
+
+  const formatTimestamp = useCallback((value: string) => {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(new Date(value));
+    } catch {
+      return value;
     }
-    if (res.ok) {
-      await load();
-    }
-  };
+  }, []);
+
+  const renderComment = useCallback(
+    (comment: Comment) => {
+      const author = userMap[comment.userId];
+      const name = author?.name || author?.email || 'Unknown user';
+      const avatarFallback = name ? name.charAt(0).toUpperCase() : undefined;
+      return (
+        <div key={comment._id} className="flex flex-col gap-3">
+          <div className="flex items-start gap-3">
+            <Avatar
+              src={author?.avatar}
+              fallback={avatarFallback}
+              className="h-9 w-9 flex-shrink-0"
+            />
+            <div className="flex-1">
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span className="text-sm font-semibold text-[#111827]">{name}</span>
+                <time className="text-xs text-[#6B7280]">
+                  {formatTimestamp(comment.createdAt)}
+                </time>
+              </div>
+              <div className="mt-2 rounded-2xl bg-[#F3F4F6] px-4 py-3 text-sm text-[#111827] shadow-sm">
+                {comment.content}
+              </div>
+              <div className="mt-2 flex items-center gap-3">
+                <button
+                  type="button"
+                  className="text-xs font-medium text-[#4F46E5] transition hover:text-[#4338CA]"
+                  onClick={() => setReplyingTo(comment._id)}
+                  disabled={!user}
+                >
+                  Reply
+                </button>
+              </div>
+            </div>
+          </div>
+          {replyingTo === comment._id ? (
+            <div className="ml-12">
+              <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+                <textarea
+                  value={replyContent}
+                  onChange={(e) => setReplyContent(e.target.value)}
+                  placeholder={user ? 'Write a reply…' : 'Sign in to reply'}
+                  disabled={!user}
+                  className="min-h-[72px] w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#C7D2FE]"
+                />
+                <div className="mt-3 flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setReplyingTo(null);
+                      setReplyContent('');
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => void handleCreate(comment._id)}
+                    disabled={!user || !replyContent.trim()}
+                  >
+                    Reply
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
+          <CommentThread taskId={taskId} parentId={comment._id} />
+        </div>
+      );
+    },
+    [formatTimestamp, handleCreate, replyContent, replyingTo, taskId, user, userMap]
+  );
 
   return (
-    <div className={parentId ? 'ml-4 mt-2' : 'mt-4'}>
-      {!parentId && (
-        <div className="mb-4">
-          <Textarea
-            value={newContent}
-            onChange={(e) => {
-              setNewContent(e.target.value);
-              if (typingTimeout.current) clearTimeout(typingTimeout.current);
-              typingTimeout.current = setTimeout(() => {
-                emit();
-              }, 300);
-            }}
-            placeholder={user ? 'Add a comment...' : 'Sign in to comment'}
-            disabled={!user}
-          />
-          {typingUsers.map((u) => (
-            <p key={u._id} className="mt-1 text-xs text-gray-500">
-              {`${u.name ?? 'Someone'} is typing...`}
-            </p>
-          ))}
-          <Button
-            className="mt-1 text-xs"
-            onClick={() => void handleCreate(null)}
-            disabled={!user || !newContent.trim()}
-          >
-            Comment
-          </Button>
-        </div>
+    <div
+      className={cn(
+        parentId
+          ? 'mt-4 space-y-6 border-l border-gray-200 pl-6'
+          : 'flex flex-1 flex-col gap-6',
+        className
       )}
-      {comments.map((c) => (
-        <div key={c._id} className="mb-2">
-          <div className="p-2 border rounded">
-            <p className="text-sm">{c.content}</p>
-            <button
-              className="text-xs text-blue-500"
-              onClick={() => setReplyingTo(c._id)}
-            >
-              Reply
-            </button>
+    >
+      <div className={cn('flex flex-col gap-6', parentId ? '' : 'flex-1')}>
+        {comments.length ? (
+          comments.map((comment) => renderComment(comment))
+        ) : parentId ? null : (
+          <div className="rounded-xl border border-dashed border-gray-200 bg-[#F9FAFB] px-4 py-6 text-center text-sm text-[#6B7280]">
+            No comments yet. Start the conversation!
           </div>
-          {replyingTo === c._id && (
-            <div className="ml-4 mt-2">
-              <Textarea
-                value={replyContent}
-                onChange={(e) => setReplyContent(e.target.value)}
-              />
-              <Button
-                className="mt-1 text-xs"
-                onClick={() => void handleCreate(c._id)}
-                disabled={!user || !replyContent.trim()}
-              >
-                Submit
-              </Button>
+        )}
+      </div>
+      {!parentId && (
+        <form
+          className="mt-auto space-y-4 border-t border-gray-200 pt-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleCreate(null);
+          }}
+        >
+          <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+            <textarea
+              value={newContent}
+              onChange={(e) => {
+                setNewContent(e.target.value);
+                if (typingTimeout.current) clearTimeout(typingTimeout.current);
+                typingTimeout.current = setTimeout(() => {
+                  emit();
+                }, 300);
+              }}
+              placeholder={user ? 'Share an update…' : 'Sign in to comment'}
+              disabled={!user}
+              className="min-h-[96px] w-full resize-none rounded-xl border-0 bg-transparent px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-0"
+            />
+          </div>
+          {displayUsers.length ? (
+            <div className="text-xs text-[#6B7280]">
+              {displayUsers.map((u) => (
+                <span key={u._id} className="block">
+                  {`${u.name ?? 'Someone'} is typing…`}
+                </span>
+              ))}
             </div>
-          )}
-          <CommentThread taskId={taskId} parentId={c._id} />
-        </div>
-      ))}
+          ) : null}
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!user || !newContent.trim()}>
+              Post comment
+            </Button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { Avatar } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
 
 export interface TimelineEvent {
   user: { name: string; avatar?: string };
@@ -10,52 +11,80 @@ export interface TimelineEvent {
   type?: 'comment' | 'update' | 'transition';
 }
 
+const ICONS: Record<NonNullable<TimelineEvent['type']>, string> = {
+  comment: '💬',
+  update: '✏️',
+  transition: '🔀',
+};
+
+function formatTimestamp(date: string) {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(date));
+  } catch {
+    return date;
+  }
+}
+
 export function Timeline({ events }: { events: TimelineEvent[] }) {
-  const ICONS: Record<NonNullable<TimelineEvent['type']>, string> = {
-    comment: '💬',
-    update: '✏️',
-    transition: '🔀',
-  };
+  if (!events.length) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-200 bg-[#F9FAFB] px-4 py-6 text-center text-sm text-[#6B7280]">
+        No activity yet.
+      </div>
+    );
+  }
+
   return (
-    <div className="bg-white">
-      <ul className="relative ml-4 border-l border-gray-200">
-        {events.map((event, index) => (
+    <ul className="relative space-y-6 border-l border-gray-200 pl-6">
+      {events.map((event, index) => {
+        const interactive = Boolean(event.type);
+        const icon = event.type ? ICONS[event.type] : '•';
+        const fallbackInitial = event.user.name
+          ? event.user.name.charAt(0)
+          : undefined;
+        return (
           <motion.li
-            key={index}
+            key={`${event.date}-${index}`}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
-            className="relative pl-4 sm:pl-6 md:pl-8 pb-6 sm:pb-8 text-gray-700"
+            className="group relative pl-4"
+            aria-disabled={!interactive}
           >
-            {index > 0 && (
-              <motion.span
-                className="absolute -left-px -top-8 w-px bg-[#2684FF]"
-                initial={{ height: 0 }}
-                animate={{ height: 32 }}
-                transition={{ duration: 0.3 }}
-              />
-            )}
-            <span className="absolute -left-2 top-1 w-4 h-4 rounded-full border-2 border-[#2684FF] bg-white" />
-            <div className="flex items-start gap-4">
+            <span className="absolute -left-[26px] top-3 flex h-5 w-5 items-center justify-center rounded-full border border-[#4F46E5] bg-white text-[11px] font-semibold text-[#4F46E5]">
+              {icon}
+            </span>
+            {index !== events.length - 1 ? (
+              <span className="absolute -left-[18px] top-7 block h-full w-px bg-gray-200" aria-hidden />
+            ) : null}
+            <div
+              className={cn(
+                'flex items-start gap-3 rounded-lg border border-transparent px-4 py-3 transition-colors',
+                'group-hover:border-[#E5E7EB] group-hover:bg-[#F9FAFB]',
+                'group-aria-[disabled=true]:opacity-70 group-aria-[disabled=true]:hover:border-transparent group-aria-[disabled=true]:hover:bg-transparent'
+              )}
+            >
               <Avatar
                 src={event.user.avatar}
-                fallback={event.user.name.charAt(0)}
-                className="sm:w-9 sm:h-9 md:w-10 md:h-10"
+                fallback={fallbackInitial}
+                className="h-9 w-9 flex-shrink-0"
               />
-              <div>
-                <div className="font-medium">{event.user.name}</div>
-                <div className="text-sm flex items-center">
-                  {event.type && <span className="mr-1">{ICONS[event.type]}</span>}
-                  <span>{event.status}</span>
-                  <span className="ml-2 text-gray-500">
-                    {new Date(event.date).toLocaleString()}
-                  </span>
+              <div className="flex-1">
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <span className="text-sm font-semibold text-[#111827]">{event.user.name}</span>
+                  <time className="text-xs text-[#6B7280]">
+                    {formatTimestamp(event.date)}
+                  </time>
                 </div>
+                <p className="mt-1 text-sm text-[#6B7280]">{event.status}</p>
               </div>
             </div>
           </motion.li>
-        ))}
-      </ul>
-    </div>
+        );
+      })}
+    </ul>
   );
 }
 


### PR DESCRIPTION
## Summary
- restyle the task activity sidebar into a sticky card with its own scroll area and embed the comment thread within it
- redesign the comment thread to display avatars, author details, timestamps, conversation bubbles, and a bottom composer with reply support
- refresh the timeline component styling to share the card aesthetics, align typography, and provide updated hover/disabled states

## Testing
- npm run lint *(fails: existing repository warnings outside the touched files)*
- npm run typecheck *(fails: existing type errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d01d7749788328b8cb49b0febc7b08