### PR TITLE
Restyle task card layout

### DIFF
--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -2,9 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { Avatar } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 
 export interface TaskCardProps {
@@ -44,11 +42,7 @@ const getPriorityBadgeClasses = (priority?: string) => {
   return 'bg-slate-100 text-slate-600';
 };
 
-export default function TaskCard({ task, onChange, href, canEdit = true }: TaskCardProps) {
-  const router = useRouter();
-  const normalizedStatus = task.status?.trim().toUpperCase();
-  const isDone = normalizedStatus === 'DONE';
-  const showActions = canEdit && !isDone;
+export default function TaskCard({ task, href }: TaskCardProps) {
   const combinedTags = React.useMemo(
     () =>
       [...(task.tags ?? []), task.status].filter(
@@ -57,46 +51,16 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
     [task.tags, task.status]
   );
 
-  const handleEdit = () => {
-    if (!showActions) return;
-    router.push(`/tasks/${task._id}/edit`);
-  };
-
-  const handleDelete = async () => {
-    if (!showActions) return;
-    await fetch(`/api/tasks/${task._id}`, { method: 'DELETE' });
-    onChange?.();
-  };
-
-  const handleEditClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    handleEdit();
-  };
-
-  const handleDeleteClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    await handleDelete();
-  };
-
   const cardContent = (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
-        <div className="flex-1">
-          <h3 className="text-sm font-semibold text-slate-800 line-clamp-1">
-            {task.title}
-          </h3>
-          {task.description && (
-            <p className="mt-1 text-sm text-slate-500 line-clamp-2">
-              {task.description}
-            </p>
-          )}
-        </div>
+        <h3 className="text-base font-medium text-slate-900 line-clamp-2">
+          {task.title}
+        </h3>
         {task.priority && (
           <span
             className={cn(
-              'inline-flex shrink-0 items-center rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-wide',
+              'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize',
               getPriorityBadgeClasses(task.priority)
             )}
           >
@@ -104,87 +68,54 @@ export default function TaskCard({ task, onChange, href, canEdit = true }: TaskC
           </span>
         )}
       </div>
-      <div className="mt-3 flex flex-wrap gap-2">
-        {combinedTags.map((tag) => (
-          <Badge
-            key={`${task._id}-${tag}`}
-            className="rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-slate-600"
-          >
-            {tag}
-          </Badge>
-        ))}
-      </div>
-      <div className="mt-4 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          {task.assignee && (
-            <Avatar
-              src={task.assigneeAvatar}
-              fallback={task.assignee.charAt(0)}
-              className="h-8 w-8 text-sm"
-            />
-          )}
-          <div className="flex flex-col text-xs text-slate-500">
-            {task.assignee && (
-              <span className="font-medium text-slate-700">{task.assignee}</span>
-            )}
-            {task.dueDate && <span>Due {task.dueDate}</span>}
-          </div>
+      {task.description && (
+        <p className="text-sm text-[#6b7280] line-clamp-2">{task.description}</p>
+      )}
+      {combinedTags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {combinedTags.map((tag) => (
+            <span
+              key={`${task._id}-${tag}`}
+              className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
+            >
+              {tag}
+            </span>
+          ))}
         </div>
-        {showActions ? (
-          <div className="flex items-center gap-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100">
-            <button
-              type="button"
-              onClick={handleEditClick}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-200 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:ring-offset-2 focus:ring-offset-white"
-              aria-label="Edit task"
-              title="Edit task"
+      )}
+      <div className="mt-auto flex items-center justify-between gap-3 pt-1 text-sm">
+        <div className="flex items-center gap-2 text-slate-700">
+          {task.assignee && (
+            <>
+              <Avatar
+                src={task.assigneeAvatar}
+                fallback={task.assignee.charAt(0)}
+                className="h-6 w-6 text-xs"
+              />
+              <span className="font-medium">{task.assignee}</span>
+            </>
+          )}
+        </div>
+        {task.dueDate && (
+          <div className="flex items-center gap-1 text-xs text-slate-500">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-4 w-4"
+              aria-hidden="true"
             >
-              <span className="sr-only">Edit task</span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-4 w-4"
-              >
-                <path d="M16.862 4.487l1.651-1.651a1.875 1.875 0 112.652 2.652L7.1 19.554a3 3 0 01-1.265.757l-2.5.75.75-2.5a3 3 0 01.757-1.265L16.862 4.487z" />
-                <path d="M15 5.25l3 3" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              onClick={handleDeleteClick}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-200 text-rose-500 transition-colors hover:bg-rose-100 focus:outline-none focus:ring-2 focus:ring-rose-400/40 focus:ring-offset-2 focus:ring-offset-white"
-              aria-label="Delete task"
-              title="Delete task"
-            >
-              <span className="sr-only">Delete task</span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-4 w-4"
-              >
-                <path d="M9.75 9.75l.347 8.347a1 1 0 00.996.903h2.214a1 1 0 00.996-.903L14.65 9.75" />
-                <path d="M19.5 6h-15" />
-                <path d="M16.5 6l-.427-1.708A2 2 0 0014.127 3h-4.254a2 2 0 00-1.946 1.292L7.5 6" />
-              </svg>
-            </button>
+              <path d="M10 2a6 6 0 100 12A6 6 0 0010 2zM9.25 5.5a.75.75 0 011.5 0V9a.75.75 0 01-.22.53l-1.5 1.5a.75.75 0 11-1.06-1.06l1.28-1.28V5.5z" />
+            </svg>
+            <span className="text-slate-600">Due {task.dueDate}</span>
           </div>
-        ) : null}
+        )}
       </div>
     </div>
   );
 
   return (
-    <div className="group flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_35px_rgba(15,23,42,0.15)] focus-within:-translate-y-0.5 focus-within:shadow-[0_18px_35px_rgba(15,23,42,0.15)]">
+    <div className="group flex flex-col rounded-[10px] bg-white p-4 shadow-sm transition-shadow duration-200 hover:shadow-lg focus-within:shadow-lg">
       {href ? (
         <Link
           href={href}


### PR DESCRIPTION
## Summary
- restyle the task card container with updated spacing, shadows, and header layout
- refresh body content to use muted description text and outlined tag chips that wrap cleanly
- simplify the footer with avatar, assignee, and due date display while removing inline action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bf14a4bc83288e0cab53b25177c1