### PR TITLE
Add toast provider and show success notification on task creation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import AppShell from '@/components/layout/AppShell';
 import LoopBuilder from '@/components/loop-builder';
 import PushNotificationInitializer from '@/components/PushNotificationInitializer';
+import { ToastProvider } from '@/components/ui/toast-provider';
 import "./globals.css";
 
 const inter = Inter({
@@ -24,9 +25,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} antialiased bg-[var(--color-background)]`}>
-        <AppShell>{children}</AppShell>
-        <LoopBuilder />
-        <PushNotificationInitializer />
+        <ToastProvider>
+          <AppShell>{children}</AppShell>
+          <LoopBuilder />
+          <PushNotificationInitializer />
+        </ToastProvider>
       </body>
     </html>
   );

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Select } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+import { useToast } from '@/components/ui/toast-provider';
 import { DndContext, type DragEndEvent, closestCenter } from '@dnd-kit/core';
 import { SortableContext, arrayMove, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -54,6 +55,7 @@ const PRIORITY_OPTIONS: Array<{
 function NewTaskPageInner() {
   const router = useRouter();
   const { user, status, isLoading } = useAuth();
+  const { showToast } = useToast();
   const currentUserId = user?.userId ?? '';
   const [users, setUsers] = useState<User[]>([]);
 
@@ -143,6 +145,7 @@ function NewTaskPageInner() {
         return;
       }
       const task = (await resp.json()) as { _id?: string };
+      showToast({ message: 'Task created successfully', tone: 'success', duration: 5000 });
       if (typeof task._id === 'string') {
         router.push(`/tasks/${task._id}`);
       } else {

--- a/src/components/ui/toast-provider.tsx
+++ b/src/components/ui/toast-provider.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type ToastTone = "success" | "error" | "info";
+
+type ToastOptions = {
+  message: string;
+  tone?: ToastTone;
+  duration?: number;
+};
+
+type Toast = ToastOptions & {
+  id: string;
+  tone: ToastTone;
+  duration: number;
+};
+
+type ToastContextValue = {
+  showToast: (toast: ToastOptions) => string;
+  dismissToast: (id: string) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const generateId = () =>
+  (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2, 10));
+
+const DEFAULT_DURATION = 5000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    ({ message, tone = "info", duration = DEFAULT_DURATION }: ToastOptions) => {
+      const id = generateId();
+      const toast: Toast = {
+        id,
+        message,
+        tone,
+        duration,
+      };
+      setToasts((prev) => [...prev, toast]);
+      if (duration > 0) {
+        window.setTimeout(() => {
+          dismissToast(id);
+        }, duration);
+      }
+      return id;
+    },
+    [dismissToast],
+  );
+
+  const value = useMemo(() => ({ showToast, dismissToast }), [showToast, dismissToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed inset-x-0 top-4 z-[100] flex justify-center px-4">
+        <div className="flex w-full max-w-sm flex-col gap-2">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              role="status"
+              className={cn(
+                "pointer-events-auto rounded-lg px-4 py-3 text-sm font-medium text-white shadow-lg",
+                toast.tone === "success" && "bg-[#10B981]",
+                toast.tone === "error" && "bg-[#EF4444]",
+                toast.tone === "info" && "bg-[#6366F1]",
+              )}
+            >
+              {toast.message}
+            </div>
+          ))}
+        </div>
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- add a global toast provider with success styling that persists across navigations
- wrap the root layout with the toast provider so any page can push notifications
- trigger a success toast when a task is created before redirecting to the task page

## Testing
- npm run lint *(fails: existing warnings for console usage and unsafe assignments in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d032243b748328b470f3e1ed91e9e9