### PR TITLE
feat: redesign kanban column layout and cards

### DIFF
--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -4,54 +4,44 @@ import * as React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Avatar } from '@/components/ui/avatar';
-import { Badge, type BadgeProps } from '@/components/ui/badge';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
 
 export interface TaskCardProps {
   task: {
     _id: string;
     title: string;
+    description?: string;
     assignee?: string;
     assigneeAvatar?: string;
     dueDate?: string;
     priority?: string;
     status: string;
+    tags?: string[];
   };
   onChange?: () => void;
   href?: string;
   canEdit?: boolean;
 }
 
-const getBadgeVariant = (value?: string): BadgeProps['variant'] => {
-  if (!value) return 'secondary';
+const getPriorityBadgeClasses = (priority?: string) => {
+  if (!priority) return '';
 
-  const normalized = value.toLowerCase();
-  const sanitized = normalized.replace(/[_-]/g, ' ');
+  const normalized = priority.trim().toLowerCase();
 
-  if (['success', 'done', 'completed', 'complete'].includes(sanitized)) {
-    return 'success';
+  if (['urgent', 'critical', 'high'].includes(normalized)) {
+    return 'bg-rose-100 text-rose-600';
   }
 
-  if (
-    ['in progress', 'in-progress', 'progress', 'doing'].some(
-      (state) => sanitized === state
-    )
-  ) {
-    return 'inProgress';
+  if (['medium', 'normal'].includes(normalized)) {
+    return 'bg-amber-100 text-amber-700';
   }
 
-  if (['backlog', 'todo', 'to do'].includes(sanitized)) {
-    return 'backlog';
+  if (['low', 'minor'].includes(normalized)) {
+    return 'bg-emerald-100 text-emerald-600';
   }
 
-  if (['urgent', 'high'].includes(sanitized)) {
-    return 'urgent';
-  }
-
-  if (['low', 'low priority'].includes(sanitized)) {
-    return 'low';
-  }
-
-  return 'secondary';
+  return 'bg-slate-100 text-slate-600';
 };
 
 export default function TaskCard({ task, onChange, href, canEdit = true }: TaskCardProps) {
@@ -59,6 +49,13 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
   const normalizedStatus = task.status?.trim().toUpperCase();
   const isDone = normalizedStatus === 'DONE';
   const showActions = canEdit && !isDone;
+  const combinedTags = React.useMemo(
+    () =>
+      [...(task.tags ?? []), task.status].filter(
+        (tag): tag is string => Boolean(tag)
+      ),
+    [task.tags, task.status]
+  );
 
   const handleEdit = () => {
     if (!showActions) return;
@@ -71,30 +68,123 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
     onChange?.();
   };
 
+  const handleEditClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    handleEdit();
+  };
+
+  const handleDeleteClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    await handleDelete();
+  };
+
   const cardContent = (
-    <div className="flex w-full items-center gap-3">
-      {task.assignee && (
-        <Avatar
-          src={task.assigneeAvatar}
-          fallback={task.assignee.charAt(0)}
-        />
-      )}
-      <div className="flex flex-col">
-        <span className="text-sm font-semibold text-[#111827]">{task.title}</span>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[#4B5563]">
-          {task.assignee && <span>{task.assignee}</span>}
-          {task.dueDate && <span>Due {task.dueDate}</span>}
-          {task.priority && (
-            <Badge variant={getBadgeVariant(task.priority)}>{task.priority}</Badge>
+    <div className="flex h-full flex-col">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-slate-800 line-clamp-1">
+            {task.title}
+          </h3>
+          {task.description && (
+            <p className="mt-1 text-sm text-slate-500 line-clamp-2">
+              {task.description}
+            </p>
           )}
-          <Badge variant={getBadgeVariant(task.status)}>{task.status}</Badge>
         </div>
+        {task.priority && (
+          <span
+            className={cn(
+              'inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-wide',
+              getPriorityBadgeClasses(task.priority)
+            )}
+          >
+            {task.priority}
+          </span>
+        )}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {combinedTags.map((tag) => (
+          <Badge
+            key={`${task._id}-${tag}`}
+            className="rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-slate-600"
+          >
+            {tag}
+          </Badge>
+        ))}
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {task.assignee && (
+            <Avatar
+              src={task.assigneeAvatar}
+              fallback={task.assignee.charAt(0)}
+              className="h-8 w-8 text-sm"
+            />
+          )}
+          <div className="flex flex-col text-xs text-slate-500">
+            {task.assignee && (
+              <span className="font-medium text-slate-700">{task.assignee}</span>
+            )}
+            {task.dueDate && <span>Due {task.dueDate}</span>}
+          </div>
+        </div>
+        {showActions ? (
+          <div className="flex items-center gap-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100">
+            <button
+              type="button"
+              onClick={handleEditClick}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:ring-offset-2 focus:ring-offset-white"
+              aria-label="Edit task"
+              title="Edit task"
+            >
+              <span className="sr-only">Edit task</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+              >
+                <path d="M16.862 4.487l1.651-1.651a1.875 1.875 0 112.652 2.652L7.1 19.554a3 3 0 01-1.265.757l-2.5.75.75-2.5a3 3 0 01.757-1.265L16.862 4.487z" />
+                <path d="M15 5.25l3 3" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={handleDeleteClick}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-200 text-rose-500 transition-colors hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-400/40 focus:ring-offset-2 focus:ring-offset-white"
+              aria-label="Delete task"
+              title="Delete task"
+            >
+              <span className="sr-only">Delete task</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+              >
+                <path d="M9.75 9.75l.347 8.347a1 1 0 00.996.903h2.214a1 1 0 00.996-.903L14.65 9.75" />
+                <path d="M19.5 6h-15" />
+                <path d="M16.5 6l-.427-1.708A2 2 0 0014.127 3h-4.254a2 2 0 00-1.946 1.292L7.5 6" />
+              </svg>
+            </button>
+          </div>
+        ) : null}
       </div>
     </div>
   );
 
   return (
-    <div className="flex flex-col gap-3 rounded-[12px] border border-[#E5E7EB] bg-white p-4 shadow-sm transition-all hover:border-indigo-200 hover:shadow-[0_12px_24px_rgba(79,70,229,0.12)] focus-within:border-indigo-200 focus-within:shadow-[0_12px_24px_rgba(79,70,229,0.12)]">
+    <div className="group flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_35px_rgba(15,23,42,0.15)] focus-within:-translate-y-0.5 focus-within:shadow-[0_18px_35px_rgba(15,23,42,0.15)]">
       {href ? (
         <Link
           href={href}
@@ -105,55 +195,6 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
       ) : (
         cardContent
       )}
-      {showActions ? (
-        <div className="mt-2 flex justify-end gap-2 sm:justify-start">
-          <button
-            type="button"
-            onClick={() => handleEdit()}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[#E5E7EB] text-[#4B5563] transition-colors hover:bg-[rgba(79,70,229,0.08)] hover:text-[#4338CA] focus:outline-none focus:ring-2 focus:ring-[#4F46E5]/30 focus:ring-offset-2 focus:ring-offset-white"
-            aria-label="Edit task"
-            title="Edit task"
-          >
-            <span className="sr-only">Edit task</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-4 w-4"
-            >
-              <path d="M16.862 4.487l1.651-1.651a1.875 1.875 0 112.652 2.652L7.1 19.554a3 3 0 01-1.265.757l-2.5.75.75-2.5a3 3 0 01.757-1.265L16.862 4.487z" />
-              <path d="M15 5.25l3 3" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={() => void handleDelete()}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[#FECACA] text-[#DC2626] transition-colors hover:bg-[#FEE2E2] hover:text-[#B91C1C] focus:outline-none focus:ring-2 focus:ring-[#DC2626]/30 focus:ring-offset-2 focus:ring-offset-white"
-            aria-label="Delete task"
-            title="Delete task"
-          >
-            <span className="sr-only">Delete task</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-4 w-4"
-            >
-              <path d="M9.75 9.75l.347 8.347a1 1 0 00.996.903h2.214a1 1 0 00.996-.903L14.65 9.75" />
-              <path d="M19.5 6h-15" />
-              <path d="M16.5 6l-.427-1.708A2 2 0 0014.127 3h-4.254a2 2 0 00-1.946 1.292L7.5 6" />
-            </svg>
-          </button>
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/components/task-kanban-column.tsx
+++ b/src/components/task-kanban-column.tsx
@@ -37,55 +37,88 @@ export default function TaskKanbanColumn({
     : 0;
 
   return (
-    <section className="flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 shadow-sm md:max-h-[70vh]">
-      <header className="flex flex-col gap-3 border-b border-gray-200 bg-white px-4 py-4">
-        <div className="flex items-center justify-between">
-          <div className="text-sm font-semibold uppercase tracking-wide text-gray-600">
-            {label}
-          </div>
-          <span
-            className={cn(
-              'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold',
-              statusAccent.badge
-            )}
-          >
-            {cardTasks.length} tasks
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-200">
-            <div
-              className={cn('h-full rounded-full transition-all duration-300 ease-out', statusAccent.progress)}
-              style={{ width: `${progressPercentage}%` }}
-              aria-hidden
-            />
-          </div>
-          <span className="text-xs font-medium text-gray-500">{progressPercentage}%</span>
-        </div>
-      </header>
-      <div className="flex-1 overflow-hidden">
-        <div className="flex h-full flex-col px-4 py-4 md:overflow-y-auto">
-          {isLoading ? (
-            <ul className="space-y-3">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <li
-                  key={i}
-                  className="h-24 animate-pulse rounded-xl border border-gray-200 bg-gray-100"
+    <div className="flex gap-6 overflow-x-auto pb-6">
+      <section className="min-w-80 shrink-0 overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm ring-1 ring-black/5">
+        <header
+          className={cn(
+            'flex flex-col gap-4 px-5 py-5 text-white',
+            statusAccent.header
+          )}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-white/80">
+                <span
+                  className={cn('h-2.5 w-2.5 rounded-full', statusAccent.dot)}
+                  aria-hidden
                 />
-              ))}
-            </ul>
-          ) : isEmpty ? (
-            <div className="py-6 text-center text-sm text-gray-500">
-              No tasks found.
+                {label}
+              </span>
+              <p className="mt-2 text-sm font-medium text-white/90">
+                {cardTasks.length} tasks
+              </p>
             </div>
-          ) : (
-            <div className="space-y-3">
-              {cardTasks.map((task) => {
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-full border border-white/40 bg-white/10 px-3 py-1 text-xs font-medium text-white/90 shadow-sm transition-colors hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <path d="M10 4.167v11.666" />
+                <path d="M4.167 10h11.666" />
+              </svg>
+              Add task
+            </button>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/30">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-all duration-300 ease-out',
+                  statusAccent.progress
+                )}
+                style={{ width: `${progressPercentage}%` }}
+                aria-hidden
+              />
+            </div>
+            <span className="text-xs font-semibold text-white/90">
+              {progressPercentage}%
+            </span>
+          </div>
+        </header>
+        <div className="flex max-h-[70vh] flex-1 flex-col overflow-hidden">
+          <div className="flex-1 space-y-4 overflow-y-auto px-5 py-5">
+            {isLoading ? (
+              <ul className="space-y-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <li
+                    key={i}
+                    className="h-28 animate-pulse rounded-2xl border border-white/40 bg-white/30"
+                  />
+                ))}
+              </ul>
+            ) : isEmpty ? (
+              <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-white/40 bg-white/10 px-6 py-10 text-center text-sm text-slate-100">
+                <p className="font-medium text-white/80">No tasks found.</p>
+                <p className="mt-1 text-xs text-white/70">
+                  Start by creating a new item for this stage.
+                </p>
+              </div>
+            ) : (
+              cardTasks.map((task) => {
                 const extendedTask = task as Task & { assignee?: string };
                 const canEdit = Boolean(
                   currentUserId &&
-                    (currentUserId === task.createdBy ||
-                      currentUserId === task.ownerId)
+                    (currentUserId === task.createdBy || currentUserId === task.ownerId)
                 );
                 const isSelected = Boolean(
                   currentUserId &&
@@ -94,14 +127,14 @@ export default function TaskKanbanColumn({
                 return (
                   <motion.div
                     key={task._id}
-                    initial={{ opacity: 0, y: 6 }}
+                    initial={{ opacity: 0, y: 8 }}
                     animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 6 }}
+                    exit={{ opacity: 0, y: 8 }}
                     className={cn(
-                      'group rounded-xl ring-1 ring-transparent ring-offset-2 ring-offset-gray-50 transition duration-200',
-                      'hover:-translate-y-0.5 hover:ring-2 hover:ring-indigo-200 hover:shadow-md',
-                      'focus-within:outline-none focus-within:ring-2 focus-within:ring-indigo-300 focus-within:shadow-md',
-                      isSelected && 'ring-2 ring-indigo-300 shadow-md'
+                      'group rounded-2xl ring-1 ring-transparent ring-offset-2 ring-offset-white transition duration-200',
+                      'hover:-translate-y-0.5 hover:ring-2 hover:ring-white/80 hover:shadow-[0_20px_45px_rgba(15,23,42,0.18)]',
+                      'focus-within:outline-none focus-within:ring-2 focus-within:ring-white focus-within:shadow-[0_18px_40px_rgba(15,23,42,0.16)]',
+                      isSelected && 'ring-2 ring-white shadow-[0_18px_40px_rgba(15,23,42,0.16)]'
                     )}
                     data-selected={isSelected}
                   >
@@ -109,10 +142,13 @@ export default function TaskKanbanColumn({
                       task={{
                         _id: task._id,
                         title: task.title,
+                        description: (task as Task & { description?: string }).description,
                         assignee: extendedTask.assignee || task.ownerId,
+                        assigneeAvatar: (task as Task & { assigneeAvatar?: string }).assigneeAvatar,
                         dueDate: task.dueDate,
                         priority: task.priority,
                         status: task.status,
+                        tags: (task as Task & { tags?: string[] }).tags,
                       }}
                       href={`/tasks/${task._id}`}
                       onChange={onTaskChange}
@@ -120,52 +156,84 @@ export default function TaskKanbanColumn({
                     />
                   </motion.div>
                 );
-              })}
-            </div>
-          )}
+              })
+            )}
+          </div>
+          <div className="border-t border-dashed border-white/30 px-5 py-4">
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-slate-200 bg-white/70 py-3 text-sm font-medium text-slate-500 transition-colors hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-5 w-5"
+                aria-hidden="true"
+              >
+                <path d="M10 4.167v11.666" />
+                <path d="M4.167 10h11.666" />
+              </svg>
+              Add task
+            </button>
+          </div>
         </div>
-      </div>
-      {hasMore && onLoadMore && (
-        <div className="border-t border-gray-200 bg-white px-4 py-3">
-          <button
-            className="w-full rounded-md border border-gray-200 bg-gray-100 px-3 py-2 text-sm font-medium text-gray-600 transition hover:border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 disabled:cursor-not-allowed disabled:opacity-60"
-            onClick={() => void onLoadMore()}
-            disabled={isLoadingMore}
-          >
-            {isLoadingMore ? 'Loading…' : 'Load more'}
-          </button>
-        </div>
-      )}
-    </section>
+        {hasMore && onLoadMore && (
+          <div className="border-t border-slate-200 bg-white px-5 py-3">
+            <button
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-100 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => void onLoadMore()}
+              disabled={isLoadingMore}
+            >
+              {isLoadingMore ? 'Loading…' : 'Load more'}
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
   );
 }
 
 function getStatusAccentStyles(
   status: string
-): { badge: string; progress: string } {
+): { header: string; dot: string; progress: string } {
   switch (status) {
     case 'OPEN':
       return {
-        badge: 'bg-sky-100 text-sky-700',
-        progress: 'bg-sky-500',
+        header: 'bg-red-500',
+        dot: 'bg-white',
+        progress: 'bg-white',
       };
     case 'IN_PROGRESS':
-    case 'IN_REVIEW':
-    case 'REVISIONS':
     case 'FLOW_IN_PROGRESS':
       return {
-        badge: 'bg-amber-100 text-amber-700',
-        progress: 'bg-amber-500',
+        header: 'bg-blue-500',
+        dot: 'bg-white',
+        progress: 'bg-white',
+      };
+    case 'IN_REVIEW':
+    case 'REVIEW':
+    case 'REVISIONS':
+      return {
+        header: 'bg-yellow-500',
+        dot: 'bg-slate-900/80',
+        progress: 'bg-white',
       };
     case 'DONE':
       return {
-        badge: 'bg-emerald-100 text-emerald-700',
-        progress: 'bg-emerald-500',
+        header: 'bg-green-500',
+        dot: 'bg-white',
+        progress: 'bg-white',
       };
     default:
       return {
-        badge: 'bg-indigo-100 text-indigo-700',
-        progress: 'bg-indigo-500',
+        header: 'bg-slate-600',
+        dot: 'bg-white/80',
+        progress: 'bg-white',
       };
   }
 }


### PR DESCRIPTION
## Summary
- render kanban columns inside a horizontal scrolling track with updated status headers and add-task affordances
- refresh column status styling to align with the open/in progress/review/done palette and progress visuals
- restyle task cards with priority chips, tag badges, metadata footer, and hover transitions for consistency

## Testing
- npm run lint *(fails: existing repository warnings about console usage and unsafe any assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68d7a726036c8328aa4e0b1a5606c443