### PR TITLE
Implement sequential step status handling

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -83,7 +83,7 @@ export async function seed() {
       ownerId: user1._id,
       organizationId: org._id,
       teamId: team._id,
-      status: 'FLOW_IN_PROGRESS',
+      status: 'OPEN',
       steps: [
         { title: 'Step 1', ownerId: user1._id, status: 'OPEN' },
         { title: 'Step 2', ownerId: user2._id, status: 'OPEN' },

--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { Types, startSession } from 'mongoose';
 import type { ClientSession } from 'mongoose';
 import dbConnect from '@/lib/db';
-import { Task, type IStep } from '@/models/Task';
+import { Task, deriveTaskStatusFromSteps, resolveCurrentStepIndex } from '@/models/Task';
+import type { IStep } from '@/models/Task';
 import { ActivityLog } from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { emitTaskTransition } from '@/lib/ws';
@@ -102,48 +103,62 @@ export async function POST(
   };
 
   if (task.steps?.length) {
-    // Only DONE is meaningful when steps exist
-    if (body.action !== 'DONE') {
-      return problem(400, 'Invalid action', 'Only DONE is allowed for step tasks');
+    if (body.action !== 'START' && body.action !== 'DONE') {
+      return problem(400, 'Invalid action', 'Only START or DONE is allowed for step tasks');
     }
     if (!isOwner && !isAdmin) {
       return problem(
         403,
         'Forbidden',
-        'Only the current step owner or an admin may complete the step'
+        'Only the current step owner or an admin may update the step'
       );
     }
 
     let completedStepIndex = -1;
+    type StepFailure = 'NONE' | 'STEP_MISSING' | 'STEP_DONE' | 'STEP_NOT_READY';
     const performStepTransition = async (
       session?: ClientSession
-    ): Promise<{ updated: ITask | null; failure: 'NONE' | 'STEP_MISSING' | 'STEP_DONE' }> => {
+    ): Promise<{ updated: ITask | null; failure: StepFailure }> => {
       const t = (session
         ? ((await Task.findById(task._id).session(session)) as ITask | null)
         : ((await Task.findById(task._id)) as ITask | null));
       if (!t) throw new Error('Task not found');
       if (!t.steps) throw new Error('Task steps missing');
-      const idx = t.currentStepIndex ?? 0;
+
+      const idx = resolveCurrentStepIndex(t.steps);
       const step = t.steps[idx];
       if (!step) {
         return { updated: null, failure: 'STEP_MISSING' };
       }
-      if (step.status === 'DONE') {
-        return { updated: null, failure: 'STEP_DONE' };
-      }
-      completedStepIndex = idx;
-      step.status = 'DONE';
-      step.completedAt = new Date();
 
-      const allDone = t.steps.every((s: IStep) => s.status === 'DONE');
-      if (allDone) {
-        t.status = 'DONE';
+      if (body.action === 'START') {
+        if (step.status === 'DONE') {
+          return { updated: null, failure: 'STEP_DONE' };
+        }
+        if (step.status !== 'IN_PROGRESS') {
+          step.status = 'IN_PROGRESS';
+          step.completedAt = undefined;
+        }
       } else {
-        const nextIdx = t.steps.findIndex((s: IStep) => s.status !== 'DONE');
-        t.currentStepIndex = nextIdx;
-        t.ownerId = t.steps[nextIdx].ownerId;
-        t.status = 'FLOW_IN_PROGRESS';
+        if (step.status === 'DONE') {
+          return { updated: null, failure: 'STEP_DONE' };
+        }
+        if (step.status !== 'IN_PROGRESS') {
+          return { updated: null, failure: 'STEP_NOT_READY' };
+        }
+        completedStepIndex = idx;
+        step.status = 'DONE';
+        step.completedAt = new Date();
       }
+
+      t.currentStepIndex = resolveCurrentStepIndex(t.steps);
+      t.status = deriveTaskStatusFromSteps(t.steps as IStep[]);
+      const activeIdx = t.currentStepIndex;
+      const activeStep = t.steps[activeIdx] ?? t.steps[t.steps.length - 1];
+      if (activeStep) {
+        t.ownerId = activeStep.ownerId;
+      }
+
       if (session) {
         await t.save({ session });
       } else {
@@ -166,7 +181,7 @@ export async function POST(
     };
 
     const mongoSession = await startSession();
-    let result: { updated: ITask | null; failure: 'NONE' | 'STEP_MISSING' | 'STEP_DONE' } = {
+    let result: { updated: ITask | null; failure: StepFailure } = {
       updated: null,
       failure: 'NONE',
     };
@@ -191,6 +206,9 @@ export async function POST(
       }
       if (failure === 'STEP_DONE') {
         return problem(409, 'Conflict', 'Step already completed');
+      }
+      if (failure === 'STEP_NOT_READY') {
+        return problem(409, 'Conflict', 'Step must be in progress before completion');
       }
       return problem(500, 'Error', 'Transition failed');
     }

--- a/src/lib/schemas/taskStep.ts
+++ b/src/lib/schemas/taskStep.ts
@@ -7,7 +7,7 @@ export const stepSchema: z.ZodType<TaskStepPayload> = z
     ownerId: z.string(),
     description: z.string().optional(),
     dueAt: z.coerce.date().optional(),
-    status: z.enum(['OPEN', 'DONE']).optional(),
+    status: z.enum(['OPEN', 'IN_PROGRESS', 'DONE']).optional(),
     completedAt: z.coerce.date().optional(),
   });
 

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -22,8 +22,22 @@ export interface IStep {
   ownerId: Types.ObjectId;
   description?: string;
   dueAt?: Date;
-  status: 'OPEN' | 'DONE';
+  status: 'OPEN' | 'IN_PROGRESS' | 'DONE';
   completedAt?: Date;
+}
+
+export function deriveTaskStatusFromSteps(steps: IStep[]): TaskStatus {
+  if (!steps.length) return 'OPEN';
+  if (steps.every((step) => step.status === 'DONE')) return 'DONE';
+  const hasProgress = steps.some((step) => step.status !== 'OPEN');
+  return hasProgress ? 'IN_PROGRESS' : 'OPEN';
+}
+
+export function resolveCurrentStepIndex(steps: IStep[]): number {
+  if (!steps.length) return 0;
+  const next = steps.findIndex((step) => step.status !== 'DONE');
+  if (next === -1) return steps.length - 1;
+  return next;
 }
 
 const stepSchema = new Schema<IStep>(
@@ -32,7 +46,7 @@ const stepSchema = new Schema<IStep>(
     ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     description: String,
     dueAt: Date,
-    status: { type: String, enum: ['OPEN', 'DONE'], default: 'OPEN' },
+    status: { type: String, enum: ['OPEN', 'IN_PROGRESS', 'DONE'], default: 'OPEN' },
     completedAt: Date,
   },
   { _id: false }

--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -5,7 +5,7 @@ export interface TaskStepPayload {
   ownerId: string;
   description?: string | undefined;
   dueAt?: Date | undefined;
-  status?: 'OPEN' | 'DONE' | undefined;
+  status?: 'OPEN' | 'IN_PROGRESS' | 'DONE' | undefined;
   completedAt?: Date | undefined;
 }
 
@@ -46,7 +46,7 @@ export interface TaskStep {
   ownerId: string;
   description?: string | undefined;
   dueAt?: string | undefined;
-  status: 'OPEN' | 'DONE';
+  status: 'OPEN' | 'IN_PROGRESS' | 'DONE';
   completedAt?: string | undefined;
 }
 


### PR DESCRIPTION
## Summary
- add helpers for deriving task step status and active index
- update task creation, editing, and transition APIs to enforce OPEN → IN_PROGRESS → DONE flow
- expose step status controls in the task detail UI with gating based on the current step and adjust tests/types

## Testing
- npm run lint *(fails: repository contains existing lint warnings exceeding max)*
- npm run typecheck *(fails: repository has numerous pre-existing TypeScript errors)*
- npm test *(fails: existing test suite issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d6c065388328abb3d67145e9fb10