### PR TITLE
Prepopulate loop builder and support patch saves

### DIFF
--- a/src/components/loop-builder.test.tsx
+++ b/src/components/loop-builder.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLoopSteps, type LoopStep } from '@/hooks/useLoopBuilder';
+import { buildLoopSaveRequest } from './loop-builder';
+
+describe('loop builder helpers', () => {
+  it('normalizes existing loop data without dropping steps', () => {
+    const normalized = normalizeLoopSteps([
+      { assignedTo: 'user-1', description: 'First step' },
+      { assignedTo: 'user-2', description: 'Second step', dependencies: [0] },
+    ]);
+
+    expect(normalized).toHaveLength(2);
+    expect(normalized[0]?.description).toBe('First step');
+    expect(normalized[1]?.description).toBe('Second step');
+    expect(normalized[1]?.dependencies).toHaveLength(1);
+    const dependencyId = normalized[1]?.dependencies?.[0];
+    expect(dependencyId).toBeDefined();
+    expect(normalized[0]?.id).toBe(dependencyId);
+  });
+
+  it('builds a PATCH request when editing an existing loop', () => {
+    const steps: LoopStep[] = [
+      {
+        id: '0',
+        index: 0,
+        assignedTo: 'user-1',
+        description: 'Updated description',
+        dependencies: [],
+      },
+    ];
+
+    const request = buildLoopSaveRequest(steps, true);
+    expect(request.method).toBe('PATCH');
+    expect(request.body.sequence).toEqual([
+      { index: 0, assignedTo: 'user-1', description: 'Updated description' },
+    ]);
+    expect(request.orderedSteps).toHaveLength(1);
+    expect(request.orderedSteps[0]?.description).toBe('Updated description');
+  });
+});

--- a/src/components/loop-tasks-section.tsx
+++ b/src/components/loop-tasks-section.tsx
@@ -274,8 +274,8 @@ export default function LoopTasksSection({
       onManageLoop();
       return;
     }
-    openLoopBuilder(taskId);
-  }, [onManageLoop, taskId]);
+    openLoopBuilder(taskId, loop ?? null);
+  }, [loop, onManageLoop, taskId]);
 
   return (
     <Card className={cn("flex flex-col gap-4", className)}>

--- a/src/lib/loopBuilder.ts
+++ b/src/lib/loopBuilder.ts
@@ -1,10 +1,23 @@
-let listener: ((taskId: string) => void) | null = null;
+export interface LoopBuilderData {
+  sequence?: Array<{
+    id?: string;
+    _id?: string;
+    assignedTo?: string | { _id?: string } | null;
+    description?: string | null;
+    estimatedTime?: number | null;
+    dependencies?: Array<string | number> | null;
+  }>;
+}
 
-export function registerLoopBuilder(fn: (taskId: string) => void): void {
+let listener: ((taskId: string, loop?: LoopBuilderData | null) => void) | null = null;
+
+export function registerLoopBuilder(
+  fn: (taskId: string, loop?: LoopBuilderData | null) => void
+): void {
   listener = fn;
 }
 
-export function openLoopBuilder(taskId: string): void {
-  listener?.(taskId);
+export function openLoopBuilder(taskId: string, loop?: LoopBuilderData | null): void {
+  listener?.(taskId, loop);
 }
 


### PR DESCRIPTION
## Summary
- pre-populate the loop builder using normalized loop data rather than clearing the step list
- send PATCH requests when saving updates to existing loops and wire loop data through the manage loop action
- add unit coverage for step normalization and PATCH save payloads

## Testing
- npx vitest run src/components/loop-builder.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d0c762ab488328b3e08e3d5ebe9547