### PR TITLE
Allow step owners to view tasks

### DIFF
--- a/src/lib/access.test.ts
+++ b/src/lib/access.test.ts
@@ -8,6 +8,7 @@ describe('task access', () => {
   const ownerId = new Types.ObjectId();
   const helperId = new Types.ObjectId();
   const mentionId = new Types.ObjectId();
+  const stepOwnerId = new Types.ObjectId();
   const teamId = new Types.ObjectId();
   const otherTeamId = new Types.ObjectId();
   const otherUserId = new Types.ObjectId();
@@ -48,6 +49,17 @@ describe('task access', () => {
   it('mention can read but not write', () => {
     const task = { ...baseTask, mentions: [mentionId] };
     const user = { _id: mentionId, teamId, organizationId: orgId };
+    expect(canReadTask(user, task)).toBe(true);
+    expect(canWriteTask(user, task)).toBe(false);
+  });
+
+  it('step owner can read but not write', () => {
+    const task = {
+      ...baseTask,
+      steps: [{ ownerId: stepOwnerId }],
+      participantIds: [stepOwnerId],
+    };
+    const user = { _id: stepOwnerId, teamId, organizationId: orgId };
     expect(canReadTask(user, task)).toBe(true);
     expect(canWriteTask(user, task)).toBe(false);
   });

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -17,6 +17,7 @@ export function canReadTask(user: UserLike, task: ITask): boolean {
   if (task.ownerId?.toString() === userId) return true;
   if (task.helpers?.some((h) => h.toString() === userId)) return true;
   if (task.mentions?.some((m) => m.toString() === userId)) return true;
+  if (task.participantIds?.some((p) => p.toString() === userId)) return true;
 
   if (
     task.visibility === 'TEAM' &&


### PR DESCRIPTION
## Summary
- allow task participants from step assignments to read task details by checking participantIds
- add a unit test ensuring step owners have read access

## Testing
- npx vitest run src/lib/access.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4e216f6f08328a4e8f9c8fcc68931