### PR TITLE
Replace loop section with collaboration tabs

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -8,11 +8,11 @@ import Link from 'next/link';
 import { SessionProvider } from 'next-auth/react';
 import useAuth from '@/hooks/useAuth';
 import TaskDetail from "@/components/task-detail";
-import LoopTasksSection from "@/components/loop-tasks-section";
 import StatusBadge from "@/components/status-badge";
 import CommentThread from "@/components/comment-thread";
 import type { TimelineEvent } from "@/components/timeline/timeline";
 import Timeline from "@/components/timeline/timeline";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DeleteTaskModal from '@/components/delete-task-modal';
 import type { TaskStatus } from '@/models/Task';
 import { Button } from '@/components/ui/button';
@@ -398,222 +398,222 @@ function TaskPageContent({ id }: { id: string }) {
             ) : null}
           </div>
         </div>
-        <div className="mt-6 grid flex-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="flex flex-col gap-6">
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <div className="mb-4 flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-[#111827]">Task Information</h2>
-              </div>
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-2">
-                  <span className="text-sm font-medium text-[#374151]">Owner</span>
-                  {canEdit ? (
-                    <div className="relative">
-                      <input
-                        className="h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30"
-                        value={userQuery}
-                        onChange={(e) => setUserQuery(e.target.value)}
-                        placeholder={ownerName || 'Search users'}
-                      />
-                      {ownerErrors.ownerId ? (
-                        <span className="mt-1 block text-xs text-red-600">
-                          {ownerErrors.ownerId.message}
-                        </span>
-                      ) : null}
-                      {users.length ? (
-                        <ul className="absolute z-10 mt-2 max-h-48 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow-lg">
-                          {users.map((u) => (
-                            <li
-                              key={u._id}
-                              className="cursor-pointer px-3 py-2 text-sm text-[#111827] hover:bg-[#EEF2FF]"
-                              onClick={() => void handleOwnerSelect(u)}
-                            >
-                              {u.name || u.email}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
-                    </div>
-                  ) : (
-                    <span className="rounded-full bg-[#EEF2FF] px-3 py-1 text-sm font-medium text-[#4338CA]">
-                      {ownerName || 'Unassigned'}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </section>
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-[#111827]">Task Details</h2>
-              <div className="mt-4">
-                <TaskDetail
-                  key={task.ownerId}
-                  id={id}
-                  canEdit={canEdit}
-                  readOnly
-                  showLoopTasks={false}
-                />
-              </div>
-            </section>
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-[#111827]">Step Progress</h2>
-              <div className="mt-4 flex flex-col gap-3">
-                {task.steps?.length ? (
-                  task.steps.map((step, idx) => {
-                    const ownerInfo = stepOwners[step.ownerId];
-                    const ownerLabel = ownerInfo?.name || ownerInfo?.email || 'Unassigned';
-                    const isActive = activeStepIndex === idx && step.status !== 'DONE';
-                    const waitingOnPrevious = activeStepIndex >= 0 && idx > activeStepIndex;
-                    const isStepOwner = Boolean(step.ownerId) && step.ownerId === user?.userId;
-                    const canModify =
-                      stepUpdating === null &&
-                      isActive &&
-                      (canEdit || isStepOwner);
-
-                    const handleChange = (value: string) => {
-                      if (value === step.status) return;
-                      if (value === 'IN_PROGRESS' || value === 'DONE') {
-                        void handleStepStatusChange(idx, value as 'IN_PROGRESS' | 'DONE');
-                      }
-                    };
-
-                    return (
-                      <div
-                        key={`${step.ownerId}-${idx}`}
-                        className="rounded-lg border border-gray-200 bg-gray-50 p-4"
-                      >
-                        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                          <div>
-                            <p className="text-sm font-medium text-[#111827]">
-                              {step.title || `Step ${idx + 1}`}
-                            </p>
-                            <p className="text-xs text-[#6B7280]">
-                              Assigned to {ownerLabel}
-                              {isActive
-                                ? ' • Active'
-                                : step.status === 'DONE'
-                                  ? ' • Completed'
-                                  : ''}
-                            </p>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
-                              Status
-                            </span>
-                            <select
-                              className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-[#111827] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-[#9CA3AF]"
-                              value={step.status}
-                              onChange={(event) => handleChange(event.target.value)}
-                              disabled={!canModify}
-                            >
-                              <option value="OPEN">Open</option>
-                              <option value="IN_PROGRESS" disabled={step.status === 'DONE'}>
-                                In Progress
-                              </option>
-                              <option value="DONE" disabled={step.status === 'OPEN'}>
-                                Done
-                              </option>
-                            </select>
-                          </div>
-                        </div>
-                        {waitingOnPrevious ? (
-                          <p className="mt-2 text-xs text-[#6B7280]">
-                            Waiting for the previous step to be completed.
-                          </p>
-                        ) : null}
-                        {isActive && step.status === 'OPEN' && canEdit ? (
-                          <p className="mt-2 text-xs text-[#6B7280]">
-                            Start this step when you&apos;re ready to work on it.
-                          </p>
-                        ) : null}
-                      </div>
-                    );
-                  })
-                ) : (
-                  <p className="text-sm text-[#6B7280]">No steps defined for this task.</p>
-                )}
-              </div>
-            </section>
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-[#111827]">Loop Tasks</h2>
-              <div className="mt-4">
-                <LoopTasksSection
-                  taskId={id}
-                  canEdit={canEdit}
-                  className="border border-transparent bg-transparent p-0 shadow-none"
-                />
-              </div>
-            </section>
-            <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-[#111827]">Attachments</h2>
-              <div className="mt-4 flex flex-col gap-4">
+        <div className="mt-6 flex flex-1 flex-col gap-6">
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-[#111827]">Task Information</h2>
+            </div>
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <span className="text-sm font-medium text-[#374151]">Owner</span>
                 {canEdit ? (
-                  <form onSubmit={submitUpload(onUploadSubmit)} className="flex flex-col gap-3 rounded-lg border border-dashed border-[#C7D2FE] bg-[#EEF2FF]/40 p-4">
-                    <label className="text-sm font-medium text-[#4338CA]">
-                      Upload new file
-                      <input
-                        type="file"
-                        {...registerUpload('file')}
-                        className="mt-2 block w-full text-sm text-[#4B5563]"
-                      />
-                    </label>
-                    {uploadErrors.file ? (
-                      <span className="text-xs text-red-600">
-                        {uploadErrors.file.message as string}
+                  <div className="relative">
+                    <input
+                      className="h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30"
+                      value={userQuery}
+                      onChange={(e) => setUserQuery(e.target.value)}
+                      placeholder={ownerName || 'Search users'}
+                    />
+                    {ownerErrors.ownerId ? (
+                      <span className="mt-1 block text-xs text-red-600">
+                        {ownerErrors.ownerId.message}
                       </span>
                     ) : null}
-                    <div className="flex justify-end">
-                      <Button type="submit">Upload</Button>
-                    </div>
-                  </form>
-                ) : null}
-                <ul className="flex flex-col gap-3">
-                  {attachments.map((a) => (
-                    <li
-                      key={a._id}
-                      className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-[#111827]"
-                    >
-                      <a
-                        href={a.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="font-medium text-[#4F46E5] hover:text-[#4338CA]"
-                      >
-                        {a.filename}
-                      </a>
-                      {canEdit ? (
-                        <button
-                          onClick={() => void handleDelete(a._id)}
-                          className="text-xs font-medium text-red-600 hover:text-red-700"
-                        >
-                          Remove
-                        </button>
-                      ) : null}
-                    </li>
-                  ))}
-                  {!attachments.length ? (
-                    <li className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-[#6B7280]">
-                      No attachments yet.
-                    </li>
-                  ) : null}
-                </ul>
-              </div>
-            </section>
-          </div>
-          <aside className="flex flex-col gap-6 lg:sticky lg:top-24">
-            <section className="flex max-h-[calc(100vh-8rem)] flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-              <div className="border-b border-gray-200 px-6 py-4">
-                <h2 className="text-lg font-semibold text-[#111827]">Activity</h2>
-              </div>
-              <div className="flex flex-1 flex-col overflow-hidden">
-                <div className="flex flex-1 flex-col overflow-y-auto px-6 py-4">
-                  <div className="flex flex-1 flex-col gap-8">
-                    <Timeline events={history} />
-                    <CommentThread taskId={id} className="flex-1" />
+                    {users.length ? (
+                      <ul className="absolute z-10 mt-2 max-h-48 w-full overflow-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                        {users.map((u) => (
+                          <li
+                            key={u._id}
+                            className="cursor-pointer px-3 py-2 text-sm text-[#111827] hover:bg-[#EEF2FF]"
+                            onClick={() => void handleOwnerSelect(u)}
+                          >
+                            {u.name || u.email}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
                   </div>
-                </div>
+                ) : (
+                  <span className="rounded-full bg-[#EEF2FF] px-3 py-1 text-sm font-medium text-[#4338CA]">
+                    {ownerName || 'Unassigned'}
+                  </span>
+                )}
               </div>
-            </section>
-          </aside>
+            </div>
+          </section>
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[#111827]">Task Details</h2>
+            <div className="mt-4">
+              <TaskDetail
+                key={task.ownerId}
+                id={id}
+                canEdit={canEdit}
+                readOnly
+                showLoopTasks={false}
+              />
+            </div>
+          </section>
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[#111827]">Step Progress</h2>
+            <div className="mt-4 flex flex-col gap-3">
+              {task.steps?.length ? (
+                task.steps.map((step, idx) => {
+                  const ownerInfo = stepOwners[step.ownerId];
+                  const ownerLabel = ownerInfo?.name || ownerInfo?.email || 'Unassigned';
+                  const isActive = activeStepIndex === idx && step.status !== 'DONE';
+                  const waitingOnPrevious = activeStepIndex >= 0 && idx > activeStepIndex;
+                  const isStepOwner = Boolean(step.ownerId) && step.ownerId === user?.userId;
+                  const canModify =
+                    stepUpdating === null &&
+                    isActive &&
+                    (canEdit || isStepOwner);
+
+                  const handleChange = (value: string) => {
+                    if (value === step.status) return;
+                    if (value === 'IN_PROGRESS' || value === 'DONE') {
+                      void handleStepStatusChange(idx, value as 'IN_PROGRESS' | 'DONE');
+                    }
+                  };
+
+                  return (
+                    <div
+                      key={`${step.ownerId}-${idx}`}
+                      className="rounded-lg border border-gray-200 bg-gray-50 p-4"
+                    >
+                      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                        <div>
+                          <p className="text-sm font-medium text-[#111827]">
+                            {step.title || `Step ${idx + 1}`}
+                          </p>
+                          <p className="text-xs text-[#6B7280]">
+                            Assigned to {ownerLabel}
+                            {isActive
+                              ? ' • Active'
+                              : step.status === 'DONE'
+                                ? ' • Completed'
+                                : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+                            Status
+                          </span>
+                          <select
+                            className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-[#111827] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-[#9CA3AF]"
+                            value={step.status}
+                            onChange={(event) => handleChange(event.target.value)}
+                            disabled={!canModify}
+                          >
+                            <option value="OPEN">Open</option>
+                            <option value="IN_PROGRESS" disabled={step.status === 'DONE'}>
+                              In Progress
+                            </option>
+                            <option value="DONE" disabled={step.status === 'OPEN'}>
+                              Done
+                            </option>
+                          </select>
+                        </div>
+                      </div>
+                      {waitingOnPrevious ? (
+                        <p className="mt-2 text-xs text-[#6B7280]">
+                          Waiting for the previous step to be completed.
+                        </p>
+                      ) : null}
+                      {isActive && step.status === 'OPEN' && canEdit ? (
+                        <p className="mt-2 text-xs text-[#6B7280]">
+                          Start this step when you&apos;re ready to work on it.
+                        </p>
+                      ) : null}
+                    </div>
+                  );
+                })
+              ) : (
+                <p className="text-sm text-[#6B7280]">No steps defined for this task.</p>
+              )}
+            </div>
+          </section>
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-[#111827]">Collaboration</h2>
+            </div>
+            <Tabs defaultValue="activity" className="mt-4">
+              <TabsList className="flex w-full gap-2 border-b border-gray-200">
+                <TabsTrigger
+                  value="activity"
+                  className="rounded-t-lg px-3 py-2 text-sm font-medium text-[#6B7280] data-[state=active]:bg-white data-[state=active]:text-[#4F46E5]"
+                >
+                  Activity
+                </TabsTrigger>
+                <TabsTrigger
+                  value="comments"
+                  className="rounded-t-lg px-3 py-2 text-sm font-medium text-[#6B7280] data-[state=active]:bg-white data-[state=active]:text-[#4F46E5]"
+                >
+                  Comments
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="activity" className="mt-4">
+                <Timeline events={history} />
+              </TabsContent>
+              <TabsContent value="comments" className="mt-4">
+                <CommentThread taskId={id} />
+              </TabsContent>
+            </Tabs>
+          </section>
+          <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-[#111827]">Attachments</h2>
+            <div className="mt-4 flex flex-col gap-4">
+              {canEdit ? (
+                <form onSubmit={submitUpload(onUploadSubmit)} className="flex flex-col gap-3 rounded-lg border border-dashed border-[#C7D2FE] bg-[#EEF2FF]/40 p-4">
+                  <label className="text-sm font-medium text-[#4338CA]">
+                    Upload new file
+                    <input
+                      type="file"
+                      {...registerUpload('file')}
+                      className="mt-2 block w-full text-sm text-[#4B5563]"
+                    />
+                  </label>
+                  {uploadErrors.file ? (
+                    <span className="text-xs text-red-600">
+                      {uploadErrors.file.message as string}
+                    </span>
+                  ) : null}
+                  <div className="flex justify-end">
+                    <Button type="submit">Upload</Button>
+                  </div>
+                </form>
+              ) : null}
+              <ul className="flex flex-col gap-3">
+                {attachments.map((a) => (
+                  <li
+                    key={a._id}
+                    className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-[#111827]"
+                  >
+                    <a
+                      href={a.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-[#4F46E5] hover:text-[#4338CA]"
+                    >
+                      {a.filename}
+                    </a>
+                    {canEdit ? (
+                      <button
+                        onClick={() => void handleDelete(a._id)}
+                        className="text-xs font-medium text-red-600 hover:text-red-700"
+                      >
+                        Remove
+                      </button>
+                    ) : null}
+                  </li>
+                ))}
+                {!attachments.length ? (
+                  <li className="rounded-lg border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-[#6B7280]">
+                    No attachments yet.
+                  </li>
+                ) : null}
+              </ul>
+            </div>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the loop tasks panel from the task details view
- introduce a collaboration tabs section that exposes activity and comments
- simplify the page layout by eliminating the sidebar activity feed

## Testing
- npm run lint *(fails: existing repository warnings and console usage outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fb93533883289b481bcd9dc8c8d9