### PR TITLE
Fix step due date sequencing validation

### DIFF
--- a/src/app/api/tasks/route.test.ts
+++ b/src/app/api/tasks/route.test.ts
@@ -84,7 +84,7 @@ describe('POST /tasks validation', () => {
     expect(mockDbConnect).not.toHaveBeenCalled();
   });
 
-  it('rejects a task when step due dates are not in descending order', async () => {
+  it('rejects a task when a step due date is before an earlier step', async () => {
     const ownerId = new Types.ObjectId().toString();
 
     const res = await POST(
@@ -98,12 +98,12 @@ describe('POST /tasks validation', () => {
             {
               title: 'Step 1',
               ownerId,
-              dueAt: '2025-12-05T00:00:00.000Z',
+              dueAt: '2025-12-06T00:00:00.000Z',
             },
             {
               title: 'Step 2',
               ownerId,
-              dueAt: '2025-12-06T00:00:00.000Z',
+              dueAt: '2025-12-05T00:00:00.000Z',
             },
           ],
         }),
@@ -114,7 +114,7 @@ describe('POST /tasks validation', () => {
     expect(await res.json()).toEqual(
       expect.objectContaining({
         title: 'Invalid request',
-        detail: 'Step "Step 2" due date must be before step "Step 1" due date',
+        detail: 'Step "Step 2" due date must not be before step "Step 1" due date',
       })
     );
     expect(mockDbConnect).not.toHaveBeenCalled();

--- a/src/lib/validateStepDueDates.ts
+++ b/src/lib/validateStepDueDates.ts
@@ -15,11 +15,11 @@ export function assertSequentialStepDueDates(steps: StepWithDueDate[]) {
   let previousIndex = -1;
   steps.forEach((step, index) => {
     if (!step.dueAt) return;
-    if (previousDueAt && step.dueAt >= previousDueAt) {
+    if (previousDueAt && step.dueAt < previousDueAt) {
       const currentLabel = formatStepLabel(index, step.title);
       const previousLabel = formatStepLabel(previousIndex, steps[previousIndex]?.title);
       throw new Error(
-        `Step ${currentLabel} due date must be before step ${previousLabel} due date`
+        `Step ${currentLabel} due date must not be before step ${previousLabel} due date`
       );
     }
     previousDueAt = step.dueAt;


### PR DESCRIPTION
## Summary
- ensure sequential step due date validation blocks steps scheduled before earlier steps
- update API route test to cover the new validation rule and message

## Testing
- npm run test -- src/app/api/tasks/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d58888f6d08328bf142a473988ed0c