### PR TITLE
Refine shared components to use refreshed theme palette

### DIFF
--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -188,18 +188,18 @@ export default function CommentThread({
             />
             <div className="flex-1">
               <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <span className="text-sm font-semibold text-[#111827]">{name}</span>
-                <time className="text-xs text-[#6B7280]">
+                <span className="text-sm font-semibold text-[var(--tone-text-strong)]">{name}</span>
+                <time className="text-xs text-[var(--color-text-muted)]">
                   {formatTimestamp(comment.createdAt)}
                 </time>
               </div>
-              <div className="mt-2 rounded-2xl bg-[#F3F4F6] px-4 py-3 text-sm text-[#111827] shadow-sm">
+              <div className="mt-2 rounded-2xl bg-[var(--surface-page)] px-4 py-3 text-sm text-[var(--tone-text)] shadow-sm">
                 {comment.content}
               </div>
               <div className="mt-2 flex items-center gap-3">
                 <button
                   type="button"
-                  className="text-xs font-medium text-[#4F46E5] transition hover:text-[#4338CA]"
+                  className="text-xs font-medium text-[var(--brand-primary)] transition hover:text-[color:rgba(3,2,19,0.7)]"
                   onClick={() => setReplyingTo(comment._id)}
                   disabled={!user}
                 >
@@ -210,13 +210,13 @@ export default function CommentThread({
           </div>
           {replyingTo === comment._id ? (
             <div className="ml-12">
-              <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+              <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-4 shadow-sm">
                 <textarea
                   value={replyContent}
                   onChange={(e) => setReplyContent(e.target.value)}
                   placeholder={user ? 'Write a reply…' : 'Sign in to reply'}
                   disabled={!user}
-                  className="min-h-[72px] w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#C7D2FE]"
+                  className="min-h-[72px] w-full resize-none rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--tone-text)] placeholder:text-[var(--color-text-secondary)] focus:border-[var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20"
                 />
                 <div className="mt-3 flex justify-end gap-2">
                   <Button
@@ -251,7 +251,7 @@ export default function CommentThread({
     <div
       className={cn(
         parentId
-          ? 'mt-4 space-y-6 border-l border-gray-200 pl-6'
+          ? 'mt-4 space-y-6 border-l border-[var(--color-border)] pl-6'
           : 'flex flex-1 flex-col gap-6',
         className
       )}
@@ -260,20 +260,20 @@ export default function CommentThread({
         {comments.length ? (
           comments.map((comment) => renderComment(comment))
         ) : parentId ? null : (
-          <div className="rounded-xl border border-dashed border-gray-200 bg-[#F9FAFB] px-4 py-6 text-center text-sm text-[#6B7280]">
+          <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-page)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
             No comments yet. Start the conversation!
           </div>
         )}
       </div>
       {!parentId && (
         <form
-          className="mt-auto space-y-4 border-t border-gray-200 pt-4"
+          className="mt-auto space-y-4 border-t border-[var(--color-border)] pt-4"
           onSubmit={(event) => {
             event.preventDefault();
             void handleCreate(null);
           }}
         >
-          <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-sm">
             <textarea
               value={newContent}
               onChange={(e) => {
@@ -285,11 +285,11 @@ export default function CommentThread({
               }}
               placeholder={user ? 'Share an update…' : 'Sign in to comment'}
               disabled={!user}
-              className="min-h-[96px] w-full resize-none rounded-xl border-0 bg-transparent px-4 py-3 text-sm text-[#111827] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-0"
+              className="min-h-[96px] w-full resize-none rounded-xl border-0 bg-transparent px-4 py-3 text-sm text-[var(--tone-text)] placeholder:text-[var(--color-text-secondary)] focus:outline-none focus:ring-0"
             />
           </div>
           {displayUsers.length ? (
-            <div className="text-xs text-[#6B7280]">
+            <div className="text-xs text-[var(--color-text-muted)]">
               {displayUsers.map((u) => (
                 <span key={u._id} className="block">
                   {`${u.name ?? 'Someone'} is typing…`}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -78,19 +78,19 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[#E5E7EB] bg-[#F9FAFB] px-3 py-6 transition-all duration-300 ease-in-out',
+        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--color-border)] bg-[var(--surface-page)] px-3 py-6 transition-all duration-300 ease-in-out',
         collapsed ? 'w-20' : 'w-72'
       )}
     >
       <div className="space-y-8">
         <div className={cn('flex items-center gap-3 px-2', collapsed && 'justify-center px-0')}>
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-white shadow-sm">
-            <span className="text-lg font-semibold text-[#4F46E5]">LT</span>
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[var(--color-surface)] shadow-sm">
+            <span className="text-lg font-semibold text-[var(--brand-primary)]">LT</span>
           </div>
           {!collapsed && (
             <div>
-              <p className="text-base font-semibold text-[#111827]">LoopTask</p>
-              <p className="text-xs text-[#6B7280]">Productivity Hub</p>
+              <p className="text-base font-semibold text-[var(--tone-text-strong)]">LoopTask</p>
+              <p className="text-xs text-[var(--color-text-muted)]">Productivity Hub</p>
             </div>
           )}
         </div>
@@ -105,12 +105,12 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-[#1F2937] transition-colors hover:bg-white hover:text-[#111827]',
-                  isActive && 'bg-white text-[#111827] shadow-sm',
+                  'group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-[var(--tone-text)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--tone-text-strong)]',
+                  isActive && 'bg-[var(--color-surface)] text-[var(--tone-text-strong)] shadow-sm',
                   collapsed && 'justify-center px-0'
                 )}
               >
-                <Icon className="h-5 w-5 text-[#4F46E5]" />
+                <Icon className="h-5 w-5 text-[var(--brand-primary)]" />
                 <span
                   className={cn(
                     'whitespace-nowrap transition-all duration-200',
@@ -125,10 +125,10 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
         </nav>
       </div>
 
-      <div className={cn('mt-auto rounded-2xl border border-[#E5E7EB] bg-white p-3 shadow-sm', collapsed && 'px-0 text-center')}>
-        {loading && <p className="text-xs text-[#6B7280]">Loading user...</p>}
+      <div className={cn('mt-auto rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-3 shadow-sm', collapsed && 'px-0 text-center')}>
+        {loading && <p className="text-xs text-[var(--color-text-muted)]">Loading user...</p>}
         {error && !loading && (
-          <p className="text-xs text-red-500" role="alert">
+          <p className="text-xs text-[var(--color-status-destructive)]" role="alert">
             {error}
           </p>
         )}
@@ -137,12 +137,12 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
             <Avatar src={user.avatar ?? undefined} fallback={initials} className="h-10 w-10 text-base" />
             {!collapsed && (
               <div className="flex flex-col">
-                <p className="text-sm font-medium text-[#111827]">{user.name}</p>
-                <p className="text-xs text-[#6B7280]">{user.email}</p>
+                <p className="text-sm font-medium text-[var(--tone-text-strong)]">{user.name}</p>
+                <p className="text-xs text-[var(--color-text-muted)]">{user.email}</p>
               </div>
             )}
             {collapsed && (
-              <p className="text-xs font-medium text-[#111827]">{user.name ?? user.email}</p>
+              <p className="text-xs font-medium text-[var(--tone-text-strong)]">{user.name ?? user.email}</p>
             )}
           </div>
         )}

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -50,14 +50,14 @@ export default function Topbar({ onNewTask, onToggleSidebar, isSidebarCollapsed 
   const currentPageTitle = breadcrumbs.at(-1)?.label ?? 'Overview';
 
   return (
-    <header className="sticky top-0 z-30 border-b border-[#E5E7EB] bg-background/95 px-6 backdrop-blur supports-[backdrop-filter]:backdrop-blur">
+    <header className="sticky top-0 z-30 border-b border-[var(--color-border)] bg-background/95 px-6 backdrop-blur supports-[backdrop-filter]:backdrop-blur">
       <div className="flex h-16 items-center justify-between gap-4">
         <div className="flex items-center gap-4">
           <button
             type="button"
             onClick={onToggleSidebar}
             disabled={!onToggleSidebar}
-            className="flex h-10 w-10 items-center justify-center rounded-xl border border-[#E5E7EB] bg-white text-[#111827] shadow-sm transition hover:border-[#4F46E5] hover:text-[#4F46E5] disabled:cursor-not-allowed disabled:opacity-60"
+            className="flex h-10 w-10 items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--tone-text-strong)] shadow-sm transition hover:border-[var(--brand-primary)] hover:text-[var(--brand-primary)] disabled:cursor-not-allowed disabled:opacity-60"
             aria-label={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
             <MenuIcon className="h-5 w-5" />

--- a/src/components/notifications-badge.tsx
+++ b/src/components/notifications-badge.tsx
@@ -48,7 +48,7 @@ export default function NotificationsBadge({ className }: NotificationsBadgeProp
 
   return (
     <Badge
-      variant="urgent"
+      variant="destructive"
       className={cn('ml-2 px-2 py-[2px] text-[11px] leading-none', className)}
     >
       {count}

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -1,37 +1,45 @@
-import { Badge } from '@/components/ui/badge';
+import { Badge, type BadgeProps } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { TaskStatus } from '@/models/Task';
 
-const STATUS_STYLES: Record<TaskStatus, { label: string; icon: string; className: string }> = {
+type BadgeVariant = NonNullable<BadgeProps['variant']>;
+
+const STATUS_STYLES: Record<
+  TaskStatus,
+  { label: string; icon: string; variant: BadgeVariant; className?: string }
+> = {
   OPEN: {
     label: 'Open',
     icon: '📝',
-    className: 'bg-[#6B7280] text-white',
+    variant: 'outline',
+    className: 'text-[var(--tone-text)]',
   },
   IN_PROGRESS: {
     label: 'In Progress',
     icon: '⏳',
-    className: 'bg-[#3B82F6] text-white',
+    variant: 'info',
   },
   IN_REVIEW: {
     label: 'In Review',
     icon: '👀',
-    className: 'bg-[#6366F1] text-white',
+    variant: 'secondary',
+    className: 'text-[var(--brand-primary)]',
   },
   REVISIONS: {
     label: 'Revisions',
     icon: '✏️',
-    className: 'bg-[#EF4444] text-white',
+    variant: 'destructive',
   },
   FLOW_IN_PROGRESS: {
     label: 'Flow In Progress',
     icon: '🔄',
-    className: 'bg-[#8B5CF6] text-white',
+    variant: 'info',
+    className: 'bg-[color:rgba(46,144,250,0.16)] text-[var(--color-status-info)]',
   },
   DONE: {
     label: 'Done',
     icon: '✅',
-    className: 'bg-[#10B981] text-white',
+    variant: 'success',
   },
 };
 
@@ -55,13 +63,15 @@ export function StatusBadge({
   className,
   showIcon = true,
 }: StatusBadgeProps) {
-  const { label, icon, className: statusClassName } = STATUS_STYLES[status];
+  const { label, icon, variant, className: statusClassName } =
+    STATUS_STYLES[status];
 
   return (
     <Badge
+      variant={variant}
       className={cn(
-        'gap-1 rounded-full font-semibold normal-case text-white shadow-sm ring-1 ring-inset ring-black/10 transition',
-        'hover:ring-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#1F2937] focus-visible:ring-offset-2 focus-visible:ring-offset-[#F9FAFB]',
+        'gap-1 rounded-full font-semibold normal-case shadow-sm ring-1 ring-inset ring-black/10 transition',
+        'hover:ring-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-page)]',
         SIZE_STYLES[size],
         statusClassName,
         className,

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -31,14 +31,14 @@ function formatTimestamp(date: string) {
 export function Timeline({ events }: { events: TimelineEvent[] }) {
   if (!events.length) {
     return (
-      <div className="rounded-xl border border-dashed border-gray-200 bg-[#F9FAFB] px-4 py-6 text-center text-sm text-[#6B7280]">
+      <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-page)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
         No activity yet.
       </div>
     );
   }
 
   return (
-    <ul className="relative space-y-6 border-l border-gray-200 pl-6">
+    <ul className="relative space-y-6 border-l border-[var(--color-border)] pl-6">
       {events.map((event, index) => {
         const interactive = Boolean(event.type);
         const icon = event.type ? ICONS[event.type] : '•';
@@ -53,16 +53,16 @@ export function Timeline({ events }: { events: TimelineEvent[] }) {
             className="group relative pl-4"
             aria-disabled={!interactive}
           >
-            <span className="absolute -left-[26px] top-3 flex h-5 w-5 items-center justify-center rounded-full border border-[#4F46E5] bg-white text-[11px] font-semibold text-[#4F46E5]">
+            <span className="absolute -left-[26px] top-3 flex h-5 w-5 items-center justify-center rounded-full border border-[var(--brand-primary)] bg-[var(--color-surface)] text-[11px] font-semibold text-[var(--brand-primary)]">
               {icon}
             </span>
             {index !== events.length - 1 ? (
-              <span className="absolute -left-[18px] top-7 block h-full w-px bg-gray-200" aria-hidden />
+              <span className="absolute -left-[18px] top-7 block h-full w-px bg-[var(--color-border)]" aria-hidden />
             ) : null}
             <div
               className={cn(
                 'flex items-start gap-3 rounded-lg border border-transparent px-4 py-3 transition-colors',
-                'group-hover:border-[#E5E7EB] group-hover:bg-[#F9FAFB]',
+                'group-hover:border-[var(--color-border)] group-hover:bg-[var(--surface-page)]',
                 'group-aria-[disabled=true]:opacity-70 group-aria-[disabled=true]:hover:border-transparent group-aria-[disabled=true]:hover:bg-transparent'
               )}
             >
@@ -73,12 +73,12 @@ export function Timeline({ events }: { events: TimelineEvent[] }) {
               />
               <div className="flex-1">
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                  <span className="text-sm font-semibold text-[#111827]">{event.user.name}</span>
-                  <time className="text-xs text-[#6B7280]">
+                  <span className="text-sm font-semibold text-[var(--tone-text-strong)]">{event.user.name}</span>
+                  <time className="text-xs text-[var(--color-text-muted)]">
                     {formatTimestamp(event.date)}
                   </time>
                 </div>
-                <p className="mt-1 text-sm text-[#6B7280]">{event.status}</p>
+                <p className="mt-1 text-sm text-[var(--color-text-muted)]">{event.status}</p>
               </div>
             </div>
           </motion.li>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,16 +2,29 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
+type BadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'outline'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+  | 'info';
+
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
-  variant?:
-    | 'default'
-    | 'secondary'
-    | 'success'
-    | 'inProgress'
-    | 'backlog'
-    | 'urgent'
-    | 'low';
+  variant?: BadgeVariant;
 }
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'bg-[var(--brand-primary)] text-white',
+  secondary: 'bg-[var(--brand-secondary)] text-[var(--brand-primary)]',
+  outline:
+    'border border-[var(--color-border-strong)] bg-transparent text-[var(--tone-text-strong)]',
+  destructive: 'bg-[var(--color-status-destructive)] text-white',
+  success: 'bg-[var(--color-status-success)] text-white',
+  warning: 'bg-[var(--color-status-warning)] text-white',
+  info: 'bg-[var(--color-status-info)] text-white',
+};
 
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   ({ className, variant = 'default', ...props }, ref) => {
@@ -19,16 +32,8 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
       <span
         ref={ref}
         className={cn(
-          'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium capitalize',
-          {
-            default: 'bg-gray-100 text-gray-800',
-            secondary: 'bg-blue-100 text-blue-800',
-            success: 'bg-[#10B981] text-white',
-            inProgress: 'bg-[#3B82F6] text-white',
-            backlog: 'bg-[#F59E0B] text-white',
-            urgent: 'bg-[#EF4444] text-white',
-            low: 'bg-[#6B7280] text-white',
-          }[variant],
+          'inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-1 text-xs font-medium capitalize tracking-wide transition-colors',
+          variantClasses[variant],
           className
         )}
         {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,20 +2,50 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'default' | 'outline';
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'outline';
+type ButtonSize = 'sm' | 'md' | 'lg' | 'icon';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
 }
 
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-[var(--brand-primary)] text-white shadow-sm hover:bg-[#151433] focus-visible:ring-[var(--brand-primary)] disabled:bg-[color:rgba(3,2,19,0.35)] disabled:text-white/70',
+  secondary:
+    'bg-[var(--brand-secondary)] text-[var(--brand-primary)] shadow-sm hover:bg-[#d8d3ff] focus-visible:ring-[var(--brand-primary)] disabled:bg-[color:rgba(227,225,255,0.6)] disabled:text-[var(--brand-primary)]/60',
+  ghost:
+    'bg-transparent text-[var(--brand-primary)] hover:bg-[color:rgba(227,225,255,0.5)] focus-visible:ring-[var(--brand-primary)] disabled:text-[var(--brand-primary)]/50',
+  outline:
+    'border border-[var(--color-border-strong)] bg-transparent text-[var(--brand-primary)] shadow-sm hover:bg-[color:rgba(227,225,255,0.4)] focus-visible:ring-[var(--brand-primary)] disabled:text-[var(--brand-primary)]/50 disabled:border-[color:rgba(194,199,214,0.8)]',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-8 px-3 text-xs',
+  md: 'h-9 px-4 text-sm',
+  lg: 'h-11 px-6 text-base',
+  icon: 'h-9 w-9',
+};
+
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'default', ...props }, ref) => {
+  (
+    {
+      className,
+      variant = 'primary',
+      size = 'md',
+      ...props
+    },
+    ref,
+  ) => {
     return (
       <button
         ref={ref}
         className={cn(
-          'inline-flex items-center justify-center rounded-lg text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] focus:ring-opacity-30 disabled:pointer-events-none h-9 px-5 py-2.5 tracking-tight',
-          variant === 'default'
-            ? 'bg-[#4F46E5] text-white hover:bg-[#4338CA] disabled:bg-[#E0E7FF] disabled:text-[#4338CA]/60'
-            : 'border border-[#4F46E5] text-[#4F46E5] hover:bg-[rgba(79,70,229,0.08)] hover:text-[#4338CA] disabled:border-[#E0E7FF] disabled:text-[#A5B4FC]',
+          'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)] disabled:pointer-events-none disabled:opacity-90',
+          sizeClasses[size],
+          variantClasses[variant],
           className
         )}
         {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -13,7 +13,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(function Card(
     <div
       ref={ref}
       className={cn(
-        "bg-white rounded-xl shadow-md border border-[#EEF2FF] p-5", 
+        "rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-md",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -8,10 +8,10 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, children, ...props }, ref) => {
     return (
-      <select
-        ref={ref}
-        className={cn(
-          "flex h-10 w-full appearance-none rounded-lg border border-[#E5E7EB] bg-white px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 transition focus:border-[#4F46E5] focus:outline-none focus:ring-2 focus:ring-[#4F46E5] focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:bg-gray-50", 
+        <select
+          ref={ref}
+          className={cn(
+          "flex h-10 w-full appearance-none rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--tone-text)] placeholder:text-[var(--color-text-secondary)] transition focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-30 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] focus:border-[var(--brand-primary)] disabled:cursor-not-allowed disabled:bg-[color:rgba(227,225,255,0.35)] disabled:text-[var(--color-text-secondary)]",
           className
         )}
         {...props}

--- a/src/components/ui/toast-provider.tsx
+++ b/src/components/ui/toast-provider.tsx
@@ -71,9 +71,9 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
               role="status"
               className={cn(
                 "pointer-events-auto rounded-lg px-4 py-3 text-sm font-medium text-white shadow-lg",
-                toast.tone === "success" && "bg-[#10B981]",
-                toast.tone === "error" && "bg-[#EF4444]",
-                toast.tone === "info" && "bg-[#6366F1]",
+                toast.tone === "success" && "bg-[var(--color-status-success)]",
+                toast.tone === "error" && "bg-[var(--color-status-destructive)]",
+                toast.tone === "info" && "bg-[var(--brand-primary)]",
               )}
             >
               {toast.message}


### PR DESCRIPTION
## Summary
- extend the button component with primary/secondary/ghost variants, size options, and refreshed focus styles
- refresh badge variants and other shared UI elements to rely on the updated theme color tokens
- align layout, status, and activity components with the new palette for consistent styling across the app

## Testing
- npm run lint *(fails: existing repository warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d7b95b290883288ae9c03ecd3d8694