### PR TITLE
Remove offline status banner from task detail view

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -175,7 +175,7 @@ export default function TaskDetail({ id, canEdit: canEditProp }: { id: string; c
     },
     [id, taskVersion, loopVersion]
   );
-  const { status } = useRealtime({ onMessage: handleMessage });
+  useRealtime({ onMessage: handleMessage });
 
   const canEdit = useMemo(() => {
     if (typeof canEditProp === "boolean") return canEditProp;
@@ -225,11 +225,6 @@ export default function TaskDetail({ id, canEdit: canEditProp }: { id: string; c
 
   return (
     <div className="p-4 flex flex-col gap-4">
-      {status !== "connected" && (
-        <div className="bg-red-500 text-white text-center p-1 text-xs">
-          Offline
-        </div>
-      )}
       <Card className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
           <label className="text-xs font-semibold uppercase tracking-wide text-gray-500">


### PR DESCRIPTION
## Summary
- remove the offline status banner from the task detail component
- stop reading the realtime connection status in task detail while keeping message subscriptions active

## Testing
- `npm run lint` *(fails: existing warnings about console statements and unsafe assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68d0286b1e088328a29a496db68b3776