### PR TITLE
Add notifications bell to global header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,6 +159,45 @@ body {
   margin-left: auto;
 }
 
+.app-header__icon-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid var(--color-border);
+  background: var(--surface-card);
+  color: var(--color-text);
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.app-header__icon-button:hover {
+  background: rgba(79, 70, 229, 0.08);
+  border-color: rgba(79, 70, 229, 0.4);
+}
+
+.app-header__icon-button:focus-visible {
+  outline: 2px solid rgba(79, 70, 229, 0.5);
+  outline-offset: 3px;
+}
+
+.app-header__icon-button svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.app-header__notification-badge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  transform: translate(10%, -10%);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
 .app-header__search {
   position: relative;
   display: inline-flex;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import NotificationsBadge from "@/components/notifications-badge";
 import { Avatar } from "@/components/ui/avatar";
 
 type AppShellProps = {
@@ -106,6 +107,19 @@ const GoalsIcon = (props: React.SVGProps<SVGSVGElement>) => (
       strokeWidth={1.5}
       strokeLinecap="round"
       strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const BellIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 00-5-5.917V4a1 1 0 10-2 0v1.083A6 6 0 006 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0a3 3 0 11-6 0m6 0H9"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
     />
   </svg>
 );
@@ -362,6 +376,16 @@ function AuthenticatedAppShell({
             </span>
             <span className="app-header__name">LoopTask</span>
           </div>
+        </div>
+        <div className="app-header__actions">
+          <Link
+            href="/notifications"
+            className="app-header__icon-button"
+            aria-label="View notifications"
+          >
+            <BellIcon />
+            <NotificationsBadge className="app-header__notification-badge" />
+          </Link>
         </div>
       </header>
 

--- a/src/components/notifications-badge.tsx
+++ b/src/components/notifications-badge.tsx
@@ -3,8 +3,13 @@ import { useEffect, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import useNotificationsChannel from '@/hooks/useNotificationsChannel';
 import type { UnreadCount } from '@/types/api/notifications';
+import { cn } from '@/lib/utils';
 
-export default function NotificationsBadge() {
+interface NotificationsBadgeProps {
+  className?: string;
+}
+
+export default function NotificationsBadge({ className }: NotificationsBadgeProps) {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -41,5 +46,12 @@ export default function NotificationsBadge() {
 
   if (count === 0) return null;
 
-  return <Badge className="ml-2">{count}</Badge>;
+  return (
+    <Badge
+      variant="urgent"
+      className={cn('ml-2 px-2 py-[2px] text-[11px] leading-none', className)}
+    >
+      {count}
+    </Badge>
+  );
 }


### PR DESCRIPTION
## Summary
- add a bell icon link to `/notifications` in the global header and show the unread badge
- allow `NotificationsBadge` styling overrides and switch to the urgent badge variant for the counter
- style the header icon button container and badge positioning for the bubble indicator

## Testing
- npm test *(fails: existing Vitest/Playwright suites error when run together in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d58be9a5cc8328beeb3713ecbdfe62