### PR TITLE
Adjust task view actions

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -285,6 +285,13 @@ function TaskPageContent({ id }: { id: string }) {
             </div>
             {canEdit ? (
               <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => router.push(`/tasks/${id}/edit`)}
+                >
+                  Edit Task
+                </Button>
                 {actions.map((a, index) => (
                   <Button
                     key={a.action}

--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -366,53 +366,53 @@ export default function TaskDetail({
           </div>
         </div>
       </Card>
-      <Card className="flex flex-col gap-4">
-        {loopLoading ? (
-          <div className="text-sm text-gray-500">Loading loop...</div>
-        ) : loop ? (
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Loop Progress
-              </span>
-              <LoopProgress
-                total={loop.sequence.length}
-                completed={
-                  loop.sequence.filter((s: LoopStep) => s.status === 'COMPLETED').length
-                }
-              />
+      {fieldsEditable ? (
+        <Card className="flex flex-col gap-4">
+          {loopLoading ? (
+            <div className="text-sm text-gray-500">Loading loop...</div>
+          ) : loop ? (
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Loop Progress
+                </span>
+                <LoopProgress
+                  total={loop.sequence.length}
+                  completed={
+                    loop.sequence.filter((s: LoopStep) => s.status === 'COMPLETED').length
+                  }
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Loop Steps
+                </span>
+                <LoopVisualizer
+                  steps={
+                    loop.sequence.map((s: LoopStep, idx) => ({
+                      id: String(idx),
+                      assignedTo: s.assignedTo ?? '',
+                      description: s.description,
+                      estimatedTime: s.estimatedTime,
+                      dependencies: s.dependencies ?? [],
+                      index: idx,
+                      status: s.status,
+                    })) as StepWithStatus[]
+                  }
+                  users={users}
+                />
+              </div>
             </div>
-            <div className="flex flex-col gap-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                Loop Steps
-              </span>
-              <LoopVisualizer
-                steps={
-                  loop.sequence.map((s: LoopStep, idx) => ({
-                    id: String(idx),
-                    assignedTo: s.assignedTo ?? '',
-                    description: s.description,
-                    estimatedTime: s.estimatedTime,
-                    dependencies: s.dependencies ?? [],
-                    index: idx,
-                    status: s.status,
-                  })) as StepWithStatus[]
-                }
-                users={users}
-              />
-            </div>
-          </div>
-        ) : (
-          <div className="text-sm text-gray-500">No loop defined yet.</div>
-        )}
-        {canEdit ? (
+          ) : (
+            <div className="text-sm text-gray-500">No loop defined yet.</div>
+          )}
           <div className="flex justify-end">
             <Button onClick={() => openLoopBuilder(id)} className="px-5">
               Manage Loop
             </Button>
           </div>
-        ) : null}
-      </Card>
+        </Card>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- hide the loop progress, visualizer, and manage button when TaskDetail is rendered in read-only mode
- add an Edit Task action in the task header that routes to the edit experience

## Testing
- npm run lint *(fails: existing repository warnings about unsafe assignments and console usage)*

------
https://chatgpt.com/codex/tasks/task_e_68d03b9d81b083288efc759e5029f585