### PR TITLE
Add validation for task creation payload

### DIFF
--- a/src/app/api/tasks/route.test.ts
+++ b/src/app/api/tasks/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { Types } from 'mongoose';
+
+const mockDbConnect = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db', () => ({ default: mockDbConnect }));
+
+const auth = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth', () => ({ auth }));
+
+// Silence side-effect heavy modules that are unused in these tests
+vi.mock('@/models/Task', () => ({ Task: { create: vi.fn() } }));
+vi.mock('@/models/User', () => ({ User: { findOne: vi.fn() } }));
+vi.mock('@/models/ActivityLog', () => ({ ActivityLog: { create: vi.fn() } }));
+vi.mock('@/models/TaskLoop', () => ({ TaskLoop: { create: vi.fn() } }));
+vi.mock('@/models/LoopHistory', () => ({ LoopHistory: { create: vi.fn() } }));
+vi.mock('@/lib/notify', () => ({
+  notifyAssignment: vi.fn(),
+  notifyMention: vi.fn(),
+}));
+vi.mock('@/lib/agenda', () => ({ scheduleTaskJobs: vi.fn() }));
+vi.mock('@/lib/taskParticipants', () => ({ computeParticipants: vi.fn() }));
+vi.mock('@/lib/taskLoopSync', () => ({ prepareLoopFromSteps: vi.fn() }));
+vi.mock('@/lib/ws', () => ({ emitLoopUpdated: vi.fn() }));
+
+import { POST } from './route';
+
+describe('POST /tasks validation', () => {
+  beforeEach(() => {
+    auth.mockReset();
+    auth.mockResolvedValue({
+      userId: new Types.ObjectId().toString(),
+      organizationId: new Types.ObjectId().toString(),
+      teamId: null,
+    });
+    mockDbConnect.mockReset();
+  });
+
+  it('rejects a task with an empty title', async () => {
+    const ownerId = new Types.ObjectId().toString();
+
+    const res = await POST(
+      new Request('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: '   ', ownerId }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        title: 'Invalid request',
+      })
+    );
+    expect(mockDbConnect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a task when a step has an empty title', async () => {
+    const ownerId = new Types.ObjectId().toString();
+
+    const res = await POST(
+      new Request('http://localhost/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Valid Title',
+          ownerId,
+          steps: [
+            {
+              title: '   ',
+              ownerId,
+            },
+          ],
+        }),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        title: 'Invalid request',
+      })
+    );
+    expect(mockDbConnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -25,9 +25,9 @@ import { prepareLoopFromSteps } from '@/lib/taskLoopSync';
 
 const createTaskSchema: z.ZodType<TaskPayload> = z
   .object({
-    title: z.string(),
+    title: z.string().trim().min(1, 'Title is required'),
     description: z.string().optional(),
-    ownerId: z.string().optional(),
+    ownerId: z.string().trim().optional(),
     helpers: z.array(z.string()).optional(),
     mentions: z.array(z.string()).optional(),
     teamId: z.string().optional(),

--- a/src/lib/schemas/taskStep.ts
+++ b/src/lib/schemas/taskStep.ts
@@ -3,8 +3,8 @@ import type { TaskStepPayload } from '@/types/api/task';
 
 export const stepSchema: z.ZodType<TaskStepPayload> = z
   .object({
-    title: z.string(),
-    ownerId: z.string(),
+    title: z.string().trim().min(1, 'Step title is required'),
+    ownerId: z.string().trim().min(1, 'Step owner is required'),
     description: z.string().optional(),
     dueAt: z.coerce.date().optional(),
     status: z.enum(['OPEN', 'IN_PROGRESS', 'DONE']).optional(),


### PR DESCRIPTION
## Summary
- enforce non-empty titles when creating tasks and trim owner identifiers before processing
- require step payloads to include meaningful titles and owners
- add API tests covering validation errors for empty task titles and step titles

## Testing
- npm test *(fails: existing suite issues in project, e.g. Playwright config and mocked model setup errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d5766b76588328b88f0c807255ca84