### PR TITLE
Adjust loop dependencies to accumulate

### DIFF
--- a/src/lib/taskLoopSync.test.ts
+++ b/src/lib/taskLoopSync.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { Types } from 'mongoose';
+import { prepareLoopFromSteps } from './taskLoopSync';
+
+const buildStep = (ownerId: Types.ObjectId, title: string) => ({
+  title,
+  ownerId,
+  status: 'OPEN' as const,
+});
+
+describe('prepareLoopFromSteps', () => {
+  it('assigns cumulative dependencies for each step', () => {
+    const taskId = new Types.ObjectId();
+    const steps = [
+      buildStep(new Types.ObjectId(), 'First'),
+      buildStep(new Types.ObjectId(), 'Second'),
+      buildStep(new Types.ObjectId(), 'Third'),
+    ];
+
+    const result = prepareLoopFromSteps(taskId, steps, 0, 'OPEN');
+
+    expect(result).not.toBeNull();
+    expect(result?.sequence[0]?.dependencies).toEqual([]);
+    expect(result?.sequence[1]?.dependencies).toEqual([0]);
+    expect(result?.sequence[2]?.dependencies).toEqual([0, 1]);
+  });
+});

--- a/src/lib/taskLoopSync.ts
+++ b/src/lib/taskLoopSync.ts
@@ -57,12 +57,15 @@ export function prepareLoopFromSteps(
       status = 'BLOCKED';
     }
 
+    const dependencies =
+      idx === 0 ? [] : Array.from({ length: idx }, (_, depIndex) => depIndex);
+
     return {
       taskId,
       assignedTo: new Types.ObjectId(step.ownerId),
       description: resolveDescription(step, idx),
       status,
-      dependencies: idx === 0 ? [] : [idx - 1],
+      dependencies,
       completedAt: completed ? step.completedAt : undefined,
     } satisfies PreparedLoopData['sequence'][number];
   });


### PR DESCRIPTION
## Summary
- generate cumulative dependency indexes when preparing loop data from task steps so each step depends on all prior steps
- add a unit test covering the new dependency ordering

## Testing
- npm test *(fails: e2e Playwright specs and mocked module suites that already error in the baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bce20dc08328a40be271b1c67094