### PR TITLE
Align UI primitives with refreshed design language

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -16,14 +16,13 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const variantClasses: Record<BadgeVariant, string> = {
-  default: 'bg-[var(--brand-primary)] text-white',
-  secondary: 'bg-[var(--brand-secondary)] text-[var(--brand-primary)]',
-  outline:
-    'border border-[var(--color-border-strong)] bg-transparent text-[var(--tone-text-strong)]',
-  destructive: 'bg-[var(--color-status-destructive)] text-white',
-  success: 'bg-[var(--color-status-success)] text-white',
-  warning: 'bg-[var(--color-status-warning)] text-white',
-  info: 'bg-[var(--color-status-info)] text-white',
+  default: 'bg-[#f3f3f5] text-[#1f2937]',
+  secondary: 'bg-[#e7e8ec] text-[#1f2937]',
+  outline: 'border border-[#d1d5db] bg-transparent text-[#1f2937]',
+  destructive: 'bg-[#fde8e8] text-[#7f1d1d]',
+  success: 'bg-[#def7ec] text-[#03543f]',
+  warning: 'bg-[#fef3c7] text-[#92400e]',
+  info: 'bg-[#e0f2fe] text-[#0b4a6f]',
 };
 
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
@@ -32,7 +31,7 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
       <span
         ref={ref}
         className={cn(
-          'inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-1 text-xs font-medium capitalize tracking-wide transition-colors',
+          'inline-flex items-center gap-1 rounded-full border border-transparent px-2.5 py-1 text-xs font-semibold capitalize tracking-wide transition-colors duration-200',
           variantClasses[variant],
           className
         )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,20 +13,20 @@ export interface ButtonProps
 
 const variantClasses: Record<ButtonVariant, string> = {
   primary:
-    'bg-[var(--brand-primary)] text-white shadow-sm hover:bg-[#151433] focus-visible:ring-[var(--brand-primary)] disabled:bg-[color:rgba(3,2,19,0.35)] disabled:text-white/70',
+    'bg-[#0b1d3f] text-white shadow-sm hover:bg-[#091632] focus-visible:ring-[#0b1d3f] disabled:bg-[#0b1d3f]/60 disabled:text-white/80',
   secondary:
-    'bg-[var(--brand-secondary)] text-[var(--brand-primary)] shadow-sm hover:bg-[#d8d3ff] focus-visible:ring-[var(--brand-primary)] disabled:bg-[color:rgba(227,225,255,0.6)] disabled:text-[var(--brand-primary)]/60',
+    'bg-[#f3f3f5] text-[#111827] shadow-sm hover:bg-[#e5e6eb] focus-visible:ring-[#0b1d3f] disabled:bg-[#f3f3f5] disabled:text-[#6b7280] disabled:shadow-none',
   ghost:
-    'bg-transparent text-[var(--brand-primary)] hover:bg-[color:rgba(227,225,255,0.5)] focus-visible:ring-[var(--brand-primary)] disabled:text-[var(--brand-primary)]/50',
+    'bg-transparent text-[#0b1d3f] hover:bg-[#e5e6eb]/70 focus-visible:ring-[#0b1d3f]/40 disabled:text-[#0b1d3f]/40',
   outline:
-    'border border-[var(--color-border-strong)] bg-transparent text-[var(--brand-primary)] shadow-sm hover:bg-[color:rgba(227,225,255,0.4)] focus-visible:ring-[var(--brand-primary)] disabled:text-[var(--brand-primary)]/50 disabled:border-[color:rgba(194,199,214,0.8)]',
+    'border border-[#c9ccd6] bg-transparent text-[#0b1d3f] shadow-sm hover:bg-[#f3f3f5] focus-visible:ring-[#0b1d3f] disabled:text-[#0b1d3f]/40 disabled:border-[#c9ccd6]/60',
 };
 
 const sizeClasses: Record<ButtonSize, string> = {
-  sm: 'h-8 px-3 text-xs',
-  md: 'h-9 px-4 text-sm',
-  lg: 'h-11 px-6 text-base',
-  icon: 'h-9 w-9',
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-3 py-2 text-sm',
+  lg: 'px-4 py-3 text-base',
+  icon: 'h-10 w-10',
 };
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -43,7 +43,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         className={cn(
-          'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-surface)] disabled:pointer-events-none disabled:opacity-90',
+          'inline-flex items-center justify-center rounded-[6px] font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-80',
           sizeClasses[size],
           variantClasses[variant],
           className

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -13,7 +13,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(function Card(
     <div
       ref={ref}
       className={cn(
-        "rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-5 shadow-md",
+        "rounded-[10px] border border-black/10 bg-white p-6 shadow-sm transition-shadow duration-200 hover:shadow-lg data-[density=compact]:p-4",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         ref={ref}
         className={cn(
-          'flex h-10 w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm placeholder:text-[var(--color-text-secondary)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-opacity-30 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] focus:border-[var(--color-primary)]',
+          'flex h-10 w-full rounded-[6px] border border-transparent bg-[#f3f3f5] px-3 py-2 text-sm text-[#111827] placeholder:text-[#6b7280] shadow-inner transition-colors duration-200 focus:border-[#0b1d3f] focus:outline-none focus:ring-2 focus:ring-[#0b1d3f]/30 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-60',
           className
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -8,10 +8,10 @@ export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, children, ...props }, ref) => {
     return (
-        <select
-          ref={ref}
-          className={cn(
-          "flex h-10 w-full appearance-none rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--tone-text)] placeholder:text-[var(--color-text-secondary)] transition focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-opacity-30 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] focus:border-[var(--brand-primary)] disabled:cursor-not-allowed disabled:bg-[color:rgba(227,225,255,0.35)] disabled:text-[var(--color-text-secondary)]",
+      <select
+        ref={ref}
+        className={cn(
+          "flex h-10 w-full appearance-none rounded-[6px] border border-transparent bg-[#f3f3f5] px-3 py-2 pr-10 text-sm text-[#111827] placeholder:text-[#6b7280] shadow-inner transition duration-200 focus:border-[#0b1d3f] focus:outline-none focus:ring-2 focus:ring-[#0b1d3f]/30 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-60 bg-[url('data:image/svg+xml;utf8,<svg fill=\\'none\\' height=\\'16\\' width=\\'16\\' xmlns=\\'http://www.w3.org/2000/svg\\'><path d=\\'M4 6l4 4 4-4\\' stroke=\\'%230b1d3f\\' stroke-linecap=\\'round\\' stroke-linejoin=\\'round\\' stroke-width=\\'1.5\\'/></svg>')] bg-[length:16px_16px] bg-[position:calc(100%-12px)_center] bg-no-repeat",
           className
         )}
         {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          'flex w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm placeholder:text-[var(--color-text-secondary)] transition-colors focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)] focus:ring-opacity-30 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] focus:border-[var(--color-primary)]',
+          'flex w-full rounded-[6px] border border-transparent bg-[#f3f3f5] px-3 py-2 text-sm text-[#111827] placeholder:text-[#6b7280] shadow-inner transition-colors duration-200 focus:border-[#0b1d3f] focus:outline-none focus:ring-2 focus:ring-[#0b1d3f]/30 focus:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-60',
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- restyle buttons to use the navy primary, light gray secondary, and refined ghost variants with consistent sizing and transitions
- update cards, inputs, selects, badges, and textareas to the new neutral surfaces, radii, and focus treatments for visual consistency

## Testing
- npm run lint *(fails: existing repository warnings must be resolved separately)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ca1e7c848328b0c72ffdce0097ce