### PR TITLE
Allow task creators to transition steps

### DIFF
--- a/src/app/api/tasks/[id]/transition/route.ts
+++ b/src/app/api/tasks/[id]/transition/route.ts
@@ -106,11 +106,11 @@ export async function POST(
     if (body.action !== 'START' && body.action !== 'DONE') {
       return problem(400, 'Invalid action', 'Only START or DONE is allowed for step tasks');
     }
-    if (!isOwner && !isAdmin) {
+    if (!isOwner && !isAdmin && !isCreator) {
       return problem(
         403,
         'Forbidden',
-        'Only the current step owner or an admin may update the step'
+        'Only the current step owner, task creator, or an admin may update the step'
       );
     }
 


### PR DESCRIPTION
## Summary
- allow task creators to transition step-based tasks alongside owners and admins
- update the authorization error message for step transitions

## Testing
- npm run lint *(fails: existing warnings across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dd3052dc8328a761dbc8c61fe58b