### PR TITLE
Revamp layout shell with collapsible sidebar

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import Sidebar from './sidebar';
 import Topbar from './topbar';
 
@@ -8,12 +9,22 @@ interface LayoutProps {
 }
 
 export default function Layout({ children, onNewTask }: LayoutProps) {
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const sidebarWidth = isSidebarCollapsed ? 80 : 288;
+
   return (
-    <div className="flex h-screen bg-[var(--color-background)] text-[var(--color-text)]">
-      <Sidebar />
-      <div className="flex flex-1 flex-col">
-        <Topbar onNewTask={onNewTask} />
-        <main className="flex-1 overflow-auto p-4">{children}</main>
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text)]">
+      <Sidebar collapsed={isSidebarCollapsed} />
+      <div
+        className="flex min-h-screen w-full flex-col transition-[margin-left] duration-300 ease-in-out"
+        style={{ marginLeft: sidebarWidth }}
+      >
+        <Topbar
+          isSidebarCollapsed={isSidebarCollapsed}
+          onToggleSidebar={() => setIsSidebarCollapsed((prev) => !prev)}
+          onNewTask={onNewTask}
+        />
+        <main className="flex-1 overflow-auto p-6">{children}</main>
       </div>
     </div>
   );

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,7 +1,13 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Avatar } from '@/components/ui/avatar';
+import { cn } from '@/lib/utils';
+
+interface SidebarProps {
+  collapsed?: boolean;
+}
 
 type User = {
   name: string;
@@ -9,10 +15,11 @@ type User = {
   avatar?: string | null;
 };
 
-export default function Sidebar() {
+export default function Sidebar({ collapsed = false }: SidebarProps) {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const pathname = usePathname();
 
   useEffect(() => {
     let isMounted = true;
@@ -51,11 +58,14 @@ export default function Sidebar() {
     };
   }, []);
 
-  const navItems = [
-    { href: '/dashboard', label: 'Dashboard' },
-    { href: '/tasks', label: 'My Tasks' },
-    { href: '/settings', label: 'Settings' },
-  ];
+  const navItems = useMemo(
+    () => [
+      { href: '/dashboard', label: 'Dashboard', icon: DashboardIcon },
+      { href: '/tasks', label: 'My Tasks', icon: TasksIcon },
+      { href: '/settings', label: 'Settings', icon: SettingsIcon },
+    ],
+    []
+  );
 
   const initials = user?.name
     ? user.name
@@ -66,35 +76,130 @@ export default function Sidebar() {
     : user?.email?.[0]?.toUpperCase();
 
   return (
-    <aside className="w-64 border-r border-[var(--color-border)] bg-[var(--color-surface)] p-4 flex flex-col">
-      <div className="mb-6">
-        {loading && <p className="text-sm text-[var(--color-muted)]">Loading user...</p>}
+    <aside
+      className={cn(
+        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[#E5E7EB] bg-[#F9FAFB] px-3 py-6 transition-all duration-300 ease-in-out',
+        collapsed ? 'w-20' : 'w-72'
+      )}
+    >
+      <div className="space-y-8">
+        <div className={cn('flex items-center gap-3 px-2', collapsed && 'justify-center px-0')}>
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm">
+            <span className="text-lg font-semibold text-[#4F46E5]">LT</span>
+          </div>
+          {!collapsed && (
+            <div>
+              <p className="text-base font-semibold text-[#111827]">LoopTask</p>
+              <p className="text-xs text-[#6B7280]">Productivity Hub</p>
+            </div>
+          )}
+        </div>
+
+        <nav className="space-y-1">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const isActive = pathname?.startsWith(item.href);
+
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-[#1F2937] transition-colors hover:bg-white hover:text-[#111827]',
+                  isActive && 'bg-white text-[#111827] shadow-sm',
+                  collapsed && 'justify-center px-0'
+                )}
+              >
+                <Icon className="h-5 w-5 text-[#4F46E5]" />
+                <span
+                  className={cn(
+                    'whitespace-nowrap transition-all duration-200',
+                    collapsed ? 'invisible w-0 opacity-0' : 'visible opacity-100'
+                  )}
+                >
+                  {item.label}
+                </span>
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+
+      <div className={cn('mt-auto rounded-2xl border border-[#E5E7EB] bg-white p-3 shadow-sm', collapsed && 'px-0 text-center')}>
+        {loading && <p className="text-xs text-[#6B7280]">Loading user...</p>}
         {error && !loading && (
-          <p className="text-sm text-red-500" role="alert">
+          <p className="text-xs text-red-500" role="alert">
             {error}
           </p>
         )}
         {!loading && !error && user && (
-          <div className="flex items-center gap-3">
+          <div className={cn('flex items-center gap-3', collapsed && 'flex-col gap-2 text-center')}>
             <Avatar src={user.avatar ?? undefined} fallback={initials} className="h-10 w-10 text-base" />
-            <div>
-              <p className="text-sm font-medium text-[var(--color-text)]">{user.name}</p>
-              <p className="text-xs text-[var(--color-muted)]">{user.email}</p>
-            </div>
+            {!collapsed && (
+              <div className="flex flex-col">
+                <p className="text-sm font-medium text-[#111827]">{user.name}</p>
+                <p className="text-xs text-[#6B7280]">{user.email}</p>
+              </div>
+            )}
+            {collapsed && (
+              <p className="text-xs font-medium text-[#111827]">{user.name ?? user.email}</p>
+            )}
           </div>
         )}
       </div>
-      <nav className="space-y-2">
-        {navItems.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className="flex items-center justify-between rounded px-2 py-1 text-[var(--color-text)] hover:bg-[var(--color-primary)]/10 transition"
-          >
-            {item.label}
-          </Link>
-        ))}
-      </nav>
     </aside>
+  );
+}
+
+function DashboardIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3 13h8V3H3v10zM13 21h8V11h-8v10zM13 3v6h8V3h-8zM3 21h8v-6H3v6z" />
+    </svg>
+  );
+}
+
+function TasksIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M9 11l2 2 4-4" />
+      <rect x="3" y="4" width="18" height="16" rx="2" ry="2" />
+    </svg>
+  );
+}
+
+function SettingsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 15a3 3 0 100-6 3 3 0 000 6z" />
+      <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09a1.65 1.65 0 00-1-1.51 1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06a1.65 1.65 0 00.33-1.82 1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09a1.65 1.65 0 001.51-1 1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06a1.65 1.65 0 001.82.33H9a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06a1.65 1.65 0 00-.33 1.82V9c0 .69.4 1.31 1.01 1.6.3.15.64.22.99.22H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
+    </svg>
   );
 }

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -1,17 +1,40 @@
 'use client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { timing } from '@/lib/motion';
 
 interface TopbarProps {
   onNewTask?: () => void;
+  onToggleSidebar?: () => void;
+  isSidebarCollapsed?: boolean;
 }
 
-export default function Topbar({ onNewTask }: TopbarProps) {
+export default function Topbar({ onNewTask, onToggleSidebar, isSidebarCollapsed }: TopbarProps) {
   const [ripples, setRipples] = useState<{ id: number; x: number; y: number }[]>([]);
   const prefersReducedMotion = useReducedMotion();
   const MotionButton = motion(Button);
+  const pathname = usePathname();
+
+  const breadcrumbs = useMemo(() => {
+    if (!pathname || pathname === '/') {
+      return [];
+    }
+
+    const segments = pathname.split('/').filter(Boolean);
+
+    return segments.map((segment, index) => {
+      const href = `/${segments.slice(0, index + 1).join('/')}`;
+      const label = segment
+        .split('-')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+
+      return { href, label };
+    });
+  }, [pathname]);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!onNewTask) return;
@@ -24,28 +47,75 @@ export default function Topbar({ onNewTask }: TopbarProps) {
     onNewTask();
   };
 
+  const currentPageTitle = breadcrumbs.at(-1)?.label ?? 'Overview';
+
   return (
-    <header className="h-14 flex items-center justify-between px-4 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
-      <h1 className="font-semibold text-lg text-[var(--color-text)]">Tasks</h1>
-      {onNewTask && (
-        <MotionButton
-          onClick={handleClick}
-          whileTap={{ scale: 0.95 }}
-          className="relative overflow-hidden"
-        >
-          New Task
-          {ripples.map((r) => (
-            <motion.span
-              key={r.id}
-              className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/30"
-              style={{ left: r.x, top: r.y, width: 20, height: 20 }}
-              initial={{ opacity: 0.5, scale: 0 }}
-              animate={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 8 }}
-              transition={timing.settle}
-            />
-          ))}
-        </MotionButton>
-      )}
+    <header className="sticky top-0 z-30 border-b border-[#E5E7EB] bg-background/95 px-6 backdrop-blur supports-[backdrop-filter]:backdrop-blur">
+      <div className="flex h-16 items-center justify-between gap-4">
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={onToggleSidebar}
+            disabled={!onToggleSidebar}
+            className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#E5E7EB] bg-white text-[#111827] shadow-sm transition hover:border-[#4F46E5] hover:text-[#4F46E5] disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            <MenuIcon className="h-5 w-5" />
+          </button>
+          <div className="flex flex-col">
+            <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-xs text-[var(--color-muted)]">
+              <Link href="/" className="transition hover:text-[var(--color-text)]">
+                Home
+              </Link>
+              {breadcrumbs.map((crumb) => (
+                <span key={crumb.href} className="flex items-center gap-2">
+                  <span className="text-[var(--color-border)]">/</span>
+                  <Link href={crumb.href} className="transition hover:text-[var(--color-text)]">
+                    {crumb.label}
+                  </Link>
+                </span>
+              ))}
+            </nav>
+            <h1 className="text-lg font-semibold text-[var(--color-text)]">{currentPageTitle}</h1>
+          </div>
+        </div>
+
+        {onNewTask && (
+          <MotionButton
+            onClick={handleClick}
+            whileTap={{ scale: 0.95 }}
+            className="relative overflow-hidden"
+          >
+            New Task
+            {ripples.map((r) => (
+              <motion.span
+                key={r.id}
+                className="absolute pointer-events-none -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/30"
+                style={{ left: r.x, top: r.y, width: 20, height: 20 }}
+                initial={{ opacity: 0.5, scale: 0 }}
+                animate={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 8 }}
+                transition={timing.settle}
+              />
+            ))}
+          </MotionButton>
+        )}
+      </div>
     </header>
+  );
+}
+
+function MenuIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      className={className}
+    >
+      <path d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary
- refactor the layout shell to reserve a fixed sidebar width and apply the blurred sticky header treatment
- redesign the sidebar with off-white styling, icon navigation, collapse states, and a pinned user profile card
- update the topbar to surface the sidebar toggle, breadcrumb trail, and compact sticky header spacing

## Testing
- npm run lint *(fails: existing warnings for console usage and unsafe any assignments across legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a0eee3cc83288c93b0737f47a87a