### PR TITLE
Add admin portal self-registration flow

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -31,6 +31,22 @@ describe('middleware', () => {
     expect(response.status).toBe(200);
   });
 
+  it('allows admin register page without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/admin/register'));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('allows admin register api without a session', async () => {
+    vi.mocked(getToken).mockResolvedValue(null);
+
+    const response = await middleware(createRequest('/api/admin/register'));
+
+    expect(response.status).toBe(200);
+  });
+
   const protectedPaths = [
     '/dashboard',
     '/tasks',

--- a/middleware.ts
+++ b/middleware.ts
@@ -9,10 +9,12 @@ const PUBLIC_ROUTES = new Set([
   '/login',
   '/signin',
   '/register',
+  '/admin/register',
   '/forgot-password',
   '/terms',
   '/privacy',
   '/api/register',
+  '/api/admin/register',
   ADMIN_LOGIN_PATH,
 ]);
 

--- a/src/app/admin/register/page.tsx
+++ b/src/app/admin/register/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+const domainPattern = /^(?!-)(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,}$/;
+
+type AdminRegisterFormData = {
+  name: string;
+  email: string;
+  password: string;
+  organizationName: string;
+  organizationDomain: string;
+};
+
+export default function AdminRegisterPage() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState('');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<AdminRegisterFormData>();
+
+  const onSubmit = async (data: AdminRegisterFormData) => {
+    setServerError('');
+    try {
+      const res = await fetch('/api/admin/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const payload = (await res.json().catch(() => null)) as { detail?: string } | null;
+        setServerError(payload?.detail ?? 'Registration failed. Please try again.');
+        return;
+      }
+
+      router.push('/admin/login');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unexpected error';
+      setServerError(message);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 p-6">
+      <div className="w-full max-w-2xl space-y-8 rounded-xl bg-white/95 p-10 shadow-2xl">
+        <div className="space-y-2 text-center">
+          <p className="text-xs font-semibold uppercase tracking-widest text-blue-500">Product Ops Portal</p>
+          <h1 className="text-3xl font-semibold text-slate-900">Create admin workspace</h1>
+          <p className="text-sm text-slate-600">
+            Provision a new organization and create the first administrator account for your product team.
+          </p>
+        </div>
+
+        {serverError && (
+          <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{serverError}</div>
+        )}
+
+        <form onSubmit={handleSubmit(onSubmit)} className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <label className="flex flex-col gap-1 text-left">
+              <span className="text-sm font-medium text-slate-700">Organization name</span>
+              <input
+                type="text"
+                placeholder="Acme Product Ops"
+                className="rounded border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                {...register('organizationName', { required: 'Organization name is required' })}
+              />
+            </label>
+            {errors.organizationName && (
+              <p className="mt-1 text-xs text-red-600">{errors.organizationName.message}</p>
+            )}
+          </div>
+
+          <div className="sm:col-span-2">
+            <label className="flex flex-col gap-1 text-left">
+              <span className="text-sm font-medium text-slate-700">Primary domain</span>
+              <input
+                type="text"
+                placeholder="acme.com"
+                className="rounded border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                {...register('organizationDomain', {
+                  required: 'Domain is required',
+                  pattern: {
+                    value: domainPattern,
+                    message: 'Enter a valid domain (e.g., acme.com)',
+                  },
+                })}
+              />
+            </label>
+            {errors.organizationDomain && (
+              <p className="mt-1 text-xs text-red-600">{errors.organizationDomain.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="flex flex-col gap-1 text-left">
+              <span className="text-sm font-medium text-slate-700">Your name</span>
+              <input
+                type="text"
+                placeholder="Alex Morgan"
+                className="rounded border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                {...register('name', { required: 'Name is required' })}
+              />
+            </label>
+            {errors.name && <p className="mt-1 text-xs text-red-600">{errors.name.message}</p>}
+          </div>
+
+          <div>
+            <label className="flex flex-col gap-1 text-left">
+              <span className="text-sm font-medium text-slate-700">Work email</span>
+              <input
+                type="email"
+                placeholder="alex@acme.com"
+                className="rounded border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                {...register('email', {
+                  required: 'Email is required',
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: 'Enter a valid email address',
+                  },
+                })}
+              />
+            </label>
+            {errors.email && <p className="mt-1 text-xs text-red-600">{errors.email.message}</p>}
+          </div>
+
+          <div className="sm:col-span-2">
+            <label className="flex flex-col gap-1 text-left">
+              <span className="text-sm font-medium text-slate-700">Password</span>
+              <input
+                type="password"
+                placeholder="Create a secure password"
+                className="rounded border border-slate-300 px-3 py-2 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                {...register('password', {
+                  required: 'Password is required',
+                  minLength: {
+                    value: 8,
+                    message: 'Password must be at least 8 characters',
+                  },
+                })}
+              />
+            </label>
+            {errors.password && <p className="mt-1 text-xs text-red-600">{errors.password.message}</p>}
+          </div>
+
+          <div className="sm:col-span-2 flex flex-col gap-4 pt-2">
+            <button
+              type="submit"
+              className="w-full rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Creating workspace…' : 'Create admin workspace'}
+            </button>
+            <p className="text-center text-xs text-slate-500">
+              Already have an account?{' '}
+              <a href="/admin/login" className="font-medium text-blue-600 hover:underline">
+                Sign in
+              </a>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/api/admin/register/route.ts
+++ b/src/app/api/admin/register/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { z } from 'zod';
+import crypto from 'crypto';
+import dbConnect from '@/lib/db';
+import { Organization } from '@/models/Organization';
+import { User } from '@/models/User';
+import { problem } from '@/lib/http';
+
+const domainPattern = /^(?!-)(?:[a-zA-Z0-9-]{1,63}\.)+[a-zA-Z]{2,}$/;
+
+const adminRegisterSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .max(200, 'Name is too long')
+    .transform((value) => value.trim()),
+  email: z.string().email('Email must be valid').transform((value) => value.toLowerCase()),
+  password: z
+    .string()
+    .min(8, 'Password must be at least 8 characters long')
+    .max(200, 'Password is too long'),
+  organizationName: z
+    .string()
+    .min(1, 'Organization name is required')
+    .max(200, 'Organization name is too long')
+    .transform((value) => value.trim()),
+  organizationDomain: z
+    .string()
+    .min(1, 'Domain is required')
+    .max(255, 'Domain is too long')
+    .regex(domainPattern, 'Domain must be a valid hostname')
+    .transform((value) => value.toLowerCase()),
+});
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  let body: z.infer<typeof adminRegisterSchema>;
+  try {
+    body = adminRegisterSchema.parse(await req.json());
+  } catch (e: unknown) {
+    const err = e as Error;
+    return problem(400, 'Invalid request', err.message);
+  }
+
+  await dbConnect();
+
+  const existingOrganization = await Organization.findOne({
+    domain: body.organizationDomain,
+  }).lean();
+
+  if (existingOrganization) {
+    return problem(409, 'Conflict', 'An organization with this domain already exists.');
+  }
+
+  let organization;
+  try {
+    organization = await Organization.create({
+      name: body.organizationName,
+      domain: body.organizationDomain,
+    });
+  } catch (e: unknown) {
+    const err = e as Error & { code?: number };
+    if (err.code === 11000) {
+      return problem(409, 'Conflict', 'An organization with this domain already exists.');
+    }
+    return problem(500, 'Internal Server Error', 'Failed to create organization');
+  }
+
+  const [usernameBase] = body.email.split('@');
+  const sanitizedBase = usernameBase.replace(/[^a-zA-Z0-9._-]/g, '').toLowerCase();
+  const basePrefix = (sanitizedBase || 'admin').slice(0, 24);
+  let usernameCandidate = basePrefix || `admin-${crypto.randomBytes(2).toString('hex')}`;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const existingUser = await User.exists({ username: usernameCandidate });
+    if (!existingUser) {
+      break;
+    }
+    const suffix = crypto.randomBytes(2).toString('hex');
+    usernameCandidate = `${basePrefix}-${suffix}`.slice(0, 40);
+  }
+
+  try {
+    const user = await User.create({
+      name: body.name,
+      email: body.email,
+      username: usernameCandidate,
+      password: body.password,
+      organizationId: organization._id,
+      role: 'ADMIN',
+    });
+    return NextResponse.json({ id: user._id.toString() }, { status: 201 });
+  } catch (e: unknown) {
+    const err = e as Error & { code?: number };
+
+    await organization.deleteOne().catch(() => {});
+
+    if (err.code === 11000) {
+      return problem(409, 'Conflict', 'An account with this email or username already exists.');
+    }
+    if (err.name === 'ValidationError') {
+      return problem(400, 'Invalid request', err.message);
+    }
+    return problem(500, 'Internal Server Error', 'Failed to create admin user');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a self-serve admin registration page that provisions a new organization and first admin account
- expose a public API endpoint to create the organization and admin with validation and conflict handling
- allow unauthenticated access to the new routes and cover them in middleware tests

## Testing
- npm test *(fails: existing Vitest suites unrelated to this change, e.g. Playwright specs loaded in Vitest environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d620de21d083289f4fe94b8affd5c9