### PR TITLE
Restrict task due dates to today or later

### DIFF
--- a/src/lib/dateInput.ts
+++ b/src/lib/dateInput.ts
@@ -1,0 +1,44 @@
+export function getTodayDateInputValue(): string {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function parseDateInput(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+
+  const [yearStr, monthStr, dayStr] = value.split('-');
+  const year = Number.parseInt(yearStr, 10);
+  const month = Number.parseInt(monthStr, 10);
+  const day = Number.parseInt(dayStr, 10);
+
+  if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+export function isDateInputBeforeToday(value: string): boolean {
+  const date = parseDateInput(value);
+  if (!date) {
+    return false;
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date.getTime() < today.getTime();
+}


### PR DESCRIPTION
## Summary
- prevent selecting past due dates when editing a task by guarding the detail view input and surfacing validation feedback
- enforce that workflow steps use due dates of today or later by adding validation and disabling past dates in the task form
- add a shared date input utility for generating today strings and checking for past dates

## Testing
- npx eslint src/components/task-form.tsx src/components/task-detail.tsx src/lib/dateInput.ts

------
https://chatgpt.com/codex/tasks/task_e_68d57805d4188328b9de4a9c192994b3