### PR TITLE
Add platform admin role and cross-organization access

### DIFF
--- a/src/app/admin/admin-users/new/page.tsx
+++ b/src/app/admin/admin-users/new/page.tsx
@@ -4,21 +4,34 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { SessionProvider } from 'next-auth/react';
 import useAuth from '@/hooks/useAuth';
+import PlatformRoleSelector from '@/components/platform-role-selector';
+import type { UserRole } from '@/lib/roles';
 
 function NewAdminForm() {
   const { user } = useAuth();
+  const canAssignPlatform = user?.role === 'PLATFORM';
   const [form, setForm] = useState({
     name: '',
     email: '',
     username: '',
     password: '',
     teamId: '',
+    role: 'ADMIN' as UserRole,
   });
   const [error, setError] = useState('');
   const router = useRouter();
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]:
+        name === 'role'
+          ? ((canAssignPlatform ? value : 'ADMIN') as UserRole)
+          : value,
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -31,7 +44,7 @@ function NewAdminForm() {
     const res = await fetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...form, organizationId: user?.organizationId, role: 'ADMIN' }),
+      body: JSON.stringify({ ...form, organizationId: user?.organizationId }),
     });
     if (!res.ok) {
       const data = (await res
@@ -51,6 +64,13 @@ function NewAdminForm() {
       <input name="username" value={form.username} onChange={handleChange} placeholder="Username" className="border p-2" required />
       <input name="password" type="password" value={form.password} onChange={handleChange} placeholder="Password" className="border p-2" required />
       <input name="teamId" value={form.teamId} onChange={handleChange} placeholder="Team ID" className="border p-2" />
+      <PlatformRoleSelector
+        name="role"
+        value={form.role}
+        onChange={handleChange}
+        includePlatform={canAssignPlatform}
+        className="border p-2"
+      />
       <button type="submit" className="bg-blue-500 text-white p-2">Save Admin</button>
     </form>
   );

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,13 +1,14 @@
 import { redirect } from 'next/navigation';
 import LoginForm from '@/components/auth/LoginForm';
 import { auth } from '@/lib/auth';
+import { isPlatformRole } from '@/lib/roles';
 
 const ADMIN_HOME_PATH = '/admin/users';
 
 export default async function AdminLoginPage() {
   const session = await auth();
 
-  if (session?.role === 'ADMIN') {
+  if (session?.role === 'ADMIN' || isPlatformRole(session?.role)) {
     redirect(ADMIN_HOME_PATH);
   }
 

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -2,11 +2,15 @@
 
 import { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import RoleSelector from '@/components/role-selector';
+import PlatformRoleSelector from '@/components/platform-role-selector';
+import type { UserRole } from '@/lib/roles';
+import useAuth from '@/hooks/useAuth';
 
 export default function EditUserPage() {
   const params = useParams();
   const id = params?.id as string;
+  const { user: currentUser } = useAuth();
+  const canAssignPlatform = currentUser?.role === 'PLATFORM';
   const [form, setForm] = useState({
     name: '',
     email: '',
@@ -14,7 +18,7 @@ export default function EditUserPage() {
     password: '',
     organizationId: '',
     teamId: '',
-    role: 'USER',
+    role: 'USER' as UserRole,
   });
   const [status, setStatus] = useState<{ success?: string; error?: string }>({});
 
@@ -29,7 +33,7 @@ export default function EditUserPage() {
         password: '',
         organizationId: data.organizationId ?? '',
         teamId: data.teamId ?? '',
-        role: data.role ?? 'USER',
+        role: (data.role as UserRole | undefined) ?? 'USER',
       });
     };
     if (id) void load();
@@ -39,7 +43,10 @@ export default function EditUserPage() {
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
   ) => {
     const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
+    setForm((prev) => ({
+      ...prev,
+      [name]: name === 'role' ? ((canAssignPlatform ? value : prev.role) as UserRole) : value,
+    }));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -74,10 +81,11 @@ export default function EditUserPage() {
       <input name="password" type="password" value={form.password} onChange={handleChange} placeholder="Password" className="border p-2" />
       <input name="organizationId" value={form.organizationId} onChange={handleChange} placeholder="Organization ID" className="border p-2" required />
       <input name="teamId" value={form.teamId} onChange={handleChange} placeholder="Team ID" className="border p-2" />
-      <RoleSelector
+      <PlatformRoleSelector
         name="role"
         value={form.role}
         onChange={handleChange}
+        includePlatform={canAssignPlatform}
         className="border p-2"
       />
       {status.success && <p className="text-green-600">{status.success}</p>}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -8,14 +8,21 @@ import {
   type ChangeEvent,
 } from 'react';
 import Link from 'next/link';
+import type { UserRole } from '@/lib/roles';
 
 interface User {
   _id: string;
   name: string;
   email: string;
   username: string;
-  role: string;
+  role: UserRole;
 }
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  USER: 'Member',
+  ADMIN: 'Tenant Admin',
+  PLATFORM: 'Platform Admin',
+};
 
 interface Organization {
   _id: string;
@@ -124,7 +131,7 @@ export default function UsersPage() {
             <th className="border p-2">Name</th>
             <th className="border p-2">Email</th>
             <th className="border p-2">Username</th>
-            <th className="border p-2">Admin</th>
+            <th className="border p-2">Role</th>
             <th className="border p-2">Actions</th>
           </tr>
         </thead>
@@ -134,7 +141,7 @@ export default function UsersPage() {
               <td className="border p-2">{u.name}</td>
               <td className="border p-2">{u.email}</td>
               <td className="border p-2">{u.username}</td>
-              <td className="border p-2">{u.role === 'ADMIN' ? 'Yes' : 'No'}</td>
+              <td className="border p-2">{ROLE_LABELS[u.role] ?? u.role}</td>
               <td className="border p-2 flex gap-2">
                 <Link
                   href={`/admin/users/${u._id}`}

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -17,13 +17,18 @@ export const GET = withOrganization(
     session: Session
   ) => {
     const { params } = context;
-const { id } = await params;
+    const { id } = await params;
     await dbConnect();
     const task = await Task.findById(id);
     if (
       !task ||
       !canReadTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {

--- a/src/app/api/tasks/[id]/history/route.ts
+++ b/src/app/api/tasks/[id]/history/route.ts
@@ -6,6 +6,7 @@ import { ActivityLog } from '@/models/ActivityLog';
 import { auth } from '@/lib/auth';
 import { canReadTask } from '@/lib/access';
 import { problem } from '@/lib/http';
+import { isPlatformRole } from '@/lib/roles';
 
 export async function GET(
   req: NextRequest,
@@ -14,7 +15,8 @@ export async function GET(
   const { params } = context;
   const { id } = await params;
   const session = await auth();
-  if (!session?.userId || !session.organizationId) {
+  const isPlatform = isPlatformRole(session?.role);
+  if (!session?.userId || (!isPlatform && !session.organizationId)) {
     return problem(401, 'Unauthorized', 'You must be signed in.');
   }
   await dbConnect();
@@ -22,7 +24,12 @@ export async function GET(
   if (
     !task ||
     !canReadTask(
-      { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+      {
+        _id: session.userId,
+        teamId: session.teamId,
+        organizationId: session.organizationId,
+        role: session.role,
+      },
       task
     )
   ) {

--- a/src/app/api/tasks/[id]/loop/history/route.ts
+++ b/src/app/api/tasks/[id]/loop/history/route.ts
@@ -42,7 +42,12 @@ export const GET = withOrganization(
     if (
       !task ||
       !canReadTask(
-        { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+        {
+          _id: session.userId,
+          teamId: session.teamId,
+          organizationId: session.organizationId,
+          role: session.role,
+        },
         task
       )
     ) {

--- a/src/app/api/tasks/[id]/loop/route.ts
+++ b/src/app/api/tasks/[id]/loop/route.ts
@@ -249,7 +249,7 @@ export const GET = withOrganization(
     ) {
       return problem(403, 'Forbidden', 'You cannot access this loop');
     }
-      const loop = await TaskLoop.findOne({ taskId: id }).lean<ITaskLoop>();
+    const loop = await TaskLoop.findOne({ taskId: id }).lean<ITaskLoop>();
     if (!loop) return problem(404, 'Not Found', 'Loop not found');
     return NextResponse.json(loop);
   }
@@ -436,7 +436,7 @@ export const DELETE = withOrganization(
     const { params } = context;
     const { id } = await params;
     await dbConnect();
-      const task = await Task.findById(id).lean<ITask>();
+    const task = await Task.findById(id).lean<ITask>();
     if (!task) return problem(404, 'Not Found', 'Task not found');
     if (
       !canWriteTask(
@@ -451,7 +451,7 @@ export const DELETE = withOrganization(
     ) {
       return problem(403, 'Forbidden', 'You cannot delete this loop');
     }
-      const loop = await TaskLoop.findOneAndDelete({ taskId: id }).lean();
+    const loop = await TaskLoop.findOneAndDelete({ taskId: id }).lean();
     if (!loop) return problem(404, 'Not Found', 'Loop not found');
     return NextResponse.json({ success: true });
   }

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -83,7 +83,12 @@ export const GET = withOrganization(
   if (
     !task ||
     !canReadTask(
-      { _id: session.userId, teamId: session.teamId, organizationId: session.organizationId },
+      {
+        _id: session.userId,
+        teamId: session.teamId,
+        organizationId: session.organizationId,
+        role: session.role,
+      },
       task
     )
   ) {
@@ -133,7 +138,7 @@ export const PATCH = withOrganization(
   if (body.ownerId) {
     const owner = await User.findOne({
       _id: new Types.ObjectId(body.ownerId),
-      organizationId: new Types.ObjectId(session.organizationId),
+      organizationId: new Types.ObjectId(task.organizationId),
     });
     if (!owner) {
       return problem(400, 'Invalid request', 'Owner must be in your organization');
@@ -143,7 +148,7 @@ export const PATCH = withOrganization(
     for (const s of body.steps) {
       const stepOwner = await User.findOne({
         _id: new Types.ObjectId(s.ownerId),
-        organizationId: new Types.ObjectId(session.organizationId),
+        organizationId: new Types.ObjectId(task.organizationId),
       });
       if (!stepOwner) {
         return problem(400, 'Invalid request', 'Step owner must be in your organization');
@@ -315,10 +320,10 @@ export const PUT = withOrganization(
       )
     )
       return problem(403, 'Forbidden', 'You cannot edit this task');
-    const owner = await User.findOne({
-      _id: new Types.ObjectId(body.ownerId),
-      organizationId: new Types.ObjectId(session.organizationId),
-    });
+  const owner = await User.findOne({
+    _id: new Types.ObjectId(body.ownerId),
+    organizationId: new Types.ObjectId(task.organizationId),
+  });
     if (!owner) {
       return problem(400, 'Invalid request', 'Owner must be in your organization');
     }
@@ -332,10 +337,10 @@ export const PUT = withOrganization(
       return problem(400, 'Invalid request', message);
     }
     for (const s of body.steps) {
-      const stepOwner = await User.findOne({
-        _id: new Types.ObjectId(s.ownerId),
-        organizationId: new Types.ObjectId(session.organizationId),
-      });
+    const stepOwner = await User.findOne({
+      _id: new Types.ObjectId(s.ownerId),
+      organizationId: new Types.ObjectId(task.organizationId),
+    });
       if (!stepOwner) {
         return problem(400, 'Invalid request', 'Step owner must be in your organization');
       }

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -18,6 +18,7 @@ import DeleteTaskModal from '@/components/delete-task-modal';
 import type { TaskStatus } from '@/models/Task';
 import { Button } from '@/components/ui/button';
 import type { TaskStep } from '@/types/api/task';
+import { isElevatedAdminRole } from '@/lib/roles';
 
 interface Task {
   _id: string;
@@ -226,7 +227,7 @@ function TaskPageContent({ id }: { id: string }) {
 
   const canEdit = useMemo(() => {
     if (!user?.userId || !task) return false;
-    if (user.role === 'ADMIN') return true;
+    if (isElevatedAdminRole(user.role)) return true;
     return user.userId === task.createdBy;
   }, [task, user?.role, user?.userId]);
 

--- a/src/components/platform-role-selector.tsx
+++ b/src/components/platform-role-selector.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+import type { UserRole } from '@/lib/roles';
+
+interface PlatformRoleSelectorProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  includePlatform?: boolean;
+}
+
+const PlatformRoleSelector = forwardRef<
+  HTMLSelectElement,
+  PlatformRoleSelectorProps
+>(function PlatformRoleSelector(props, ref) {
+  const { includePlatform = true, ...rest } = props;
+  return (
+    <select ref={ref} {...rest}>
+      <option value="USER">Member</option>
+      <option value="ADMIN">Tenant Admin</option>
+      {includePlatform ? <option value="PLATFORM">Platform Admin</option> : null}
+    </select>
+  );
+});
+
+export default PlatformRoleSelector;
+export type PlatformRole = UserRole;

--- a/src/components/role-selector.tsx
+++ b/src/components/role-selector.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React, { forwardRef } from 'react';
+import type { OrganizationRole } from '@/lib/roles';
 
-export type Role = 'ADMIN' | 'USER';
+export type Role = OrganizationRole;
 
 const RoleSelector = forwardRef<
   HTMLSelectElement,

--- a/src/components/task-form.tsx
+++ b/src/components/task-form.tsx
@@ -10,11 +10,12 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { getTodayDateInputValue, isDateInputBeforeToday } from '@/lib/dateInput';
+import type { UserRole } from '@/lib/roles';
 
 export interface TaskFormUser {
   _id: string;
   name: string;
-  role?: string;
+  role?: UserRole;
 }
 
 export interface TaskFormStepInput {
@@ -183,7 +184,10 @@ export default function TaskForm({
         const res = await fetch('/api/users', { credentials: 'include' });
         if (!res.ok) return;
         const data = (await res.json()) as TaskFormUser[];
-        if (isMounted) setUsers(data.filter((user) => user.role !== 'ADMIN'));
+        if (isMounted)
+          setUsers(
+            data.filter((user) => user.role !== 'ADMIN' && user.role !== 'PLATFORM')
+          );
       } catch {
         // swallow fetch errors; list will remain empty
       }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@
 import { useCallback, useMemo } from 'react';
 import { signIn, signOut, useSession } from 'next-auth/react';
 import type { Session } from 'next-auth';
+import type { UserRole } from '@/lib/roles';
 
 type BaseUser = NonNullable<Session['user']>;
 
@@ -10,7 +11,7 @@ type AuthUser = BaseUser & {
   userId?: string;
   organizationId?: string;
   teamId?: string;
-  role?: string;
+  role?: UserRole;
   accessToken?: string;
   accessTokenExpires?: number;
   refreshToken?: string;

--- a/src/lib/access.test.ts
+++ b/src/lib/access.test.ts
@@ -46,6 +46,13 @@ describe('task access', () => {
     expect(canWriteTask(user, task)).toBe(true);
   });
 
+  it('platform admin can read and write across organizations', () => {
+    const task = { ...baseTask, organizationId: otherOrgId };
+    const user = { _id: ownerId, teamId, organizationId: orgId, role: 'PLATFORM' };
+    expect(canReadTask(user, task)).toBe(true);
+    expect(canWriteTask(user, task)).toBe(true);
+  });
+
   it('helper can read but not write', () => {
     const task = { ...baseTask, helpers: [helperId] };
     const user = { _id: helperId, teamId, organizationId: orgId };

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@ import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import { User } from '@/models/User';
 import { RefreshToken, type ClientMetadata } from '@/models/RefreshToken';
+import type { UserRole } from '@/lib/roles';
 
 declare global {
   var __NEXTAUTH_SECRET: string | undefined;
@@ -22,7 +23,7 @@ interface AuthUser {
   email: string;
   organizationId?: string | undefined;
   teamId?: string | undefined;
-  role?: string | undefined;
+  role?: UserRole | undefined;
   client?: ClientMetadata;
 }
 

--- a/src/lib/middleware/withOrganization.ts
+++ b/src/lib/middleware/withOrganization.ts
@@ -2,6 +2,7 @@ import type { Session } from 'next-auth';
 import { type NextRequest } from 'next/server';
 import { auth } from '@/lib/auth';
 import { problem } from '@/lib/http';
+import { isPlatformRole } from '@/lib/roles';
 
 export function withOrganization(
   handler: (req: NextRequest, session: Session) => Promise<Response>
@@ -14,7 +15,10 @@ export function withOrganization(
 ) {
   return async (req: NextRequest, ctx?: unknown) => {
     const session = await auth();
-    if (!session?.userId || !session.organizationId) {
+    if (!session?.userId) {
+      return problem(401, 'Unauthorized', 'You must be signed in.');
+    }
+    if (!isPlatformRole(session.role) && !session.organizationId) {
       return problem(401, 'Unauthorized', 'You must be signed in.');
     }
     if (handler.length < 3) {

--- a/src/lib/roles.ts
+++ b/src/lib/roles.ts
@@ -1,0 +1,18 @@
+export const USER_ROLE_VALUES = ['USER', 'ADMIN', 'PLATFORM'] as const;
+export const ORGANIZATION_ROLE_VALUES = ['USER', 'ADMIN'] as const;
+
+export type UserRole = (typeof USER_ROLE_VALUES)[number];
+export type OrganizationRole = (typeof ORGANIZATION_ROLE_VALUES)[number];
+
+export const isPlatformRole = (
+  role: string | null | undefined
+): role is Extract<UserRole, 'PLATFORM'> => role === 'PLATFORM';
+
+export const isTenantAdminRole = (
+  role: string | null | undefined
+): role is Extract<UserRole, 'ADMIN'> => role === 'ADMIN';
+
+export const isElevatedAdminRole = (
+  role: string | null | undefined
+): role is Extract<UserRole, 'ADMIN' | 'PLATFORM'> =>
+  role === 'ADMIN' || role === 'PLATFORM';

--- a/src/models/Invitation.ts
+++ b/src/models/Invitation.ts
@@ -1,4 +1,5 @@
 import { Schema, model, models, type InferSchemaType, type Model } from 'mongoose';
+import { ORGANIZATION_ROLE_VALUES } from '@/lib/roles';
 
 const invitationSchema = new Schema(
   {
@@ -9,7 +10,7 @@ const invitationSchema = new Schema(
       required: true,
     },
     tokenHash: { type: String, required: true, unique: true },
-    role: { type: String, enum: ['ADMIN', 'USER'], default: 'USER' },
+    role: { type: String, enum: ORGANIZATION_ROLE_VALUES, default: 'USER' },
     expiresAt: { type: Date, required: true },
     used: { type: Boolean, default: false },
   },

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -7,6 +7,7 @@ import {
   type Model,
 } from 'mongoose';
 import bcrypt from 'bcrypt';
+import { USER_ROLE_VALUES } from '@/lib/roles';
 
 const SALT_ROUNDS = 10;
 
@@ -39,7 +40,7 @@ const userSchema = new Schema(
     teamId: { type: Schema.Types.ObjectId, ref: 'Team' },
     timezone: { type: String, default: 'Asia/Kolkata' },
     isActive: { type: Boolean, default: true },
-    role: { type: String, enum: ['ADMIN', 'USER'], default: 'USER' },
+    role: { type: String, enum: USER_ROLE_VALUES, default: 'USER' },
     avatar: { type: String },
     permissions: { type: [String], default: [] },
     notificationSettings: {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,5 +1,6 @@
 import 'next-auth';
 import 'next-auth/jwt';
+import type { UserRole } from '@/lib/roles';
 
 declare module 'next-auth' {
   interface Session {
@@ -7,7 +8,7 @@ declare module 'next-auth' {
     email: string;
     organizationId: string | undefined;
     teamId: string | undefined;
-    role: string | undefined;
+    role: UserRole | undefined;
     accessToken?: string;
     accessTokenExpires?: number;
     refreshToken?: string;
@@ -21,7 +22,7 @@ declare module 'next-auth/jwt' {
     email: string;
     organizationId: string | undefined;
     teamId: string | undefined;
-    role: string | undefined;
+    role: UserRole | undefined;
     accessToken?: string;
     accessTokenExpires?: number;
     refreshToken?: string;


### PR DESCRIPTION
## Summary
- add centralized role utilities and extend user/invitation schemas plus auth typings to include the platform admin role
- update authorization helpers and admin APIs so platform admins inherit cross-organization privileges while keeping tenant admin behaviour unchanged
- introduce platform-aware role selectors in admin screens so product-team admins can assign the platform role without exposing it to tenant admins

## Testing
- npm run test *(fails: existing Vitest suite relies on unsupported Playwright usage and module mocks in this environment)*
- npm run typecheck *(fails: repository contains pre-existing TypeScript errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d614bcee9c8328943c77df7c2f4d32