### PR TITLE
Align loop dependencies with index-based identifiers

### DIFF
--- a/src/app/api/tasks/[id]/loop/post.test.ts
+++ b/src/app/api/tasks/[id]/loop/post.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Types } from 'mongoose';
+
+const mockDb = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db', () => ({ default: mockDb }));
+
+const auth = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth', () => ({ auth }));
+
+const findTaskById = vi.hoisted(() => vi.fn());
+vi.mock('@/models/Task', () => ({ Task: { findById: findTaskById } }));
+
+const createLoop = vi.hoisted(() => vi.fn());
+vi.mock('@/models/TaskLoop', () => ({ TaskLoop: { create: createLoop } }));
+
+const createHistory = vi.hoisted(() => vi.fn());
+vi.mock('@/models/LoopHistory', () => ({ LoopHistory: { create: createHistory } }));
+
+const findUsers = vi.hoisted(() => vi.fn());
+vi.mock('@/models/User', () => ({ User: { find: findUsers } }));
+
+vi.mock('@/lib/access', () => ({ canWriteTask: () => true }));
+
+const emitLoopUpdated = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/ws', () => ({ emitLoopUpdated }));
+
+import { POST } from './route';
+
+describe('POST /tasks/:id/loop', () => {
+  const taskId = new Types.ObjectId();
+  const orgId = new Types.ObjectId();
+  const userA = new Types.ObjectId();
+  const userB = new Types.ObjectId();
+
+  beforeEach(() => {
+    auth.mockReset();
+    auth.mockResolvedValue({
+      userId: new Types.ObjectId().toString(),
+      teamId: null,
+      organizationId: orgId.toString(),
+    });
+    findTaskById.mockReset();
+    findTaskById.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        _id: taskId,
+        organizationId: orgId,
+        teamId: null,
+      }),
+    });
+    findUsers.mockReset();
+    findUsers.mockReturnValue({
+      lean: vi
+        .fn()
+        .mockResolvedValue([
+          { _id: userA, organizationId: orgId },
+          { _id: userB, organizationId: orgId },
+        ]),
+    });
+    createLoop.mockReset();
+    createLoop.mockResolvedValue({
+      taskId,
+      sequence: [],
+      updatedAt: new Date(),
+    });
+    createHistory.mockReset();
+    createHistory.mockResolvedValue(null);
+    emitLoopUpdated.mockReset();
+  });
+
+  it('creates a loop with dependency indexes', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sequence: [
+          {
+            assignedTo: userA.toString(),
+            description: 'First step',
+          },
+          {
+            assignedTo: userB.toString(),
+            description: 'Second step',
+            dependencies: [0],
+          },
+        ],
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: taskId.toString() }) });
+
+    expect(res.status).toBe(200);
+    const [createArg] = createLoop.mock.calls[0] ?? [];
+    expect(createArg.sequence).toHaveLength(2);
+    expect(createArg.sequence[0]?.dependencies).toEqual([]);
+    expect(createArg.sequence[1]?.dependencies).toEqual([0]);
+    expect(createArg.sequence[0]?.assignedTo.equals(userA)).toBe(true);
+    expect(createArg.sequence[1]?.assignedTo.equals(userB)).toBe(true);
+    expect(createHistory).toHaveBeenCalledWith([
+      expect.objectContaining({ stepIndex: 0 }),
+      expect.objectContaining({ stepIndex: 1 }),
+    ]);
+    expect(emitLoopUpdated).toHaveBeenCalled();
+  });
+
+  it('rejects invalid dependency indexes', async () => {
+    const req = new Request('http://localhost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sequence: [
+          {
+            assignedTo: userA.toString(),
+            description: 'Only step',
+            dependencies: [5],
+          },
+        ],
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: taskId.toString() }) });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/components/loop-builder.test.tsx
+++ b/src/components/loop-builder.test.tsx
@@ -37,4 +37,40 @@ describe('loop builder helpers', () => {
     expect(request.orderedSteps).toHaveLength(1);
     expect(request.orderedSteps[0]?.description).toBe('Updated description');
   });
+
+  it('builds a POST request with dependency indexes for a new loop', () => {
+    const steps: LoopStep[] = [
+      {
+        id: 'step-1',
+        index: 0,
+        assignedTo: 'user-1',
+        description: 'First step',
+        dependencies: [],
+      },
+      {
+        id: 'step-2',
+        index: 1,
+        assignedTo: 'user-2',
+        description: 'Second step',
+        dependencies: ['step-1'],
+      },
+    ];
+
+    const request = buildLoopSaveRequest(steps, false);
+    expect(request.method).toBe('POST');
+    expect(request.body.sequence).toEqual([
+      {
+        assignedTo: 'user-1',
+        description: 'First step',
+        estimatedTime: undefined,
+        dependencies: [],
+      },
+      {
+        assignedTo: 'user-2',
+        description: 'Second step',
+        estimatedTime: undefined,
+        dependencies: [0],
+      },
+    ]);
+  });
 });

--- a/src/components/loop-builder.tsx
+++ b/src/components/loop-builder.tsx
@@ -17,6 +17,7 @@ export function buildLoopSaveRequest(steps: LoopStep[], hasExistingLoop: boolean
   orderedSteps: LoopStep[];
 } {
   const orderedSteps = [...steps].sort((a, b) => a.index - b.index);
+  const indexById = new Map(orderedSteps.map((step) => [step.id, step.index]));
 
   if (hasExistingLoop) {
     return {
@@ -39,11 +40,13 @@ export function buildLoopSaveRequest(steps: LoopStep[], hasExistingLoop: boolean
     method: 'POST',
     body: {
       sequence: orderedSteps.map(
-        ({ assignedTo, description, estimatedTime, dependencies }) => ({
+        ({ assignedTo, description, estimatedTime, dependencies, id }) => ({
           assignedTo,
           description,
           estimatedTime,
-          dependencies,
+          dependencies: dependencies
+            .map((depId) => indexById.get(depId))
+            .filter((value): value is number => typeof value === 'number'),
         })
       ),
     },

--- a/src/hooks/useLoopBuilder.ts
+++ b/src/hooks/useLoopBuilder.ts
@@ -42,17 +42,21 @@ export function normalizeLoopSteps(sequence?: LoopBuilderData['sequence']): Loop
     const dependenciesRaw = Array.isArray(record.dependencies)
       ? (record.dependencies as Array<string | number | null | undefined>)
       : [];
-    const dependencies = dependenciesRaw
-      .map((dep) => {
-        if (typeof dep === 'number') {
-          return baseIds[dep] ?? String(dep);
-        }
-        if (typeof dep === 'string') {
-          return dep;
-        }
-        return null;
-      })
-      .filter((value): value is string => Boolean(value));
+    const dependencies = Array.from(
+      new Set(
+        dependenciesRaw
+          .map((dep) => {
+            if (typeof dep === 'number') {
+              return baseIds[dep] ?? String(dep);
+            }
+            if (typeof dep === 'string') {
+              return dep;
+            }
+            return null;
+          })
+          .filter((value): value is string => Boolean(value))
+      )
+    );
 
     const estimatedTime = record.estimatedTime;
 
@@ -117,7 +121,8 @@ export default function useLoopBuilder() {
       return [
         ...s,
         {
-          id: Math.random().toString(36).slice(2),
+          id:
+            globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
           assignedTo: '',
           description: '',
           dependencies: [],

--- a/src/lib/loop.test.ts
+++ b/src/lib/loop.test.ts
@@ -1,91 +1,33 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Types } from 'mongoose';
+import { describe, it, expect } from 'vitest';
+import type { ILoopStep, ITaskLoop } from '@/models/TaskLoop';
+import { applyStepCompletion } from './loop';
 
-vi.mock('@/lib/db', () => ({ default: vi.fn() }));
-
-const notifyLoopStepReady = vi.fn();
-const notifyAssignment = vi.fn();
-vi.mock('@/lib/notify', () => ({ notifyLoopStepReady, notifyAssignment }));
-
-const findOne = vi.fn();
-vi.mock('@/models/TaskLoop', () => ({ TaskLoop: { findOne } }));
-
-interface Task { _id: Types.ObjectId }
-const findTaskById = vi.fn<[string], Promise<Task | null>>();
-vi.mock('@/models/Task', () => ({ Task: { findById: findTaskById } }));
-
-const createHistory = vi.fn();
-vi.mock('@/models/LoopHistory', () => ({ LoopHistory: { create: createHistory } }));
-
-import { completeStep } from './loop';
-
-interface TestLoop {
-  taskId: Types.ObjectId;
-  sequence: Array<{
-    assignedTo: Types.ObjectId;
-    status: string;
-    description?: string;
-    dependencies?: number[];
-  }>;
-  currentStep: number;
-  isActive: boolean;
-  save: () => Promise<null>;
-  parallel?: boolean;
-}
-
-describe('completeStep', () => {
-  const taskId = new Types.ObjectId();
-  const userA = new Types.ObjectId();
-  const userB = new Types.ObjectId();
-  const userC = new Types.ObjectId();
-  let loop: TestLoop;
-
-  beforeEach(() => {
-    notifyLoopStepReady.mockReset();
-    notifyAssignment.mockReset();
-    findTaskById.mockReset();
-    createHistory.mockReset();
-    loop = {
-      taskId,
-      parallel: true,
+describe('applyStepCompletion', () => {
+  it('blocks steps with unmet dependencies and activates when ready', () => {
+    const loop = {
       sequence: [
-        { assignedTo: userA, status: 'ACTIVE', dependencies: [] },
-        { assignedTo: userB, status: 'PENDING', dependencies: [0] },
-        { assignedTo: userC, status: 'PENDING', dependencies: [1] },
+        { assignedTo: 'userA', status: 'ACTIVE', dependencies: [] },
+        { assignedTo: 'userB', status: 'PENDING', dependencies: [0] },
+        { assignedTo: 'userC', status: 'PENDING', dependencies: [1] },
       ],
       currentStep: 0,
       isActive: true,
-      save: vi.fn().mockResolvedValue(null),
-    };
-    findOne.mockResolvedValue(loop);
-    findTaskById.mockResolvedValue({ _id: taskId });
-  });
+      parallel: true,
+    } satisfies Partial<ITaskLoop> & { sequence: ILoopStep[] };
 
-  it('blocks steps with unmet dependencies and activates when ready', async () => {
-    let res = await completeStep(taskId.toString(), 0, userA.toString());
-    expect(res).toBe(loop);
+    const first = applyStepCompletion(loop as ITaskLoop, 0);
+    expect(first.completed).toBe(true);
+    expect(first.newlyActiveIndexes).toEqual([1]);
     expect(loop.sequence[0]?.status).toBe('COMPLETED');
     expect(loop.sequence[1]?.status).toBe('ACTIVE');
     expect(loop.sequence[2]?.status).toBe('BLOCKED');
     expect(loop.currentStep).toBe(1);
-    expect(notifyAssignment).toHaveBeenCalledWith([userB], { _id: taskId }, undefined);
-    expect(notifyLoopStepReady).toHaveBeenCalledWith([userB], { _id: taskId }, undefined);
 
-    expect(createHistory).toHaveBeenCalledWith(
-      expect.objectContaining({ stepIndex: 0 })
-    );
-
-    notifyLoopStepReady.mockClear();
-    res = await completeStep(taskId.toString(), 1, userB.toString());
+    const second = applyStepCompletion(loop as ITaskLoop, 1);
+    expect(second.completed).toBe(true);
+    expect(second.newlyActiveIndexes).toEqual([2]);
     expect(loop.sequence[1]?.status).toBe('COMPLETED');
     expect(loop.sequence[2]?.status).toBe('ACTIVE');
     expect(loop.currentStep).toBe(2);
-    expect(notifyAssignment).toHaveBeenCalledWith([userC], { _id: taskId }, undefined);
-    expect(notifyLoopStepReady).toHaveBeenCalledWith([userC], { _id: taskId }, undefined);
-    expect(createHistory).toHaveBeenCalledWith(
-      expect.objectContaining({ stepIndex: 1 })
-    );
-    expect(createHistory).toHaveBeenCalledTimes(2);
   });
 });
-

--- a/src/models/TaskLoop.ts
+++ b/src/models/TaskLoop.ts
@@ -30,7 +30,7 @@ const loopStepSchema = new Schema(
     actualTime: { type: Number },
     completedAt: Date,
     comments: String,
-    dependencies: [{ type: Schema.Types.ObjectId }],
+    dependencies: [{ type: Number }],
   },
   {
     _id: false,


### PR DESCRIPTION
## Summary
- send dependency indexes from the loop builder instead of random ids and dedupe them during normalization
- persist loop dependencies as numeric indexes in the API/model and drop object id casting
- extract dependency resolution into `applyStepCompletion` and cover loop creation/completion with new tests

## Testing
- npm run test -- src/components/loop-builder.test.tsx src/lib/loop.test.ts src/app/api/tasks/[id]/loop/post.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0c9f44cd483288ed1844c7cf45ecc