### PR TITLE
Refactor authenticated app shell layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,8 +28,6 @@
   --priority-medium: var(--color-status-warning);
   --priority-low: var(--color-status-success);
 
-  --layout-header-height: 4.5rem;
-  --layout-footer-height: 3.5rem;
 
   /* Legacy aliases */
   --color-primary: var(--brand-primary);
@@ -136,105 +134,92 @@ body {
 }
 
 .app-shell {
-  --sidebar-width: 18rem;
+  --sidebar-width: 19rem;
+  --sidebar-overlay-gap: clamp(1rem, 4vw, 2rem);
+  --sidebar-border-color: rgba(15, 23, 42, 0.08);
+  --sidebar-shadow: 0 28px 80px rgba(9, 14, 34, 0.18);
   min-height: 100vh;
   background: var(--surface-page);
+  color: var(--tone-text);
 }
 
-.app-shell__content {
-  position: relative;
+.app-shell__layout {
+  display: flex;
   min-height: 100vh;
-  transition: margin-left 0.3s ease;
+  position: relative;
 }
 
-.app-header {
-  position: fixed;
+.app-shell__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.app-main-header {
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
-  height: var(--layout-header-height);
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1.5rem;
-  background: #ffffff;
-  border-bottom: 1px solid var(--color-border-strong);
-  box-shadow: var(--shadow-soft);
-  z-index: 40;
+  gap: 1rem;
+  padding: 1rem clamp(1.25rem, 3vw, 2.75rem);
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--sidebar-border-color);
+  box-shadow: 0 1px 0 rgba(12, 19, 46, 0.05);
 }
 
-.app-header__start {
-  display: inline-flex;
+.app-main-header__start {
+  display: flex;
   align-items: center;
   gap: 0.75rem;
 }
 
-.app-header__toggle {
+.app-main-header__toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 2.75rem;
   height: 2.75rem;
-  border: 1px solid var(--color-border);
-  border-radius: 0.75rem;
-  background: var(--surface-card);
-  color: var(--color-text);
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease,
-    border-color 0.2s ease;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--tone-text);
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease, transform 0.2s ease;
 }
 
-.app-header__toggle:hover {
-  background: rgba(79, 70, 229, 0.08);
-  border-color: rgba(79, 70, 229, 0.4);
+.app-main-header__toggle:hover {
+  background: rgba(99, 102, 241, 0.16);
+  border-color: rgba(99, 102, 241, 0.4);
+  color: var(--tone-text-strong);
 }
 
-.app-header__toggle:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.5);
+.app-main-header__toggle:active {
+  transform: scale(0.97);
+}
+
+.app-main-header__toggle:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.45);
   outline-offset: 3px;
 }
 
-.app-header__toggle-icon {
-  width: 1.5rem;
-  height: 1.5rem;
+.app-main-header__toggle-icon {
+  width: 1.4rem;
+  height: 1.4rem;
 }
 
-.app-header__branding {
-  display: inline-flex;
+.app-main-header__actions {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  color: var(--color-text-strong);
+  gap: 0.75rem;
 }
 
-.app-header__logo {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.75rem;
-  background: radial-gradient(circle at 20% 20%, #c7d2fe, #4f46e5);
-  color: #fff;
-  font-size: 1.125rem;
-  box-shadow: 0 4px 16px rgba(79, 70, 229, 0.25);
-}
-
-.app-header__name {
-  font-size: 1.125rem;
-}
-
-.app-header__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 1rem;
-  min-width: 3rem;
-  min-height: 2.5rem;
-  margin-left: auto;
-}
-
-.app-header__icon-button {
+.app-main-header__icon-button {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -242,257 +227,153 @@ body {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 9999px;
-  border: 1px solid var(--color-border);
-  background: var(--surface-card);
-  color: var(--color-text);
+  border: 1px solid rgba(99, 102, 241, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--tone-text);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
   transition: background-color 0.2s ease, border-color 0.2s ease,
-    color 0.2s ease;
+    color 0.2s ease, transform 0.2s ease;
 }
 
-.app-header__icon-button:hover {
-  background: rgba(79, 70, 229, 0.08);
-  border-color: rgba(79, 70, 229, 0.4);
+.app-main-header__icon-button:hover {
+  background: rgba(99, 102, 241, 0.16);
+  border-color: rgba(99, 102, 241, 0.4);
+  color: var(--tone-text-strong);
 }
 
-.app-header__icon-button:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.5);
+.app-main-header__icon-button:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.45);
   outline-offset: 3px;
 }
 
-.app-header__icon-button svg {
-  width: 1.25rem;
-  height: 1.25rem;
+.app-main-header__icon-button svg {
+  width: 1.2rem;
+  height: 1.2rem;
 }
 
-.app-header__notification-badge {
+.app-main-header__notification-badge {
   position: absolute;
-  top: -0.35rem;
+  top: -0.3rem;
   right: -0.35rem;
-  transform: translate(10%, -10%);
+  transform: translate(15%, -15%);
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
-.app-header__search {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  min-width: 16rem;
-  padding: 0.5rem 1rem 0.5rem 2.5rem;
-  border-radius: 9999px;
-  border: 1px solid #e5e7eb;
-  background: #f3f4f6;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.app-header__search:focus-within {
-  border-color: #4f46e5;
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
-}
-
-.app-header__search-icon {
-  position: absolute;
-  left: 0.9rem;
-  display: inline-flex;
-  width: 1.1rem;
-  height: 1.1rem;
-  color: #6b7280;
-}
-
-.app-header__search-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
-.app-header__search-input {
+.app-main-content {
   flex: 1;
-  border: none;
-  background: transparent;
-  font-size: 0.95rem;
-  color: var(--color-text);
-  outline: none;
-}
-
-.app-header__filters {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem;
-  border-radius: 9999px;
-  background: #eef2ff;
-}
-
-.app-header__filter {
-  border: none;
-  background: transparent;
-  color: #4338ca;
-  font-weight: 500;
-  font-size: 0.875rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 9999px;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.app-header__filter:hover {
-  background: rgba(79, 70, 229, 0.1);
-}
-
-.app-header__filter--active {
-  background: #4f46e5;
-  color: #ffffff;
-  box-shadow: 0 4px 12px rgba(79, 70, 229, 0.25);
-}
-
-.app-header__tabs {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem;
-  border-radius: 9999px;
-  background: #eef2ff;
-}
-
-.app-header__tab {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.4rem 1.1rem;
-  border-radius: 9999px;
-  color: #4338ca;
-  font-weight: 600;
-  font-size: 0.9rem;
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.app-header__tab:hover {
-  background: rgba(79, 70, 229, 0.12);
-}
-
-.app-header__tab--active {
-  background: #4f46e5;
-  color: #ffffff;
-  box-shadow: 0 6px 16px rgba(79, 70, 229, 0.25);
-}
-
-.app-header__team {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding-left: 0.5rem;
-}
-
-.app-header__team-avatars {
-  display: inline-flex;
-  align-items: center;
-}
-
-.app-header__team-avatar {
-  border: 2px solid #ffffff;
-  box-shadow: 0 4px 10px rgba(79, 70, 229, 0.15);
-}
-
-.app-header__team-avatars .app-header__team-avatar + .app-header__team-avatar {
-  margin-left: -0.55rem;
-}
-
-.app-header__team-invite {
-  width: 2.25rem;
-  height: 2.25rem;
-  border-radius: 9999px;
-  border: 1px solid #c7cffd;
-  background: #ffffff;
-  color: #4f46e5;
-  font-weight: 600;
-  font-size: 1.1rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.app-header__team-invite:hover {
-  background: #eef2ff;
-  border-color: #a5b4fc;
-}
-
-.app-header__team-invite:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.4);
-  outline-offset: 3px;
-}
-
-.app-shell__overlay {
-  position: fixed;
-  top: var(--layout-header-height);
-  right: 0;
-  bottom: var(--layout-footer-height);
-  left: 0;
-  background: rgba(79, 70, 229, 0.2);
-  z-index: 35;
-}
-
-.app-shell__overlay[hidden] {
-  display: none;
+  min-height: 0;
+  padding: clamp(1.75rem, 4vw, 3rem) clamp(1.5rem, 5vw, 3.5rem) 3.5rem;
 }
 
 .app-sidebar {
-  position: fixed;
-  top: var(--layout-header-height);
-  left: 0;
-  bottom: var(--layout-footer-height);
   width: var(--sidebar-width);
-  padding: 1.75rem 1.5rem;
-  background: #f3f4f6;
-  border-right: 1px solid var(--color-border-strong);
-  box-shadow: 8px 0 24px rgba(79, 70, 229, 0.08);
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  z-index: 40;
+  flex-shrink: 0;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(22px);
+  border-right: 1px solid var(--sidebar-border-color);
+  color: var(--tone-text);
   display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-  overflow-y: auto;
-  padding-bottom: calc(1.75rem + var(--layout-footer-height));
+  z-index: 50;
+  transition: transform 0.35s ease, opacity 0.3s ease;
 }
 
-.app-shell--sidebar-open .app-sidebar {
+.app-sidebar__inner {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 2rem;
+  padding: 2.25rem 1.75rem 2rem;
+}
+
+.app-shell--mode-desktop .app-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.app-shell--mode-desktop .app-sidebar__inner {
+  height: 100%;
+}
+
+.app-shell--mode-tablet .app-sidebar,
+.app-shell--mode-mobile .app-sidebar {
+  position: fixed;
+  top: var(--sidebar-overlay-gap);
+  bottom: var(--sidebar-overlay-gap);
+  left: var(--sidebar-overlay-gap);
+  width: min(var(--sidebar-width), calc(100vw - 2 * var(--sidebar-overlay-gap)));
+  border-radius: 1.5rem;
+  box-shadow: var(--sidebar-shadow);
+  transform: translateX(-110%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.app-shell--mode-mobile .app-sidebar {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100vw;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.app-shell--mode-tablet.app-shell--sidebar-open .app-sidebar,
+.app-shell--mode-mobile.app-shell--sidebar-open .app-sidebar {
   transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
 }
 
-.app-sidebar__nav-container {
+.app-sidebar__header {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.app-sidebar__logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  color: #ffffff;
+  box-shadow: 0 18px 42px rgba(79, 70, 229, 0.35);
+}
+
+.app-sidebar__logo svg {
+  width: 1.65rem;
+  height: 1.65rem;
+}
+
+.app-sidebar__brand {
   display: flex;
   flex-direction: column;
+  gap: 0.2rem;
+}
+
+.app-sidebar__brand-name {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--tone-text-strong);
+}
+
+.app-sidebar__brand-subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.app-sidebar__content {
   flex: 1;
   min-height: 0;
-  gap: 1.5rem;
-}
-
-.app-sidebar__profile {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.app-sidebar__profile-avatar {
-  display: inline-flex;
-  border-radius: 9999px;
-  outline: none;
-}
-
-.app-sidebar__profile-avatar:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.5);
-  outline-offset: 4px;
-}
-
-.app-sidebar__profile-greeting {
-  margin: 0;
-  color: var(--color-text);
-  font-weight: 600;
-  font-size: 1rem;
 }
 
 .app-sidebar__nav {
@@ -502,7 +383,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-top: 1.75rem;
 }
 
 .app-sidebar__link {
@@ -510,34 +390,38 @@ body {
   align-items: center;
   gap: 0.75rem;
   width: 100%;
-  padding: 0.625rem 0.85rem;
-  border-radius: 9999px;
-  color: #4b5563;
+  padding: 0.7rem 0.95rem;
+  border-radius: 0.95rem;
+  border: 1px solid transparent;
+  color: var(--tone-text-muted);
   font-weight: 600;
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease,
+    border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-sidebar__link:hover {
-  background: #e0e7ff;
-  color: #312e81;
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.22);
+  color: var(--tone-text-strong);
 }
 
 .app-sidebar__link:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.5);
+  outline: 2px solid rgba(99, 102, 241, 0.45);
   outline-offset: 3px;
 }
 
 .app-sidebar__link--active {
-  background: #4f46e5;
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  border-color: transparent;
   color: #ffffff;
-  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
+  box-shadow: 0 20px 32px rgba(99, 102, 241, 0.35);
 }
 
 .app-sidebar__link-icon {
   display: inline-flex;
-  width: 1.15rem;
-  height: 1.15rem;
+  width: 1.2rem;
+  height: 1.2rem;
   color: currentColor;
 }
 
@@ -554,12 +438,12 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.15rem 0.55rem;
+  padding: 0.2rem 0.6rem;
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 600;
-  background: rgba(79, 70, 229, 0.15);
-  color: #3730a3;
+  background: rgba(99, 102, 241, 0.15);
+  color: #4338ca;
 }
 
 .app-sidebar__badge--accent {
@@ -569,77 +453,122 @@ body {
 
 .app-sidebar__link--active .app-sidebar__badge {
   background: rgba(255, 255, 255, 0.25);
-  color: #eef2ff;
+  color: #f9fafb;
 }
 
 .app-sidebar__link--active .app-sidebar__badge--accent {
-  background: #fbbf24;
+  background: #fde68a;
   color: #1f2937;
 }
 
-.app-sidebar__logout {
+.app-sidebar__footer {
   margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--sidebar-border-color);
+}
+
+.app-sidebar__profile {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.app-sidebar__profile-avatar {
+  display: inline-flex;
+  border-radius: 9999px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.app-sidebar__profile-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.app-sidebar__profile-name {
+  margin: 0;
+  font-weight: 600;
+  color: var(--tone-text-strong);
+}
+
+.app-sidebar__profile-greeting {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.68);
+}
+
+.app-sidebar__profile-email {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.55);
+  word-break: break-word;
+}
+
+.app-sidebar__logout {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  justify-content: center;
   width: 100%;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--color-text-muted);
-  font-weight: 500;
-  font-size: 1rem;
-  text-align: left;
+  padding: 0.65rem 0.9rem;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  background: rgba(99, 102, 241, 0.12);
+  color: #4338ca;
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease, transform 0.2s ease;
   cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease,
-    border-color 0.2s ease;
 }
 
 .app-sidebar__logout:hover {
-  background: rgba(79, 70, 229, 0.08);
-  color: var(--color-text);
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  border-color: transparent;
+  color: #ffffff;
+  transform: translateY(-1px);
 }
 
 .app-sidebar__logout:focus-visible {
-  outline: 2px solid rgba(79, 70, 229, 0.5);
+  outline: 2px solid rgba(99, 102, 241, 0.45);
   outline-offset: 3px;
 }
 
-.app-main {
-  position: relative;
-  margin: var(--layout-header-height) auto var(--layout-footer-height);
-  padding: 1.75rem clamp(1.25rem, 3vw, 2.5rem);
-  width: min(1100px, 100%);
-  min-height: calc(100vh - var(--layout-header-height) - var(--layout-footer-height));
-  overflow-y: auto;
-  transition: margin-left 0.3s ease;
+.app-shell__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(9, 14, 34, 0.45);
+  backdrop-filter: blur(8px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 40;
 }
 
-@media (min-width: 1024px) {
-  .app-sidebar {
-    box-shadow: none;
-  }
+.app-shell--mode-desktop .app-shell__overlay {
+  display: none;
+}
+
+.app-shell--sidebar-open .app-shell__overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.app-shell__overlay[hidden] {
+  display: none;
 }
 
 @media (max-width: 1023px) {
-  .app-header__actions {
+  .app-main-header__actions {
     display: none;
   }
 }
 
-.app-footer {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: var(--layout-footer-height);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 1.5rem;
-  background: var(--surface-card);
-  border-top: 1px solid var(--color-border);
-  color: var(--color-text-muted);
-  font-size: 0.875rem;
+@media (max-width: 767px) {
+  .app-sidebar__inner {
+    padding: clamp(1.75rem, 6vw, 2.25rem) clamp(1.25rem, 5vw, 2rem)
+      clamp(2rem, 8vw, 2.5rem);
+  }
 }

--- a/src/components/layout/AppShell.handlers.test.ts
+++ b/src/components/layout/AppShell.handlers.test.ts
@@ -3,19 +3,19 @@ import { describe, expect, it, vi } from "vitest";
 import { closeSidebarOnNavigation } from "./AppShell";
 
 describe("closeSidebarOnNavigation", () => {
-  it("closes the sidebar when not on desktop", () => {
+  it("closes the sidebar when the navigation is in overlay mode", () => {
     const closeSidebar = vi.fn();
 
-    closeSidebarOnNavigation({ isDesktop: false, closeSidebar });
+    closeSidebarOnNavigation({ isPinned: false, closeSidebar });
 
     expect(closeSidebar).toHaveBeenCalledTimes(1);
   });
 
-  it("closes the sidebar on desktop", () => {
+  it("keeps the sidebar open when it is pinned", () => {
     const closeSidebar = vi.fn();
 
-    closeSidebarOnNavigation({ isDesktop: true, closeSidebar });
+    closeSidebarOnNavigation({ isPinned: true, closeSidebar });
 
-    expect(closeSidebar).toHaveBeenCalledTimes(1);
+    expect(closeSidebar).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Rework the authenticated AppShell to support pinned desktop navigation, tablet overlays, and mobile drawers while moving branding into the sidebar and keeping the header sticky
- Refresh global layout styles with new spacing, blur, borders, and transitions for the sidebar, overlay, and header, including updated navigation and profile footer treatments
- Update the sidebar close handler tests to reflect the new pinned vs. overlay behavior

## Testing
- npm run test -- src/components/layout/AppShell.handlers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7c4370a6c8328a20e789588d9d8cd