### PR TITLE
Hide task actions for completed tasks

### DIFF
--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -54,8 +54,12 @@ const getBadgeVariant = (value?: string): BadgeProps['variant'] => {
 };
 
 export default function TaskCard({ task, onChange, href, canEdit = true }: TaskCardProps) {
+  const normalizedStatus = task.status?.trim().toUpperCase();
+  const isDone = normalizedStatus === 'DONE';
+  const showActions = canEdit && !isDone;
+
   const handleEdit = async () => {
-    if (!canEdit) return;
+    if (!showActions) return;
     const title = prompt('New title', task.title);
     if (title) {
       await fetch(`/api/tasks/${task._id}`, {
@@ -68,7 +72,7 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
   };
 
   const handleDelete = async () => {
-    if (!canEdit) return;
+    if (!showActions) return;
     await fetch(`/api/tasks/${task._id}`, { method: 'DELETE' });
     onChange?.();
   };
@@ -107,7 +111,7 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
       ) : (
         cardContent
       )}
-      {canEdit ? (
+      {showActions ? (
         <div className="mt-2 flex justify-end gap-2 sm:justify-start">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- prevent edit and delete controls from rendering when a task is marked DONE
- reuse the same guard so mobile layouts also omit actions for completed tasks

## Testing
- npx eslint src/components/task-card.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d02615de208328a05a3b43f768496b