### PR TITLE
Add admin login route and adjust middleware redirects

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -64,4 +64,39 @@ describe('middleware', () => {
       expect(response.status).toBe(200);
     }
   );
+
+  it('allows admin login page without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/admin/login'));
+
+    expect(response.status).toBe(200);
+  });
+
+  const adminProtectedPaths = ['/admin', '/admin/users', '/admin/users/new'];
+
+  it.each(adminProtectedPaths)(
+    'redirects to admin login when hitting %s without a session',
+    async (path) => {
+      vi.mocked(getToken).mockResolvedValue(null);
+
+      const response = await middleware(createRequest(path));
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('location');
+      expect(location).toBeTruthy();
+      expect(location).toContain('/admin/login');
+    }
+  );
+
+  it.each(adminProtectedPaths)(
+    'allows authenticated users to access %s',
+    async (path) => {
+      vi.mocked(getToken).mockResolvedValue({ sub: 'user' });
+
+      const response = await middleware(createRequest(path));
+
+      expect(response.status).toBe(200);
+    }
+  );
 });

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,8 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
+const ADMIN_LOGIN_PATH = '/admin/login';
+
 const PUBLIC_ROUTES = new Set([
   '/',
   '/login',
@@ -11,12 +13,16 @@ const PUBLIC_ROUTES = new Set([
   '/terms',
   '/privacy',
   '/api/register',
+  ADMIN_LOGIN_PATH,
 ]);
 
 const PUBLIC_PREFIXES = ['/api/auth'];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  const isAdminRoute = pathname.startsWith('/admin');
+  const isAdminLoginRoute = pathname === ADMIN_LOGIN_PATH;
 
   const isAsset =
     pathname.startsWith('/_next/') ||
@@ -28,7 +34,7 @@ export async function middleware(request: NextRequest) {
     PUBLIC_ROUTES.has(pathname) ||
     PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 
-  if (isPublicRoute) {
+  if (isPublicRoute || isAdminLoginRoute) {
     return NextResponse.next();
   }
 
@@ -39,7 +45,7 @@ export async function middleware(request: NextRequest) {
   }
 
   const loginUrl = request.nextUrl.clone();
-  loginUrl.pathname = '/login';
+  loginUrl.pathname = isAdminRoute ? ADMIN_LOGIN_PATH : '/login';
   loginUrl.searchParams.set('callbackUrl', request.nextUrl.pathname + request.nextUrl.search);
 
   return NextResponse.redirect(loginUrl);

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import LoginForm from '@/components/auth/LoginForm';
+import { auth } from '@/lib/auth';
+
+const ADMIN_HOME_PATH = '/admin/users';
+
+export default async function AdminLoginPage() {
+  const session = await auth();
+
+  if (session?.role === 'ADMIN') {
+    redirect(ADMIN_HOME_PATH);
+  }
+
+  if (session) {
+    redirect('/dashboard');
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 p-6">
+      <div className="w-full max-w-md space-y-6 rounded-lg bg-white/95 p-8 text-center shadow-xl">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wider text-blue-500">
+            Product Ops Portal
+          </p>
+          <h1 className="text-2xl font-semibold text-slate-900">Admin Console Sign in</h1>
+          <p className="text-sm text-slate-600">
+            Enter your product team credentials to manage organizations, teams, and workspace settings.
+          </p>
+        </div>
+        <LoginForm callbackUrl={ADMIN_HOME_PATH} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -9,7 +9,13 @@ export type LoginFormData = {
   password: string;
 };
 
-export default function LoginForm() {
+export type LoginFormProps = {
+  callbackUrl?: string;
+};
+
+const DEFAULT_CALLBACK_URL = '/dashboard';
+
+export default function LoginForm({ callbackUrl }: LoginFormProps = {}) {
   const {
     register,
     handleSubmit,
@@ -19,10 +25,13 @@ export default function LoginForm() {
   const router = useRouter();
 
   const onSubmit = async (data: LoginFormData) => {
+    const targetCallback = callbackUrl ?? DEFAULT_CALLBACK_URL;
+
     const res = await signIn('credentials', {
       redirect: false,
       email: data.email,
       password: data.password,
+      callbackUrl: targetCallback,
     });
 
     if (res?.error) {
@@ -30,7 +39,19 @@ export default function LoginForm() {
       return;
     }
 
-    router.push('/dashboard');
+    const destination = (() => {
+      if (res?.url) {
+        try {
+          const parsed = new URL(res.url, window.location.origin);
+          return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+        } catch {
+          return res.url;
+        }
+      }
+      return targetCallback;
+    })();
+
+    router.push(destination);
   };
 
   return (

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -122,7 +122,7 @@ const NAVIGATION_LINKS: NavigationLink[] = [
   { href: "/settings", label: "Settings", icon: <SettingsIcon /> },
 ];
 
-const AUTH_ROUTES = new Set(["/signin", "/signin/verify", "/login", "/"]);
+const AUTH_ROUTES = new Set(["/signin", "/signin/verify", "/login", "/", "/admin/login"]);
 
 export function closeSidebarOnNavigation({
   isDesktop,


### PR DESCRIPTION
## Summary
- add a dedicated admin login page that reuses the shared credentials form with an admin callback
- update the shared login form, middleware, and app shell so admin routes redirect to the new entry point
- expand middleware tests to cover admin access rules

## Testing
- npm run test *(fails: existing Vitest suite errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d607c0be6883288b0f01170cc5461f