### PR TITLE
Refactor task form and add edit flow

### DIFF
--- a/src/app/tasks/[id]/edit/page.tsx
+++ b/src/app/tasks/[id]/edit/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState, use } from 'react';
+import { useRouter } from 'next/navigation';
+import { SessionProvider } from 'next-auth/react';
+import TaskForm from '@/components/task-form';
+import useAuth from '@/hooks/useAuth';
+import { useToast } from '@/components/ui/toast-provider';
+import type { TaskResponse } from '@/types/api/task';
+
+function EditTaskPageInner({ id }: { id: string }) {
+  const router = useRouter();
+  const { user, status, isLoading } = useAuth();
+  const { showToast } = useToast();
+  const [task, setTask] = useState<TaskResponse | null>(null);
+  const [loadingTask, setLoadingTask] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    if (status === 'unauthenticated' && !isLoading) {
+      router.push('/login');
+    }
+  }, [isLoading, router, status]);
+
+  useEffect(() => {
+    if (status !== 'authenticated') return;
+    let isMounted = true;
+    const load = async () => {
+      setLoadingTask(true);
+      setLoadError(null);
+      try {
+        const res = await fetch(`/api/tasks/${id}`, { credentials: 'include' });
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as { detail?: string };
+          if (res.status === 404) {
+            if (isMounted) setTask(null);
+            if (isMounted) setLoadError(err.detail ?? 'Task not found');
+            return;
+          }
+          if (isMounted) setLoadError(err.detail ?? 'Unable to load task');
+          return;
+        }
+        const data = (await res.json()) as TaskResponse;
+        if (isMounted) setTask(data);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Unable to load task';
+        if (isMounted) setLoadError(message);
+      } finally {
+        if (isMounted) setLoadingTask(false);
+      }
+    };
+    void load();
+    return () => {
+      isMounted = false;
+    };
+  }, [id, status]);
+
+  if (status === 'loading' || (status === 'authenticated' && loadingTask && !task && !loadError)) {
+    return <div className="p-4">Loading…</div>;
+  }
+
+  if (status === 'unauthenticated') {
+    return null;
+  }
+
+  if (loadError && !task) {
+    return <div className="p-4 text-red-600">{loadError}</div>;
+  }
+
+  if (!task) {
+    return <div className="p-4">Task not found.</div>;
+  }
+
+  const currentUserId = user?.userId ?? '';
+
+  return (
+    <TaskForm
+      currentUserId={currentUserId}
+      initialValues={{
+        title: task.title,
+        priority: task.priority,
+        steps:
+          task.steps?.map((step) => ({
+            title: step.title ?? '',
+            description: step.description ?? '',
+            ownerId: step.ownerId ?? '',
+            dueAt: step.dueAt ?? null,
+          })) ?? [],
+      }}
+      submitLabel="Save Changes"
+      submitPendingLabel="Saving…"
+      onCancel={() => router.push(`/tasks/${task._id}`)}
+      onSubmit={async (values) => {
+        if (isRedirecting) return;
+        try {
+          const resp = await fetch(`/api/tasks/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(values),
+          });
+          if (!resp.ok) {
+            const err = (await resp.json().catch(() => ({}))) as { detail?: string };
+            return { error: err.detail ?? 'Failed to update task' };
+          }
+          const updated = (await resp.json()) as TaskResponse;
+          showToast({ message: 'Task updated successfully', tone: 'success', duration: 5000 });
+          setIsRedirecting(true);
+          router.push(`/tasks/${updated._id}`);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : 'Failed to update task';
+          return { error: message };
+        }
+      }}
+    />
+  );
+}
+
+export default function EditTaskPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  return (
+    <SessionProvider>
+      <EditTaskPageInner id={id} />
+    </SessionProvider>
+  );
+}

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -1,161 +1,23 @@
 'use client';
-import { useState, useEffect, type CSSProperties } from 'react';
+
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { SessionProvider } from 'next-auth/react';
 import useAuth from '@/hooks/useAuth';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Select } from '@/components/ui/select';
-import { cn } from '@/lib/utils';
 import { useToast } from '@/components/ui/toast-provider';
-import { DndContext, type DragEndEvent, closestCenter } from '@dnd-kit/core';
-import { SortableContext, arrayMove, useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
-
-interface User {
-  _id: string;
-  name: string;
-}
-
-interface FlowStep {
-  id: string;
-  title: string;
-  description: string;
-  ownerId: string;
-  due: string;
-}
-
-const generateStepId = () => {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return Math.random().toString(36).slice(2, 10);
-};
-
-const createStep = (ownerId: string): FlowStep => ({
-  id: generateStepId(),
-  title: '',
-  description: '',
-  ownerId,
-  due: '',
-});
-
-const PRIORITY_OPTIONS: Array<{
-  value: 'LOW' | 'MEDIUM' | 'HIGH';
-  label: string;
-  color: string;
-}> = [
-  { value: 'LOW', label: 'Low Priority', color: '#6B7280' },
-  { value: 'MEDIUM', label: 'Medium Priority', color: '#F59E0B' },
-  { value: 'HIGH', label: 'High Priority', color: '#EF4444' },
-];
+import TaskForm from '@/components/task-form';
 
 function NewTaskPageInner() {
   const router = useRouter();
   const { user, status, isLoading } = useAuth();
   const { showToast } = useToast();
-  const currentUserId = user?.userId ?? '';
-  const [users, setUsers] = useState<User[]>([]);
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
     if (status === 'unauthenticated' && !isLoading) {
       router.push('/login');
     }
   }, [isLoading, router, status]);
-
-  useEffect(() => {
-    if (status !== 'authenticated') return;
-    const load = async () => {
-      const res = await fetch('/api/users', { credentials: 'include' });
-      if (res.ok) {
-        const data = (await res.json()) as User[];
-        setUsers(data);
-      }
-    };
-    void load();
-  }, [status]);
-
-  const [flowTitle, setFlowTitle] = useState('');
-  const [priority, setPriority] = useState<'LOW' | 'MEDIUM' | 'HIGH'>('LOW');
-  const [steps, setSteps] = useState<FlowStep[]>([createStep(currentUserId)]);
-  const [flowError, setFlowError] = useState<string | null>(null);
-
-  const selectedPriority = PRIORITY_OPTIONS.find((option) => option.value === priority);
-
-  useEffect(() => {
-    if (!currentUserId) return;
-    setSteps((prev) =>
-      prev.map((step) => (step.ownerId ? step : { ...step, ownerId: currentUserId })),
-    );
-  }, [currentUserId]);
-
-  const addStep = () => setSteps((prev) => [...prev, createStep(currentUserId)]);
-
-  const handleCancel = () => {
-    router.push('/tasks');
-  };
-
-  const updateStep = (
-    id: string,
-    key: 'title' | 'description' | 'ownerId' | 'due',
-    value: string,
-  ) => {
-    setSteps((prev) =>
-      prev.map((s: FlowStep) => (s.id === id ? { ...s, [key]: value } : s)),
-    );
-  };
-
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
-    if (!over || active.id === over.id) return;
-    setSteps((prev) => {
-      const oldIndex = prev.findIndex((step) => step.id === active.id);
-      const newIndex = prev.findIndex((step) => step.id === over.id);
-      if (oldIndex === -1 || newIndex === -1) {
-        return prev;
-      }
-      return arrayMove(prev, oldIndex, newIndex);
-    });
-  };
-
-  const submitFlow = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setFlowError(null);
-    try {
-      const body = {
-        title: flowTitle,
-        priority,
-        steps: steps.map((s: FlowStep) => ({
-          title: s.title,
-          description: s.description,
-          ownerId: s.ownerId,
-          dueAt: s.due || undefined,
-        })),
-      };
-      const resp = await fetch('/api/tasks', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(body),
-      });
-      if (!resp.ok) {
-        const err = (await resp.json().catch(() => ({}))) as { detail?: string };
-        setFlowError(err.detail ?? 'Failed to create task');
-        return;
-      }
-      const task = (await resp.json()) as { _id?: string };
-      showToast({ message: 'Task created successfully', tone: 'success', duration: 5000 });
-      if (typeof task._id === 'string') {
-        router.push(`/tasks/${task._id}`);
-      } else {
-        router.push('/tasks');
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to create task';
-      setFlowError(message);
-    }
-  };
 
   if (status === 'loading') {
     return <div className="p-4">Loading…</div>;
@@ -165,95 +27,41 @@ function NewTaskPageInner() {
     return null;
   }
 
+  const currentUserId = user?.userId ?? '';
+
   return (
-    <div className="min-h-screen bg-[#F9FAFB] px-8 py-6">
-      <form onSubmit={submitFlow} className="mx-auto max-w-3xl space-y-6">
-        <Card className="space-y-5">
-          <h2 className="text-lg font-semibold text-[#111827]">Task Info</h2>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-[#4B5563]" htmlFor="flow-title">
-                Title
-              </label>
-              <Input
-                id="flow-title"
-                placeholder="Enter task title"
-                value={flowTitle}
-                onChange={(e) => setFlowTitle(e.target.value)}
-                className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="block text-sm font-medium text-[#4B5563]" htmlFor="priority">
-                Priority
-              </label>
-              <div className="relative">
-                <span
-                  aria-hidden="true"
-                  className="pointer-events-none absolute left-3 top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-full"
-                  style={{ backgroundColor: selectedPriority?.color ?? '#6B7280' }}
-                />
-                <Select
-                  id="priority"
-                  value={priority}
-                  onChange={(e) => setPriority(e.target.value as 'LOW' | 'MEDIUM' | 'HIGH')}
-                  className="flex h-10 w-full appearance-none rounded-lg border border-[#E5E7EB] bg-white pl-9 pr-10 text-sm transition-shadow focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0 hover:border-indigo-300 hover:shadow-sm"
-                  style={{ color: selectedPriority?.color ?? '#6B7280' }}
-                >
-                  {PRIORITY_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value} style={{ color: option.color }}>
-                      ● {option.label}
-                    </option>
-                  ))}
-                </Select>
-              </div>
-            </div>
-          </div>
-        </Card>
-
-        <Card className="space-y-5">
-          <h2 className="text-lg font-semibold text-[#111827]">Steps</h2>
-          <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-            <SortableContext items={steps.map((step) => step.id)}>
-              {steps.map((step, index) => (
-                <StepCard
-                  key={step.id}
-                  step={step}
-                  index={index}
-                  users={users}
-                  onUpdate={updateStep}
-                  showDivider={index > 0}
-                />
-              ))}
-            </SortableContext>
-          </DndContext>
-        </Card>
-
-        <div className="flex justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={addStep}
-            className="border-indigo-200 text-indigo-600 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700"
-          >
-            Add Step
-          </Button>
-        </div>
-
-        {flowError && <p className="text-sm text-red-600">{flowError}</p>}
-        <div className="flex justify-end gap-3">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleCancel}
-            className="border-[#E5E7EB] text-[#4B5563] hover:border-[#D1D5DB] hover:bg-[#F3F4F6] hover:text-[#1F2937]"
-          >
-            Cancel
-          </Button>
-          <Button type="submit">Create Task</Button>
-        </div>
-      </form>
-    </div>
+    <TaskForm
+      currentUserId={currentUserId}
+      submitLabel="Create Task"
+      submitPendingLabel="Creating…"
+      onCancel={() => router.push('/tasks')}
+      onSubmit={async (values) => {
+        if (isRedirecting) return;
+        try {
+          const resp = await fetch('/api/tasks', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify(values),
+          });
+          if (!resp.ok) {
+            const err = (await resp.json().catch(() => ({}))) as { detail?: string };
+            return { error: err.detail ?? 'Failed to create task' };
+          }
+          const task = (await resp.json()) as { _id?: string };
+          showToast({ message: 'Task created successfully', tone: 'success', duration: 5000 });
+          setIsRedirecting(true);
+          if (typeof task._id === 'string') {
+            router.push(`/tasks/${task._id}`);
+          } else {
+            router.push('/tasks');
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : 'Failed to create task';
+          return { error: message };
+        }
+      }}
+    />
   );
 }
 
@@ -262,141 +70,5 @@ export default function NewTaskPage() {
     <SessionProvider>
       <NewTaskPageInner />
     </SessionProvider>
-  );
-}
-
-function StepCard({
-  step,
-  index,
-  users,
-  onUpdate,
-  showDivider,
-}: {
-  step: FlowStep;
-  index: number;
-  users: User[];
-  onUpdate: (id: string, key: 'title' | 'description' | 'ownerId' | 'due', value: string) => void;
-  showDivider: boolean;
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: step.id,
-  });
-
-  const style: CSSProperties = {
-    transform: transform ? CSS.Transform.toString(transform) : undefined,
-    transition,
-  };
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(showDivider && 'mt-4 border-t border-[#E5E7EB] pt-4', 'relative')}
-    >
-      <div
-        className={cn(
-          'flex gap-4 rounded-[12px] border border-[#E5E7EB] bg-white p-6 shadow-sm transition-shadow',
-          isDragging && 'shadow-md ring-2 ring-indigo-200 ring-offset-2',
-        )}
-      >
-        <button
-          type="button"
-          aria-label={`Reorder step ${index + 1}`}
-          {...attributes}
-          {...listeners}
-          className={cn(
-            'flex h-10 w-10 shrink-0 cursor-grab items-center justify-center rounded-md text-[#9CA3AF] transition-colors hover:text-[#4B5563] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 focus-visible:ring-offset-2',
-            isDragging && 'cursor-grabbing',
-          )}
-        >
-          <GripIcon className="h-5 w-5" />
-          <span className="sr-only">Drag handle</span>
-        </button>
-        <div className="flex-1 space-y-4">
-          <div className="space-y-2">
-            <label
-              className="block text-sm font-medium text-[#4B5563]"
-              htmlFor={`step-title-${step.id}`}
-            >
-              Step Name
-            </label>
-            <Input
-              id={`step-title-${step.id}`}
-              placeholder="Enter step name"
-              value={step.title}
-              onChange={(e) => onUpdate(step.id, 'title', e.target.value)}
-              className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
-            />
-          </div>
-          <div className="space-y-2">
-            <label
-              className="block text-sm font-medium text-[#4B5563]"
-              htmlFor={`step-description-${step.id}`}
-            >
-              Description
-            </label>
-            <Textarea
-              id={`step-description-${step.id}`}
-              placeholder="Describe the work to be completed"
-              value={step.description}
-              onChange={(e) => onUpdate(step.id, 'description', e.target.value)}
-              className="min-h-[120px] border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
-            />
-          </div>
-          <div className="space-y-2">
-            <label
-              className="block text-sm font-medium text-[#4B5563]"
-              htmlFor={`step-owner-${step.id}`}
-            >
-              Assignee
-            </label>
-            <select
-              id={`step-owner-${step.id}`}
-              value={step.ownerId}
-              onChange={(e) => onUpdate(step.id, 'ownerId', e.target.value)}
-              className="flex h-10 w-full rounded-lg border border-[#E5E7EB] bg-white px-3 py-2 text-sm text-[#111827] transition-shadow focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0 hover:border-indigo-300 hover:shadow-sm"
-            >
-              <option value="">Select assignee</option>
-              {users.map((u) => (
-                <option key={u._id} value={u._id}>
-                  {u.name}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="space-y-2">
-            <label className="block text-sm font-medium text-[#4B5563]" htmlFor={`step-due-${step.id}`}>
-              Due Date
-            </label>
-            <Input
-              id={`step-due-${step.id}`}
-              type="date"
-              value={step.due}
-              onChange={(e) => onUpdate(step.id, 'due', e.target.value)}
-              className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function GripIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 20 20"
-      fill="currentColor"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <circle cx="6" cy="5" r="1.2" />
-      <circle cx="6" cy="10" r="1.2" />
-      <circle cx="6" cy="15" r="1.2" />
-      <circle cx="14" cy="5" r="1.2" />
-      <circle cx="14" cy="10" r="1.2" />
-      <circle cx="14" cy="15" r="1.2" />
-    </svg>
   );
 }

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Avatar } from '@/components/ui/avatar';
 import { Badge, type BadgeProps } from '@/components/ui/badge';
 
@@ -54,21 +55,14 @@ const getBadgeVariant = (value?: string): BadgeProps['variant'] => {
 };
 
 export default function TaskCard({ task, onChange, href, canEdit = true }: TaskCardProps) {
+  const router = useRouter();
   const normalizedStatus = task.status?.trim().toUpperCase();
   const isDone = normalizedStatus === 'DONE';
   const showActions = canEdit && !isDone;
 
-  const handleEdit = async () => {
+  const handleEdit = () => {
     if (!showActions) return;
-    const title = prompt('New title', task.title);
-    if (title) {
-      await fetch(`/api/tasks/${task._id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title }),
-      });
-      onChange?.();
-    }
+    router.push(`/tasks/${task._id}/edit`);
   };
 
   const handleDelete = async () => {
@@ -115,7 +109,7 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
         <div className="mt-2 flex justify-end gap-2 sm:justify-start">
           <button
             type="button"
-            onClick={() => void handleEdit()}
+            onClick={() => handleEdit()}
             className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[#E5E7EB] text-[#4B5563] transition-colors hover:bg-[rgba(79,70,229,0.08)] hover:text-[#4338CA] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30 focus:ring-offset-2 focus:ring-offset-white"
             aria-label="Edit task"
             title="Edit task"

--- a/src/components/task-form.tsx
+++ b/src/components/task-form.tsx
@@ -1,0 +1,459 @@
+'use client';
+
+import { useState, useEffect, type CSSProperties, useMemo } from 'react';
+import { DndContext, type DragEndEvent, closestCenter } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Select } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+
+export interface TaskFormUser {
+  _id: string;
+  name: string;
+}
+
+export interface TaskFormStepInput {
+  title: string;
+  description: string;
+  ownerId: string;
+  dueAt?: string | null;
+}
+
+export interface TaskFormValues {
+  title: string;
+  priority: 'LOW' | 'MEDIUM' | 'HIGH';
+  steps: TaskFormStepInput[];
+}
+
+export interface TaskFormSubmitValues {
+  title: string;
+  priority: 'LOW' | 'MEDIUM' | 'HIGH';
+  steps: Array<{
+    title: string;
+    description: string;
+    ownerId: string;
+    dueAt?: string;
+  }>;
+}
+
+export interface TaskFormProps {
+  currentUserId: string;
+  initialValues?: Partial<TaskFormValues>;
+  onSubmit: (values: TaskFormSubmitValues) => Promise<void | { error?: string }>;
+  onCancel?: () => void;
+  submitLabel?: string;
+  submitPendingLabel?: string;
+}
+
+interface InternalStep {
+  id: string;
+  title: string;
+  description: string;
+  ownerId: string;
+  due: string;
+}
+
+const PRIORITY_OPTIONS: Array<{
+  value: 'LOW' | 'MEDIUM' | 'HIGH';
+  label: string;
+  color: string;
+}> = [
+  { value: 'LOW', label: 'Low Priority', color: '#6B7280' },
+  { value: 'MEDIUM', label: 'Medium Priority', color: '#F59E0B' },
+  { value: 'HIGH', label: 'High Priority', color: '#EF4444' },
+];
+
+const generateStepId = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const toDateInputValue = (dueAt?: string | null) => {
+  if (!dueAt) return '';
+  try {
+    const date = new Date(dueAt);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toISOString().slice(0, 10);
+  } catch {
+    return '';
+  }
+};
+
+const mapInitialSteps = (steps: TaskFormStepInput[] | undefined, fallbackOwnerId: string): InternalStep[] => {
+  if (!steps?.length) {
+    return [
+      {
+        id: generateStepId(),
+        title: '',
+        description: '',
+        ownerId: fallbackOwnerId,
+        due: '',
+      },
+    ];
+  }
+
+  return steps.map((step) => ({
+    id: generateStepId(),
+    title: step.title ?? '',
+    description: step.description ?? '',
+    ownerId: step.ownerId ?? fallbackOwnerId,
+    due: toDateInputValue(step.dueAt),
+  }));
+};
+
+export default function TaskForm({
+  currentUserId,
+  initialValues,
+  onSubmit,
+  onCancel,
+  submitLabel = 'Save Task',
+  submitPendingLabel,
+}: TaskFormProps) {
+  const [users, setUsers] = useState<TaskFormUser[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [flowTitle, setFlowTitle] = useState(initialValues?.title ?? '');
+  const [priority, setPriority] = useState<'LOW' | 'MEDIUM' | 'HIGH'>(
+    initialValues?.priority ?? 'LOW',
+  );
+  const [steps, setSteps] = useState<InternalStep[]>(() =>
+    mapInitialSteps(initialValues?.steps, currentUserId),
+  );
+  const [flowError, setFlowError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      try {
+        const res = await fetch('/api/users', { credentials: 'include' });
+        if (!res.ok) return;
+        const data = (await res.json()) as TaskFormUser[];
+        if (isMounted) setUsers(data);
+      } catch {
+        // swallow fetch errors; list will remain empty
+      }
+    };
+    void load();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setFlowTitle(initialValues?.title ?? '');
+  }, [initialValues?.title]);
+
+  useEffect(() => {
+    setPriority(initialValues?.priority ?? 'LOW');
+  }, [initialValues?.priority]);
+
+  useEffect(() => {
+    setSteps(mapInitialSteps(initialValues?.steps, currentUserId));
+  }, [currentUserId, initialValues?.steps]);
+
+  useEffect(() => {
+    if (!currentUserId) return;
+    setSteps((prev) =>
+      prev.map((step) => (step.ownerId ? step : { ...step, ownerId: currentUserId })),
+    );
+  }, [currentUserId]);
+
+  const selectedPriority = useMemo(
+    () => PRIORITY_OPTIONS.find((option) => option.value === priority),
+    [priority],
+  );
+
+  const addStep = () =>
+    setSteps((prev) => [
+      ...prev,
+      {
+        id: generateStepId(),
+        title: '',
+        description: '',
+        ownerId: currentUserId,
+        due: '',
+      },
+    ]);
+
+  const updateStep = (
+    id: string,
+    key: 'title' | 'description' | 'ownerId' | 'due',
+    value: string,
+  ) => {
+    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, [key]: value } : s)));
+  };
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    setSteps((prev) => {
+      const oldIndex = prev.findIndex((step) => step.id === active.id);
+      const newIndex = prev.findIndex((step) => step.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) {
+        return prev;
+      }
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  };
+
+  const submitFlow = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+    setFlowError(null);
+    setIsSubmitting(true);
+    try {
+      const payload: TaskFormSubmitValues = {
+        title: flowTitle,
+        priority,
+        steps: steps.map((step) => {
+          const base = {
+            title: step.title,
+            description: step.description,
+            ownerId: step.ownerId,
+          };
+          if (!step.due) {
+            return base;
+          }
+          return {
+            ...base,
+            dueAt: new Date(step.due + 'T00:00:00Z').toISOString(),
+          };
+        }),
+      };
+
+      const result = await onSubmit(payload);
+      if (result && 'error' in result && result.error) {
+        setFlowError(result.error);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to save task';
+      setFlowError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#F9FAFB] px-8 py-6">
+      <form onSubmit={submitFlow} className="mx-auto max-w-3xl space-y-6">
+        <Card className="space-y-5">
+          <h2 className="text-lg font-semibold text-[#111827]">Task Info</h2>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-[#4B5563]" htmlFor="flow-title">
+                Title
+              </label>
+              <Input
+                id="flow-title"
+                placeholder="Enter task title"
+                value={flowTitle}
+                onChange={(e) => setFlowTitle(e.target.value)}
+                className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-[#4B5563]" htmlFor="priority">
+                Priority
+              </label>
+              <div className="relative">
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-3 top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-full"
+                  style={{ backgroundColor: selectedPriority?.color ?? '#6B7280' }}
+                />
+                <Select
+                  id="priority"
+                  value={priority}
+                  onChange={(e) =>
+                    setPriority(e.target.value as 'LOW' | 'MEDIUM' | 'HIGH')
+                  }
+                  className="flex h-10 w-full appearance-none rounded-lg border border-[#E5E7EB] bg-white pl-9 pr-10 text-sm transition-shadow focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0 hover:border-indigo-300 hover:shadow-sm"
+                  style={{ color: selectedPriority?.color ?? '#6B7280' }}
+                >
+                  {PRIORITY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value} style={{ color: option.color }}>
+                      ● {option.label}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <Card className="space-y-5">
+          <h2 className="text-lg font-semibold text-[#111827]">Steps</h2>
+          <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={steps.map((step) => step.id)}>
+              {steps.map((step, index) => (
+                <StepCard
+                  key={step.id}
+                  step={step}
+                  index={index}
+                  users={users}
+                  onUpdate={updateStep}
+                  showDivider={index > 0}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+        </Card>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={addStep}
+            className="border-indigo-200 text-indigo-600 hover:border-indigo-300 hover:bg-indigo-50 hover:text-indigo-700"
+          >
+            Add Step
+          </Button>
+        </div>
+
+        {flowError && <p className="text-sm text-red-600">{flowError}</p>}
+        <div className="flex justify-end gap-3">
+          {onCancel ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              className="border-[#E5E7EB] text-[#4B5563] hover:border-[#D1D5DB] hover:bg-[#F3F4F6] hover:text-[#1F2937]"
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+          ) : null}
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? submitPendingLabel ?? submitLabel : submitLabel}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function StepCard({
+  step,
+  index,
+  users,
+  onUpdate,
+  showDivider,
+}: {
+  step: InternalStep;
+  index: number;
+  users: TaskFormUser[];
+  onUpdate: (id: string, key: 'title' | 'description' | 'ownerId' | 'due', value: string) => void;
+  showDivider: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: step.id,
+  });
+
+  const style: CSSProperties = {
+    transform: transform ? CSS.Transform.toString(transform) : undefined,
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(showDivider && 'mt-4 border-t border-[#E5E7EB] pt-4', 'relative')}
+    >
+      <div
+        className={cn(
+          'flex gap-4 rounded-[12px] border border-[#E5E7EB] bg-white p-6 shadow-sm transition-shadow',
+          isDragging && 'shadow-md ring-2 ring-indigo-200 ring-offset-2',
+        )}
+      >
+        <button
+          type="button"
+          aria-label={`Reorder step ${index + 1}`}
+          {...attributes}
+          {...listeners}
+          className={cn(
+            'flex h-10 w-10 shrink-0 cursor-grab items-center justify-center rounded-md text-[#9CA3AF] transition-colors hover:text-[#4B5563] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-200 focus-visible:ring-offset-2',
+            isDragging && 'cursor-grabbing',
+          )}
+        >
+          <GripIcon className="h-5 w-5" />
+          <span className="sr-only">Drag handle</span>
+        </button>
+        <div className="flex-1 space-y-4">
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-[#4B5563]" htmlFor={`step-title-${step.id}`}>
+              Step Name
+            </label>
+            <Input
+              id={`step-title-${step.id}`}
+              placeholder="Enter step name"
+              value={step.title}
+              onChange={(e) => onUpdate(step.id, 'title', e.target.value)}
+              className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-[#4B5563]" htmlFor={`step-description-${step.id}`}>
+              Description
+            </label>
+            <Textarea
+              id={`step-description-${step.id}`}
+              placeholder="Describe the work to be completed"
+              value={step.description}
+              onChange={(e) => onUpdate(step.id, 'description', e.target.value)}
+              className="min-h-[120px] border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-[#4B5563]" htmlFor={`step-owner-${step.id}`}>
+              Assignee
+            </label>
+            <select
+              id={`step-owner-${step.id}`}
+              value={step.ownerId}
+              onChange={(e) => onUpdate(step.id, 'ownerId', e.target.value)}
+              className="flex h-10 w-full rounded-lg border border-[#E5E7EB] bg-white px-3 py-2 text-sm text-[#111827] transition-shadow focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0 hover:border-indigo-300 hover:shadow-sm"
+            >
+              <option value="">Select assignee</option>
+              {users.map((user) => (
+                <option key={user._id} value={user._id}>
+                  {user.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-[#4B5563]" htmlFor={`step-due-${step.id}`}>
+              Due Date
+            </label>
+            <Input
+              id={`step-due-${step.id}`}
+              type="date"
+              value={step.due}
+              onChange={(e) => onUpdate(step.id, 'due', e.target.value)}
+              className="border-[#E5E7EB] placeholder:text-[#9CA3AF] hover:border-indigo-300 hover:shadow-sm focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:ring-offset-0"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GripIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" focusable="false">
+      <circle cx="6" cy="5" r="1.2" />
+      <circle cx="6" cy="10" r="1.2" />
+      <circle cx="6" cy="15" r="1.2" />
+      <circle cx="14" cy="5" r="1.2" />
+      <circle cx="14" cy="10" r="1.2" />
+      <circle cx="14" cy="15" r="1.2" />
+    </svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract a reusable task form component that manages flow state, drag-and-drop steps, and submission plumbing
- switch the new task page to the shared form and keep the success redirect to the detail view
- add an edit task page that preloads data into the shared form and patch-submits updates
- update task cards to route to the edit page instead of prompting inline

## Testing
- npm run lint *(fails: existing repository warnings exceed the configured zero-warning threshold)*
- npm run typecheck *(fails: repository has pre-existing TypeScript errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d0363e868c83288d581828e4fa035b