### PR TITLE
Restrict task edits to admins and creators

### DIFF
--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -52,7 +52,12 @@ export const POST = withOrganization(
     if (
       !task ||
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {
@@ -96,7 +101,12 @@ export const DELETE = withOrganization(
     if (
       !task ||
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -127,7 +127,12 @@ export const POST = withOrganization(
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {
@@ -233,7 +238,12 @@ export const GET = withOrganization(
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {
@@ -266,7 +276,12 @@ export const PATCH = withOrganization(
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {
@@ -425,7 +440,12 @@ export const DELETE = withOrganization(
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -111,7 +111,12 @@ export const PATCH = withOrganization(
   if (!task) return problem(404, 'Not Found', 'Task not found');
   if (
     !canWriteTask(
-      { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+      {
+        _id: session.userId,
+        teamId: session.teamId,
+        organizationId: session.organizationId,
+        role: session.role,
+      },
       task
     )
   )
@@ -246,10 +251,15 @@ export const DELETE = withOrganization(
     const task: ITask | null = await Task.findById(id);
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
-      !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
-        task
-      )
+    !canWriteTask(
+      {
+        _id: session.userId,
+        teamId: session.teamId,
+        organizationId: session.organizationId,
+        role: session.role,
+      },
+      task
+    )
     )
       return problem(403, 'Forbidden', 'You cannot delete this task');
 
@@ -286,7 +296,12 @@ export const PUT = withOrganization(
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     )

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -227,7 +227,7 @@ function TaskPageContent({ id }: { id: string }) {
   const canEdit = useMemo(() => {
     if (!user?.userId || !task) return false;
     if (user.role === 'ADMIN') return true;
-    return user.userId === task.createdBy || user.userId === task.ownerId;
+    return user.userId === task.createdBy;
   }, [task, user?.role, user?.userId]);
 
   useEffect(() => {

--- a/src/lib/access.test.ts
+++ b/src/lib/access.test.ts
@@ -32,9 +32,16 @@ describe('task access', () => {
     expect(canWriteTask(user, task)).toBe(true);
   });
 
-  it('owner can read and write', () => {
+  it('owner can read but not write', () => {
     const task = { ...baseTask };
     const user = { _id: ownerId, teamId, organizationId: orgId };
+    expect(canReadTask(user, task)).toBe(true);
+    expect(canWriteTask(user, task)).toBe(false);
+  });
+
+  it('admin can read and write', () => {
+    const task = { ...baseTask };
+    const user = { _id: ownerId, teamId, organizationId: orgId, role: 'ADMIN' };
     expect(canReadTask(user, task)).toBe(true);
     expect(canWriteTask(user, task)).toBe(true);
   });

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -5,6 +5,7 @@ type UserLike = {
   _id: Types.ObjectId | string;
   organizationId?: Types.ObjectId | string | undefined;
   teamId?: Types.ObjectId | string | undefined;
+  role?: string | undefined;
 };
 
 export function canReadTask(user: UserLike, task: ITask): boolean {
@@ -35,7 +36,6 @@ export function canWriteTask(user: UserLike, task: ITask): boolean {
   const userId = user?._id?.toString();
   const orgId = user.organizationId?.toString();
   if (!userId || !orgId || task.organizationId.toString() !== orgId) return false;
-  return (
-    task.createdBy.toString() === userId || task.ownerId?.toString() === userId
-  );
+  if (user.role === 'ADMIN') return true;
+  return task.createdBy.toString() === userId;
 }


### PR DESCRIPTION
## Summary
- restrict task write access checks to allow only creators or admins
- update task API routes to pass user roles for authorization and adjust loop/attachment actions
- hide task edit and delete options in the UI for non-admins who did not create the task, and update authorization tests

## Testing
- npm run test *(fails: existing issues with mocked modules and Playwright tests in the suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d5051b3a5c8328a6c22245b609b931