### PR TITLE
Add standalone admin seeding script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "npm run lint && npm run typecheck && next build",
     "worker": "tsx scripts/worker.ts",
     "seed": "tsx scripts/seed.ts",
+    "seed:admin": "tsx scripts/seed-admin.ts",
     "digest": "tsx scripts/digest.ts",
     "test": "vitest run",
     "test:e2e": "playwright test"

--- a/scripts/seed-admin.test.ts
+++ b/scripts/seed-admin.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  __esModule: true,
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+const organizationMocks = vi.hoisted(() => ({
+  orgFindOne: vi.fn(),
+  orgCreate: vi.fn(),
+}));
+
+vi.mock('@/models/Organization', () => ({
+  __esModule: true,
+  Organization: {
+    findOne: organizationMocks.orgFindOne,
+    create: organizationMocks.orgCreate,
+  },
+}));
+
+const userMocks = vi.hoisted(() => ({
+  userFindOne: vi.fn(),
+  userCreate: vi.fn(),
+}));
+
+vi.mock('@/models/User', () => ({
+  __esModule: true,
+  User: {
+    findOne: userMocks.userFindOne,
+    create: userMocks.userCreate,
+  },
+}));
+
+const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+import { seedAdmin } from './seed-admin';
+
+describe('seedAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    organizationMocks.orgFindOne.mockReset();
+    organizationMocks.orgCreate.mockReset();
+    userMocks.userFindOne.mockReset();
+    userMocks.userCreate.mockReset();
+    logSpy.mockClear();
+  });
+
+  it('creates an admin when one does not exist', async () => {
+    userMocks.userFindOne.mockResolvedValue(null);
+    organizationMocks.orgFindOne.mockResolvedValue(null);
+    organizationMocks.orgCreate.mockResolvedValue({ _id: 'org1' });
+    userMocks.userCreate.mockResolvedValue({ _id: 'user1' });
+
+    await seedAdmin();
+
+    expect(organizationMocks.orgCreate).toHaveBeenCalledWith({
+      name: 'LoopTask',
+      domain: 'looptask.local',
+    });
+    expect(userMocks.userCreate).toHaveBeenCalledWith({
+      name: 'LoopTask Admin',
+      email: 'admin@looptask.local',
+      username: 'admin',
+      password: 'admin123',
+      organizationId: 'org1',
+      role: 'ADMIN',
+    });
+    expect(logSpy).toHaveBeenCalledWith('Admin account created.', {
+      email: 'admin@looptask.local',
+      username: 'admin',
+      password: 'admin123',
+    });
+  });
+
+  it('promotes an existing user to admin if necessary', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    userMocks.userFindOne.mockResolvedValue({
+      role: 'USER',
+      save,
+    });
+
+    await seedAdmin();
+
+    expect(save).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith('Admin account already exists.', {
+      email: 'admin@looptask.local',
+      username: 'admin',
+    });
+  });
+
+  it('does not save when existing user is already admin', async () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    userMocks.userFindOne.mockResolvedValue({
+      role: 'ADMIN',
+      save,
+    });
+
+    await seedAdmin();
+
+    expect(save).not.toHaveBeenCalled();
+    expect(organizationMocks.orgCreate).not.toHaveBeenCalled();
+    expect(userMocks.userCreate).not.toHaveBeenCalled();
+  });
+});
+
+afterAll(() => {
+  logSpy.mockRestore();
+});

--- a/scripts/seed-admin.ts
+++ b/scripts/seed-admin.ts
@@ -1,0 +1,90 @@
+import dbConnect from '@/lib/db';
+import { Organization } from '@/models/Organization';
+import { User, type UserDocument } from '@/models/User';
+
+export interface AdminSeedConfig {
+  name: string;
+  email: string;
+  username: string;
+  password: string;
+  organizationName: string;
+  organizationDomain: string;
+}
+
+export const getAdminSeedConfig = (): AdminSeedConfig => ({
+  name: process.env.SEED_ADMIN_NAME ?? 'LoopTask Admin',
+  email: process.env.SEED_ADMIN_EMAIL ?? 'admin@looptask.local',
+  username: process.env.SEED_ADMIN_USERNAME ?? 'admin',
+  password: process.env.SEED_ADMIN_PASSWORD ?? 'admin123',
+  organizationName: process.env.SEED_ADMIN_ORGANIZATION_NAME ?? 'LoopTask',
+  organizationDomain:
+    process.env.SEED_ADMIN_ORGANIZATION_DOMAIN ?? 'looptask.local',
+});
+
+const ensureOrganization = async (
+  name: string,
+  domain: string
+) => {
+  const existing = await Organization.findOne({ domain });
+  if (existing) {
+    return existing;
+  }
+  return Organization.create({ name, domain });
+};
+
+const promoteToAdmin = async (user: UserDocument) => {
+  if (user.role !== 'ADMIN') {
+    user.role = 'ADMIN';
+    await user.save();
+  }
+  return user;
+};
+
+export async function seedAdmin() {
+  await dbConnect();
+  const config = getAdminSeedConfig();
+
+  const existing = await User.findOne({
+    $or: [{ email: config.email }, { username: config.username }],
+  });
+
+  if (existing) {
+    await promoteToAdmin(existing);
+    console.log('Admin account already exists.', {
+      email: config.email,
+      username: config.username,
+    });
+    return existing;
+  }
+
+  const organization = await ensureOrganization(
+    config.organizationName,
+    config.organizationDomain
+  );
+
+  const user = await User.create({
+    name: config.name,
+    email: config.email,
+    username: config.username,
+    password: config.password,
+    organizationId: organization._id,
+    role: 'ADMIN',
+  });
+
+  console.log('Admin account created.', {
+    email: config.email,
+    username: config.username,
+    password: config.password,
+  });
+
+  return user;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  seedAdmin()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add a standalone seed script that creates or promotes a default admin account
- expose an npm script for running the admin seeding routine
- cover the new admin seeding logic with dedicated unit tests

## Testing
- npm test -- scripts/seed-admin.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d60e8284508328aae4c88aa2468ac6