### PR TITLE
Refresh LoopTask palette and typography scale

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,33 +1,97 @@
 @import "tailwindcss";
 
 :root {
-  --brand-primary: #030213;
-  --brand-secondary: #e3e1ff;
+  /* Core palette */
+  --brand-primary: #4f46ef;
+  --brand-secondary: #e0e7ff;
+  --brand-accent: #4338ca;
 
-  --surface-page: #f5f6fa;
+  --surface-page: #ffffff;
   --surface-card: #ffffff;
+  --surface-muted: #f3f4f7;
+  --surface-sidebar: #f8f9fa;
+  --surface-header-glass: rgba(255, 255, 255, 0.9);
+  --surface-sidebar-glass: rgba(248, 249, 250, 0.92);
+  --surface-on-accent: rgba(255, 255, 255, 0.25);
+  --surface-on-accent-strong: rgba(255, 255, 255, 0.65);
 
-  --tone-text-strong: #0b1024;
-  --tone-text: #1b2137;
-  --tone-text-muted: #5c6376;
+  --tone-text-strong: #101828;
+  --tone-text: #344054;
+  --tone-text-muted: #667085;
+  --tone-text-subtle: #98a2b3;
+  --tone-text-inverse: #ffffff;
 
-  --border-subtle: #d7dbe6;
-  --border-strong: #c2c7d6;
+  --border-subtle: rgba(16, 24, 40, 0.1);
+  --border-strong: rgba(16, 24, 40, 0.18);
 
-  --shadow-soft: 0 16px 40px rgba(3, 2, 19, 0.08);
+  --shadow-soft: 0 20px 48px rgba(15, 23, 42, 0.08);
 
-  --color-status-destructive: #f04438;
-  --color-status-success: #12b76a;
-  --color-status-warning: #f79009;
-  --color-status-info: #2e90fa;
+  --color-status-destructive: #d92d20;
+  --color-status-success: #039855;
+  --color-status-warning: #dc6803;
+  --color-status-info: #3538cd;
+
+  --status-destructive-soft: rgba(217, 45, 32, 0.16);
+  --status-success-soft: rgba(3, 152, 85, 0.16);
+  --status-warning-soft: rgba(220, 104, 3, 0.16);
+  --status-info-soft: rgba(53, 56, 205, 0.16);
 
   --radius-base: 0.625rem;
-  --ring-color: rgba(3, 2, 19, 0.12);
+  --ring-color: rgba(79, 70, 239, 0.24);
+
+  --brand-primary-08: rgba(79, 70, 239, 0.08);
+  --brand-primary-10: rgba(79, 70, 239, 0.1);
+  --brand-primary-12: rgba(79, 70, 239, 0.12);
+  --brand-primary-15: rgba(79, 70, 239, 0.15);
+  --brand-primary-16: rgba(79, 70, 239, 0.16);
+  --brand-primary-18: rgba(79, 70, 239, 0.18);
+  --brand-primary-22: rgba(79, 70, 239, 0.22);
+  --brand-primary-25: rgba(79, 70, 239, 0.25);
+  --brand-primary-32: rgba(79, 70, 239, 0.32);
+  --brand-primary-35: rgba(79, 70, 239, 0.35);
+  --brand-primary-40: rgba(79, 70, 239, 0.4);
+  --brand-primary-45: rgba(79, 70, 239, 0.45);
 
   --priority-high: var(--color-status-destructive);
   --priority-medium: var(--color-status-warning);
   --priority-low: var(--color-status-success);
 
+  /* Typography scale */
+  --font-weight-body: 400;
+  --font-weight-body-strong: 500;
+  --font-weight-heading: 600;
+
+  --font-size-body-xl: 1.25rem;
+  --font-size-body-lg: 1.125rem;
+  --font-size-body-md: 1rem;
+  --font-size-body-sm: 0.875rem;
+  --font-size-body-xs: 0.75rem;
+
+  --line-height-body-xl: 1.6;
+  --line-height-body-lg: 1.6;
+  --line-height-body-md: 1.65;
+  --line-height-body-sm: 1.55;
+  --line-height-body-xs: 1.5;
+
+  --tracking-body: -0.01em;
+
+  --font-size-heading-1: clamp(2.75rem, 2vw + 2.2rem, 3.5rem);
+  --font-size-heading-2: clamp(2.25rem, 1.6vw + 1.8rem, 2.9rem);
+  --font-size-heading-3: clamp(1.9rem, 1.2vw + 1.6rem, 2.4rem);
+  --font-size-heading-4: clamp(1.6rem, 1vw + 1.3rem, 2.05rem);
+  --font-size-heading-5: clamp(1.35rem, 0.7vw + 1.15rem, 1.7rem);
+  --font-size-heading-6: clamp(1.15rem, 0.4vw + 1.05rem, 1.35rem);
+
+  --line-height-heading-1: 1.08;
+  --line-height-heading-2: 1.12;
+  --line-height-heading-3: 1.18;
+  --line-height-heading-4: 1.22;
+  --line-height-heading-5: 1.3;
+  --line-height-heading-6: 1.4;
+
+  --tracking-heading-tight: -0.03em;
+  --tracking-heading: -0.02em;
+  --tracking-heading-wide: -0.015em;
 
   /* Legacy aliases */
   --color-primary: var(--brand-primary);
@@ -39,18 +103,22 @@
   --color-border-strong: var(--border-strong);
   --color-background: var(--surface-page);
   --color-surface: var(--surface-card);
-  --color-text-secondary: var(--color-text-muted);
+  --color-sidebar: var(--surface-sidebar);
+  --color-text-secondary: var(--tone-text-muted);
   --font-geist-sans: var(--font-inter);
 }
 
 @theme inline {
-  --color-background: var(--surface-page);
+  --color-background: var(--color-background);
   --color-foreground: var(--tone-text);
   --color-primary: var(--brand-primary);
   --color-secondary: var(--brand-secondary);
   --color-muted: var(--tone-text-muted);
   --color-border: var(--border-subtle);
   --color-border-strong: var(--border-strong);
+  --color-surface: var(--surface-card);
+  --color-surface-muted: var(--surface-muted);
+  --color-sidebar: var(--surface-sidebar);
   --color-destructive: var(--color-status-destructive);
   --color-success: var(--color-status-success);
   --color-warning: var(--color-status-warning);
@@ -73,74 +141,149 @@
 }
 
 body {
-  background: var(--surface-page);
-  color: var(--tone-text);
+  background: var(--color-background);
+  color: var(--color-text);
   font-family: var(--font-inter), "Inter", "SF Pro Text", -apple-system,
     BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-weight: 500;
-  line-height: 1.5;
-  letter-spacing: -0.01em;
+  font-weight: var(--font-weight-body);
+  font-size: var(--font-size-body-md);
+  line-height: var(--line-height-body-md);
+  letter-spacing: var(--tracking-body);
   margin: 0;
 }
 
 @layer base {
   h1 {
-    font-size: clamp(2.5rem, 1.5vw + 2.1rem, 3.25rem);
-    font-weight: 500;
-    line-height: 1.1;
-    letter-spacing: -0.02em;
+    font-size: var(--font-size-heading-1);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-1);
+    letter-spacing: var(--tracking-heading-tight);
     color: var(--tone-text-strong);
   }
 
   h2 {
-    font-size: clamp(2.1rem, 1.2vw + 1.7rem, 2.65rem);
-    font-weight: 500;
-    line-height: 1.2;
-    letter-spacing: -0.015em;
+    font-size: var(--font-size-heading-2);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-2);
+    letter-spacing: var(--tracking-heading-tight);
     color: var(--tone-text-strong);
   }
 
   h3 {
-    font-size: clamp(1.75rem, 1vw + 1.45rem, 2.25rem);
-    font-weight: 500;
-    line-height: 1.25;
-    letter-spacing: -0.01em;
+    font-size: var(--font-size-heading-3);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-3);
+    letter-spacing: var(--tracking-heading);
     color: var(--tone-text-strong);
   }
 
   h4 {
-    font-size: clamp(1.5rem, 0.8vw + 1.3rem, 1.9rem);
-    font-weight: 500;
-    line-height: 1.3;
-    letter-spacing: -0.01em;
+    font-size: var(--font-size-heading-4);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-4);
+    letter-spacing: var(--tracking-heading);
     color: var(--tone-text-strong);
   }
 
   h5 {
-    font-size: clamp(1.25rem, 0.6vw + 1.15rem, 1.55rem);
-    font-weight: 500;
-    line-height: 1.35;
-    letter-spacing: -0.005em;
+    font-size: var(--font-size-heading-5);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-5);
+    letter-spacing: var(--tracking-heading);
     color: var(--tone-text-strong);
   }
 
   h6 {
-    font-size: 1.1rem;
-    font-weight: 500;
-    line-height: 1.4;
-    letter-spacing: -0.0025em;
+    font-size: var(--font-size-heading-6);
+    font-weight: var(--font-weight-heading);
+    line-height: var(--line-height-heading-6);
+    letter-spacing: var(--tracking-heading-wide);
     color: var(--tone-text-strong);
+  }
+}
+
+@layer utilities {
+  .text-body-xl {
+    font-size: var(--font-size-body-xl);
+    line-height: var(--line-height-body-xl);
+    letter-spacing: var(--tracking-body);
+  }
+
+  .text-body-lg {
+    font-size: var(--font-size-body-lg);
+    line-height: var(--line-height-body-lg);
+    letter-spacing: var(--tracking-body);
+  }
+
+  .text-body-md {
+    font-size: var(--font-size-body-md);
+    line-height: var(--line-height-body-md);
+    letter-spacing: var(--tracking-body);
+  }
+
+  .text-body-sm {
+    font-size: var(--font-size-body-sm);
+    line-height: var(--line-height-body-sm);
+    letter-spacing: var(--tracking-body);
+  }
+
+  .text-body-xs {
+    font-size: var(--font-size-body-xs);
+    line-height: var(--line-height-body-xs);
+    letter-spacing: var(--tracking-body);
+  }
+
+  .text-heading-1 {
+    font-size: var(--font-size-heading-1);
+    line-height: var(--line-height-heading-1);
+    letter-spacing: var(--tracking-heading-tight);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .text-heading-2 {
+    font-size: var(--font-size-heading-2);
+    line-height: var(--line-height-heading-2);
+    letter-spacing: var(--tracking-heading-tight);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .text-heading-3 {
+    font-size: var(--font-size-heading-3);
+    line-height: var(--line-height-heading-3);
+    letter-spacing: var(--tracking-heading);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .text-heading-4 {
+    font-size: var(--font-size-heading-4);
+    line-height: var(--line-height-heading-4);
+    letter-spacing: var(--tracking-heading);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .text-heading-5 {
+    font-size: var(--font-size-heading-5);
+    line-height: var(--line-height-heading-5);
+    letter-spacing: var(--tracking-heading);
+    font-weight: var(--font-weight-heading);
+  }
+
+  .text-heading-6 {
+    font-size: var(--font-size-heading-6);
+    line-height: var(--line-height-heading-6);
+    letter-spacing: var(--tracking-heading-wide);
+    font-weight: var(--font-weight-heading);
   }
 }
 
 .app-shell {
   --sidebar-width: 19rem;
   --sidebar-overlay-gap: clamp(1rem, 4vw, 2rem);
-  --sidebar-border-color: rgba(15, 23, 42, 0.08);
+  --sidebar-border-color: var(--border-subtle);
   --sidebar-shadow: 0 28px 80px rgba(9, 14, 34, 0.18);
   min-height: 100vh;
-  background: var(--surface-page);
-  color: var(--tone-text);
+  background: var(--color-background);
+  color: var(--color-text);
 }
 
 .app-shell__layout {
@@ -166,7 +309,7 @@ body {
   justify-content: space-between;
   gap: 1rem;
   padding: 1rem clamp(1.25rem, 3vw, 2.75rem);
-  background: rgba(255, 255, 255, 0.86);
+  background: var(--surface-header-glass);
   backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--sidebar-border-color);
   box-shadow: 0 1px 0 rgba(12, 19, 46, 0.05);
@@ -185,17 +328,17 @@ body {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 0.9rem;
-  border: 1px solid rgba(99, 102, 241, 0.18);
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--tone-text);
+  border: 1px solid var(--brand-primary-18);
+  background: var(--surface-card);
+  color: var(--color-text);
   box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08);
   transition: background-color 0.2s ease, border-color 0.2s ease,
     color 0.2s ease, transform 0.2s ease;
 }
 
 .app-main-header__toggle:hover {
-  background: rgba(99, 102, 241, 0.16);
-  border-color: rgba(99, 102, 241, 0.4);
+  background: var(--brand-primary-12);
+  border-color: var(--brand-primary-40);
   color: var(--tone-text-strong);
 }
 
@@ -204,7 +347,7 @@ body {
 }
 
 .app-main-header__toggle:focus-visible {
-  outline: 2px solid rgba(99, 102, 241, 0.45);
+  outline: 2px solid var(--brand-primary-45);
   outline-offset: 3px;
 }
 
@@ -227,22 +370,22 @@ body {
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 9999px;
-  border: 1px solid rgba(99, 102, 241, 0.18);
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--tone-text);
+  border: 1px solid var(--brand-primary-18);
+  background: var(--surface-card);
+  color: var(--color-text);
   box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
   transition: background-color 0.2s ease, border-color 0.2s ease,
     color 0.2s ease, transform 0.2s ease;
 }
 
 .app-main-header__icon-button:hover {
-  background: rgba(99, 102, 241, 0.16);
-  border-color: rgba(99, 102, 241, 0.4);
+  background: var(--brand-primary-12);
+  border-color: var(--brand-primary-40);
   color: var(--tone-text-strong);
 }
 
 .app-main-header__icon-button:focus-visible {
-  outline: 2px solid rgba(99, 102, 241, 0.45);
+  outline: 2px solid var(--brand-primary-45);
   outline-offset: 3px;
 }
 
@@ -269,10 +412,10 @@ body {
 .app-sidebar {
   width: var(--sidebar-width);
   flex-shrink: 0;
-  background: rgba(255, 255, 255, 0.82);
+  background: var(--surface-sidebar-glass);
   backdrop-filter: blur(22px);
   border-right: 1px solid var(--sidebar-border-color);
-  color: var(--tone-text);
+  color: var(--color-text);
   display: flex;
   z-index: 50;
   transition: transform 0.35s ease, opacity 0.3s ease;
@@ -341,9 +484,9 @@ body {
   width: 2.75rem;
   height: 2.75rem;
   border-radius: 0.9rem;
-  background: linear-gradient(135deg, #4338ca, #6366f1);
-  color: #ffffff;
-  box-shadow: 0 18px 42px rgba(79, 70, 229, 0.35);
+  background: linear-gradient(135deg, var(--brand-accent), var(--brand-primary));
+  color: var(--tone-text-inverse);
+  box-shadow: 0 18px 42px var(--brand-primary-35);
 }
 
 .app-sidebar__logo svg {
@@ -368,7 +511,7 @@ body {
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.5);
+  color: var(--tone-text-subtle);
 }
 
 .app-sidebar__content {
@@ -401,21 +544,21 @@ body {
 }
 
 .app-sidebar__link:hover {
-  background: rgba(99, 102, 241, 0.12);
-  border-color: rgba(99, 102, 241, 0.22);
+  background: var(--brand-primary-12);
+  border-color: var(--brand-primary-22);
   color: var(--tone-text-strong);
 }
 
 .app-sidebar__link:focus-visible {
-  outline: 2px solid rgba(99, 102, 241, 0.45);
+  outline: 2px solid var(--brand-primary-45);
   outline-offset: 3px;
 }
 
 .app-sidebar__link--active {
-  background: linear-gradient(135deg, #4338ca, #6366f1);
+  background: linear-gradient(135deg, var(--brand-accent), var(--brand-primary));
   border-color: transparent;
-  color: #ffffff;
-  box-shadow: 0 20px 32px rgba(99, 102, 241, 0.35);
+  color: var(--tone-text-inverse);
+  box-shadow: 0 20px 32px var(--brand-primary-35);
 }
 
 .app-sidebar__link-icon {
@@ -442,23 +585,23 @@ body {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 600;
-  background: rgba(99, 102, 241, 0.15);
-  color: #4338ca;
+  background: var(--brand-primary-15);
+  color: var(--brand-accent);
 }
 
 .app-sidebar__badge--accent {
-  background: #f59e0b;
-  color: #ffffff;
+  background: var(--status-warning-soft);
+  color: var(--color-status-warning);
 }
 
 .app-sidebar__link--active .app-sidebar__badge {
-  background: rgba(255, 255, 255, 0.25);
-  color: #f9fafb;
+  background: var(--surface-on-accent);
+  color: var(--tone-text-inverse);
 }
 
 .app-sidebar__link--active .app-sidebar__badge--accent {
-  background: #fde68a;
-  color: #1f2937;
+  background: var(--surface-on-accent-strong);
+  color: var(--color-status-warning);
 }
 
 .app-sidebar__footer {
@@ -498,13 +641,13 @@ body {
 .app-sidebar__profile-greeting {
   margin: 0;
   font-size: 0.85rem;
-  color: rgba(15, 23, 42, 0.68);
+  color: var(--tone-text-muted);
 }
 
 .app-sidebar__profile-email {
   margin: 0;
   font-size: 0.78rem;
-  color: rgba(15, 23, 42, 0.55);
+  color: var(--tone-text-subtle);
   word-break: break-word;
 }
 
@@ -515,9 +658,9 @@ body {
   width: 100%;
   padding: 0.65rem 0.9rem;
   border-radius: 0.95rem;
-  border: 1px solid rgba(99, 102, 241, 0.25);
-  background: rgba(99, 102, 241, 0.12);
-  color: #4338ca;
+  border: 1px solid var(--brand-primary-25);
+  background: var(--brand-primary-12);
+  color: var(--brand-accent);
   font-weight: 600;
   transition: background-color 0.2s ease, border-color 0.2s ease,
     color 0.2s ease, transform 0.2s ease;
@@ -525,14 +668,14 @@ body {
 }
 
 .app-sidebar__logout:hover {
-  background: linear-gradient(135deg, #4338ca, #6366f1);
+  background: linear-gradient(135deg, var(--brand-accent), var(--brand-primary));
   border-color: transparent;
-  color: #ffffff;
+  color: var(--tone-text-inverse);
   transform: translateY(-1px);
 }
 
 .app-sidebar__logout:focus-visible {
-  outline: 2px solid rgba(99, 102, 241, 0.45);
+  outline: 2px solid var(--brand-primary-45);
   outline-offset: 3px;
 }
 

--- a/src/components/comment-thread.tsx
+++ b/src/components/comment-thread.tsx
@@ -193,7 +193,7 @@ export default function CommentThread({
                   {formatTimestamp(comment.createdAt)}
                 </time>
               </div>
-              <div className="mt-2 rounded-2xl bg-[var(--surface-page)] px-4 py-3 text-sm text-[var(--tone-text)] shadow-sm">
+              <div className="mt-2 rounded-2xl bg-[var(--surface-muted)] px-4 py-3 text-sm text-[var(--tone-text)] shadow-sm">
                 {comment.content}
               </div>
               <div className="mt-2 flex items-center gap-3">
@@ -260,7 +260,7 @@ export default function CommentThread({
         {comments.length ? (
           comments.map((comment) => renderComment(comment))
         ) : parentId ? null : (
-          <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-page)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
+          <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-muted)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
             No comments yet. Start the conversation!
           </div>
         )}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -78,7 +78,7 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
   return (
     <aside
       className={cn(
-        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--color-border)] bg-[var(--surface-page)] px-3 py-6 transition-all duration-300 ease-in-out',
+        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-[var(--color-border)] bg-[var(--color-sidebar)] px-3 py-6 transition-all duration-300 ease-in-out',
         collapsed ? 'w-20' : 'w-72'
       )}
     >
@@ -89,8 +89,8 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
           </div>
           {!collapsed && (
             <div>
-              <p className="text-base font-semibold text-[var(--tone-text-strong)]">LoopTask</p>
-              <p className="text-xs text-[var(--color-text-muted)]">Productivity Hub</p>
+              <p className="text-heading-6 text-[var(--tone-text-strong)]">LoopTask</p>
+              <p className="text-body-xs text-[var(--color-text-muted)]">Productivity Hub</p>
             </div>
           )}
         </div>
@@ -105,7 +105,7 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'group flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-[var(--tone-text)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--tone-text-strong)]',
+                  'group flex items-center gap-3 rounded-xl px-3 py-2 text-body-sm font-medium text-[var(--tone-text)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--tone-text-strong)]',
                   isActive && 'bg-[var(--color-surface)] text-[var(--tone-text-strong)] shadow-sm',
                   collapsed && 'justify-center px-0'
                 )}
@@ -126,9 +126,9 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
       </div>
 
       <div className={cn('mt-auto rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-3 shadow-sm', collapsed && 'px-0 text-center')}>
-        {loading && <p className="text-xs text-[var(--color-text-muted)]">Loading user...</p>}
+        {loading && <p className="text-body-xs text-[var(--color-text-muted)]">Loading user...</p>}
         {error && !loading && (
-          <p className="text-xs text-[var(--color-status-destructive)]" role="alert">
+          <p className="text-body-xs text-[var(--color-status-destructive)]" role="alert">
             {error}
           </p>
         )}
@@ -137,12 +137,12 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
             <Avatar src={user.avatar ?? undefined} fallback={initials} className="h-10 w-10 text-base" />
             {!collapsed && (
               <div className="flex flex-col">
-                <p className="text-sm font-medium text-[var(--tone-text-strong)]">{user.name}</p>
-                <p className="text-xs text-[var(--color-text-muted)]">{user.email}</p>
+                <p className="text-body-sm font-medium text-[var(--tone-text-strong)]">{user.name}</p>
+                <p className="text-body-xs text-[var(--color-text-muted)]">{user.email}</p>
               </div>
             )}
             {collapsed && (
-              <p className="text-xs font-medium text-[var(--tone-text-strong)]">{user.name ?? user.email}</p>
+              <p className="text-body-xs font-medium text-[var(--tone-text-strong)]">{user.name ?? user.email}</p>
             )}
           </div>
         )}

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -34,7 +34,7 @@ const STATUS_STYLES: Record<
     label: 'Flow In Progress',
     icon: '🔄',
     variant: 'info',
-    className: 'bg-[color:rgba(46,144,250,0.16)] text-[var(--color-status-info)]',
+    className: 'bg-[var(--status-info-soft)] text-[var(--color-status-info)]',
   },
   DONE: {
     label: 'Done',
@@ -71,7 +71,8 @@ export function StatusBadge({
       variant={variant}
       className={cn(
         'gap-1 rounded-full font-semibold normal-case shadow-sm ring-1 ring-inset ring-black/10 transition',
-        'hover:ring-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-page)]',
+        'hover:ring-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2',
+        'focus-visible:ring-offset-[var(--color-background)]',
         SIZE_STYLES[size],
         statusClassName,
         className,

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -31,7 +31,7 @@ function formatTimestamp(date: string) {
 export function Timeline({ events }: { events: TimelineEvent[] }) {
   if (!events.length) {
     return (
-      <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-page)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
+      <div className="rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--surface-muted)] px-4 py-6 text-center text-sm text-[var(--color-text-muted)]">
         No activity yet.
       </div>
     );
@@ -62,7 +62,7 @@ export function Timeline({ events }: { events: TimelineEvent[] }) {
             <div
               className={cn(
                 'flex items-start gap-3 rounded-lg border border-transparent px-4 py-3 transition-colors',
-                'group-hover:border-[var(--color-border)] group-hover:bg-[var(--surface-page)]',
+                'group-hover:border-[var(--color-border)] group-hover:bg-[var(--surface-muted)]',
                 'group-aria-[disabled=true]:opacity-70 group-aria-[disabled=true]:hover:border-transparent group-aria-[disabled=true]:hover:bg-transparent'
               )}
             >


### PR DESCRIPTION
## Summary
- replace the global palette with LoopTask background, sidebar, brand, and status tokens and expose a reusable typography scale
- update layout styles and sidebar content to consume the new tokens and utilities, including refreshed hover/focus treatments
- retheme timeline, comment, and status badge surfaces to draw from the new muted/background colors

## Testing
- npm run lint *(fails: existing warnings for console usage and unsafe any assignments)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c6c432748328b00c3ca9e2de4187