### PR TITLE
Update new task page actions

### DIFF
--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -78,6 +78,10 @@ function NewTaskPageInner() {
 
   const addStep = () => setSteps((prev) => [...prev, createStep(currentUserId)]);
 
+  const handleCancel = () => {
+    router.push('/tasks');
+  };
+
   const updateStep = (
     id: string,
     key: 'title' | 'description' | 'ownerId' | 'due',
@@ -197,13 +201,31 @@ function NewTaskPageInner() {
               ))}
             </SortableContext>
           </DndContext>
-          <Button type="button" variant="outline" onClick={addStep}>
-            Add Step
-          </Button>
         </Card>
 
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={addStep}
+            className="border-indigo-200 text-indigo-600 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700"
+          >
+            Add Step
+          </Button>
+        </div>
+
         {flowError && <p className="text-sm text-red-600">{flowError}</p>}
-        <Button type="submit">Create Task</Button>
+        <div className="flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            className="border-[#E5E7EB] text-[#4B5563] hover:border-[#D1D5DB] hover:bg-[#F3F4F6] hover:text-[#1F2937]"
+          >
+            Cancel
+          </Button>
+          <Button type="submit">Create Task</Button>
+        </div>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle the "Add Step" control to sit beneath the steps card with indigo outline treatment
- add a cancel action that returns to the task list and group footer buttons with spacing

## Testing
- npm run lint *(fails: existing repository warnings exceed configured limit)*
- npx eslint src/app/tasks/new/page.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d030087fe08328b8c77ce53896d8a7