### PR TITLE
Update status badge styling and sizing

### DIFF
--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -1,25 +1,74 @@
 import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 import type { TaskStatus } from '@/models/Task';
 
 const STATUS_STYLES: Record<TaskStatus, { label: string; icon: string; className: string }> = {
-  OPEN: { label: 'Open', icon: '📝', className: 'bg-gray-100 text-gray-800' },
-  IN_PROGRESS: { label: 'In Progress', icon: '⏳', className: 'bg-blue-100 text-blue-800' },
-  IN_REVIEW: { label: 'In Review', icon: '👀', className: 'bg-purple-100 text-purple-800' },
-  REVISIONS: { label: 'Revisions', icon: '✏️', className: 'bg-yellow-100 text-yellow-800' },
+  OPEN: {
+    label: 'Open',
+    icon: '📝',
+    className: 'bg-[#6B7280] text-white',
+  },
+  IN_PROGRESS: {
+    label: 'In Progress',
+    icon: '⏳',
+    className: 'bg-[#3B82F6] text-white',
+  },
+  IN_REVIEW: {
+    label: 'In Review',
+    icon: '👀',
+    className: 'bg-[#6366F1] text-white',
+  },
+  REVISIONS: {
+    label: 'Revisions',
+    icon: '✏️',
+    className: 'bg-[#EF4444] text-white',
+  },
   FLOW_IN_PROGRESS: {
     label: 'Flow In Progress',
     icon: '🔄',
-    className: 'bg-indigo-100 text-indigo-800',
+    className: 'bg-[#8B5CF6] text-white',
   },
-  DONE: { label: 'Done', icon: '✅', className: 'bg-green-100 text-green-800' },
+  DONE: {
+    label: 'Done',
+    icon: '✅',
+    className: 'bg-[#10B981] text-white',
+  },
 };
 
-export function StatusBadge({ status }: { status: TaskStatus }) {
-  const { label, icon, className } = STATUS_STYLES[status];
+const SIZE_STYLES = {
+  sm: 'px-2.5 py-0.5 text-xs leading-4',
+  md: 'px-3 py-1 text-sm leading-5',
+} as const;
+
+export type StatusBadgeSize = keyof typeof SIZE_STYLES;
+
+export interface StatusBadgeProps {
+  status: TaskStatus;
+  size?: StatusBadgeSize;
+  className?: string;
+  showIcon?: boolean;
+}
+
+export function StatusBadge({
+  status,
+  size = 'md',
+  className,
+  showIcon = true,
+}: StatusBadgeProps) {
+  const { label, icon, className: statusClassName } = STATUS_STYLES[status];
+
   return (
-    <Badge className={`gap-1 ${className}`}>
-      <span>{icon}</span>
-      {label}
+    <Badge
+      className={cn(
+        'gap-1 rounded-full font-semibold normal-case text-white shadow-sm ring-1 ring-inset ring-black/10 transition',
+        'hover:ring-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#1F2937] focus-visible:ring-offset-2 focus-visible:ring-offset-[#F9FAFB]',
+        SIZE_STYLES[size],
+        statusClassName,
+        className,
+      )}
+    >
+      {showIcon ? <span aria-hidden="true">{icon}</span> : null}
+      <span>{label}</span>
     </Badge>
   );
 }


### PR DESCRIPTION
## Summary
- map task statuses to the new solid badge colors with white text and a pill silhouette
- add size and icon controls so the badge fits both sticky header and card layouts
- layer in subtle ring and transition styles to maintain contrast against the refreshed background

## Testing
- npm run lint *(fails: existing warnings across unrelated files trigger --max-warnings=0)*

------
https://chatgpt.com/codex/tasks/task_e_68d01fd161c483288585747ba74fe554