### PR TITLE
Add projects section with pages and navigation

### DIFF
--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { SessionProvider } from 'next-auth/react';
+import StatusBadge from '@/components/status-badge';
+import { Card } from '@/components/ui/card';
+import type { ProjectDetail } from '@/types/api/project';
+import type { TaskResponse as Task } from '@/types/api/task';
+
+function ProjectDetailPageInner() {
+  const params = useParams<{ id?: string | string[] }>();
+  const idParam = params?.id;
+  const projectId = Array.isArray(idParam) ? idParam[0] : idParam ?? '';
+
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tasksError, setTasksError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!projectId) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadProject = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setTasksError(null);
+        const [projectResponse, tasksResponse] = await Promise.all([
+          fetch(`/api/projects/${projectId}`, { credentials: 'include' }),
+          fetch(`/api/tasks?projectId=${projectId}`, { credentials: 'include' }),
+        ]);
+
+        if (!projectResponse.ok) {
+          const errorBody = (await projectResponse.json().catch(() => ({}))) as { detail?: string };
+          throw new Error(errorBody.detail ?? 'Unable to load project');
+        }
+
+        const projectData = (await projectResponse.json()) as ProjectDetail;
+        if (!isMounted) {
+          return;
+        }
+        setProject(projectData);
+
+        if (tasksResponse.ok) {
+          const taskData = (await tasksResponse.json()) as Task[];
+          if (isMounted) {
+            setTasks(taskData);
+          }
+        } else if (isMounted) {
+          const taskError = (await tasksResponse.json().catch(() => ({}))) as { detail?: string };
+          setTasks([]);
+          setTasksError(taskError.detail ?? 'Unable to load tasks for this project');
+        }
+      } catch (err: unknown) {
+        if (!isMounted) return;
+        const message = err instanceof Error ? err.message : 'Unable to load project';
+        setError(message);
+        setProject(null);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadProject();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [projectId]);
+
+  const stats = useMemo(() => {
+    const pending = project?.stats?.pending ?? tasks.filter((task) => task.status !== 'DONE').length;
+    const done = project?.stats?.done ?? tasks.filter((task) => task.status === 'DONE').length;
+    const total = project?.stats?.total ?? tasks.length;
+    return { pending, done, total };
+  }, [project, tasks]);
+
+  if (!projectId) {
+    return <div className="p-4 md:p-6">Project not found.</div>;
+  }
+
+  if (loading) {
+    return <div className="p-4 md:p-6 text-sm text-[var(--color-text-muted)]">Loading project…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 md:p-6">
+        <Card className="border-[var(--color-status-destructive)]/40 bg-[var(--status-destructive-soft)] text-sm text-[var(--color-status-destructive)]">
+          {error}
+        </Card>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="p-4 md:p-6">
+        <Card className="text-sm text-[var(--color-text-muted)]">Project unavailable.</Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <Card className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold text-[var(--tone-text-strong)]">{project.name}</h1>
+            {project.type?.name ? (
+              <span className="inline-flex w-fit items-center rounded-full bg-[var(--brand-primary)]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[var(--brand-primary)]">
+                {project.type.name}
+              </span>
+            ) : null}
+            {project.description ? (
+              <p className="max-w-2xl text-sm text-[var(--color-text-muted)]">{project.description}</p>
+            ) : (
+              <p className="text-sm text-[var(--color-text-muted)]">No description provided yet.</p>
+            )}
+          </div>
+          <div className="grid w-full gap-3 sm:w-auto sm:grid-cols-3">
+            <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-center">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Pending</p>
+              <p className="mt-1 text-xl font-semibold text-[var(--tone-text-strong)]">{stats.pending}</p>
+            </div>
+            <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-center">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Done</p>
+              <p className="mt-1 text-xl font-semibold text-[var(--tone-text-strong)]">{stats.done}</p>
+            </div>
+            <div className="rounded-[12px] border border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-center">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Total</p>
+              <p className="mt-1 text-xl font-semibold text-[var(--tone-text-strong)]">{stats.total}</p>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-6 text-xs text-[var(--color-text-muted)]">
+          <div>
+            <p className="font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Created</p>
+            <p className="mt-1 text-sm text-[var(--tone-text-strong)]">
+              {project.createdAt ? new Date(project.createdAt).toLocaleString() : '—'}
+            </p>
+          </div>
+          <div>
+            <p className="font-semibold uppercase tracking-wide text-[var(--color-text-muted)]">Updated</p>
+            <p className="mt-1 text-sm text-[var(--tone-text-strong)]">
+              {project.updatedAt ? new Date(project.updatedAt).toLocaleString() : '—'}
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--tone-text-strong)]">Project tasks</h2>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {tasks.length > 0 ? `${tasks.length} task${tasks.length === 1 ? '' : 's'}` : 'No tasks assigned yet.'}
+            </p>
+          </div>
+          <Link
+            href={`/tasks/new?projectId=${project._id}`}
+            className="inline-flex items-center justify-center rounded-[10px] border border-[var(--brand-primary)] px-3 py-1.5 text-sm font-semibold text-[var(--brand-primary)] transition hover:bg-[var(--brand-primary)]/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2"
+          >
+            New Task
+          </Link>
+        </div>
+        {tasksError ? (
+          <p className="mt-4 rounded-[12px] border border-[var(--color-status-destructive)]/40 bg-[var(--status-destructive-soft)] p-3 text-sm text-[var(--color-status-destructive)]">
+            {tasksError}
+          </p>
+        ) : null}
+        <div className="mt-6 divide-y divide-[var(--color-border)]">
+          {tasks.length === 0 ? (
+            <div className="py-6 text-sm text-[var(--color-text-muted)]">
+              No tasks yet. Create one to get this project moving.
+            </div>
+          ) : (
+            tasks.map((task) => (
+              <Link
+                key={task._id}
+                href={`/tasks/${task._id}`}
+                className="flex flex-col gap-3 py-4 transition hover:text-[var(--brand-primary)] sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <p className="text-sm font-semibold text-[var(--tone-text-strong)]">{task.title}</p>
+                  {task.description ? (
+                    <p className="mt-1 line-clamp-2 text-sm text-[var(--color-text-muted)]">{task.description}</p>
+                  ) : null}
+                </div>
+                <div className="flex items-center gap-3">
+                  <StatusBadge status={task.status} size="sm" />
+                  {task.dueDate ? (
+                    <span className="text-xs font-medium text-[var(--color-text-muted)]">
+                      Due {new Date(task.dueDate).toLocaleDateString()}
+                    </span>
+                  ) : null}
+                </div>
+              </Link>
+            ))
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default function ProjectDetailPage() {
+  return (
+    <SessionProvider>
+      <ProjectDetailPageInner />
+    </SessionProvider>
+  );
+}

--- a/src/app/projects/layout.tsx
+++ b/src/app/projects/layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import RequireAuth from '@/components/layout/RequireAuth';
+
+export default async function ProjectsLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return <RequireAuth callbackUrl="/projects">{children}</RequireAuth>;
+}

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { SessionProvider } from 'next-auth/react';
+import { Dialog, DialogContent, DialogTrigger, DialogClose } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { useToast } from '@/components/ui/toast-provider';
+import type { ProjectType } from '@/types/api/project';
+
+interface ProjectFormState {
+  name: string;
+  description: string;
+  typeId: string;
+}
+
+function NewProjectPageInner() {
+  const router = useRouter();
+  const { showToast } = useToast();
+
+  const [types, setTypes] = useState<ProjectType[]>([]);
+  const [typesLoading, setTypesLoading] = useState(true);
+  const [form, setForm] = useState<ProjectFormState>({
+    name: '',
+    description: '',
+    typeId: '',
+  });
+  const [formErrors, setFormErrors] = useState<Partial<Record<keyof ProjectFormState, string>>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [typeDialogOpen, setTypeDialogOpen] = useState(false);
+  const [newTypeName, setNewTypeName] = useState('');
+  const [newTypeError, setNewTypeError] = useState<string | null>(null);
+  const [creatingType, setCreatingType] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadTypes = async () => {
+      try {
+        setTypesLoading(true);
+        const response = await fetch('/api/project-types', { credentials: 'include' });
+        if (!response.ok) {
+          throw new Error('Unable to load project types');
+        }
+        const data = (await response.json()) as ProjectType[];
+        if (!isMounted) {
+          return;
+        }
+        setTypes(data);
+        setForm((prev) => {
+          if (prev.typeId) {
+            return prev;
+          }
+          const defaultType = data.find((type) => type.name.toLowerCase() === 'general');
+          const fallbackType = defaultType ?? data[0];
+          return { ...prev, typeId: fallbackType?._id ?? '' };
+        });
+      } catch {
+        if (!isMounted) return;
+        setTypes([]);
+      } finally {
+        if (isMounted) {
+          setTypesLoading(false);
+        }
+      }
+    };
+
+    void loadTypes();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const existingTypeNames = useMemo(
+    () => types.map((type) => type.name.trim().toLowerCase()),
+    [types]
+  );
+
+  const validateForm = (state: ProjectFormState) => {
+    const errors: Partial<Record<keyof ProjectFormState, string>> = {};
+    if (!state.name.trim()) {
+      errors.name = 'Project name is required';
+    }
+    if (!state.typeId) {
+      errors.typeId = 'Select a project type';
+    }
+    return errors;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedState: ProjectFormState = {
+      name: form.name.trim(),
+      description: form.description.trim(),
+      typeId: form.typeId,
+    };
+    const nextErrors = validateForm(trimmedState);
+    setFormErrors(nextErrors);
+    setSubmitError(null);
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/projects', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: trimmedState.name,
+          description: trimmedState.description || undefined,
+          typeId: trimmedState.typeId,
+        }),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { detail?: string };
+        throw new Error(body.detail ?? 'Failed to create project');
+      }
+      const project = (await response.json()) as { _id?: string };
+      showToast({ message: 'Project created successfully', tone: 'success' });
+      if (project?._id) {
+        router.push(`/projects/${project._id}`);
+      } else {
+        router.push('/projects');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to create project';
+      setSubmitError(message);
+      showToast({ message, tone: 'error' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCreateType = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = newTypeName.trim();
+    if (!trimmed) {
+      setNewTypeError('Enter a project type name');
+      return;
+    }
+    if (existingTypeNames.includes(trimmed.toLowerCase())) {
+      setNewTypeError('That project type already exists');
+      return;
+    }
+    setCreatingType(true);
+    try {
+      const response = await fetch('/api/project-types', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { detail?: string };
+        throw new Error(body.detail ?? 'Failed to create project type');
+      }
+      const created = (await response.json()) as ProjectType;
+      setTypes((prev) => [...prev, created]);
+      setForm((prev) => ({ ...prev, typeId: created._id }));
+      setNewTypeName('');
+      setNewTypeError(null);
+      setTypeDialogOpen(false);
+      showToast({ message: 'Project type added', tone: 'success' });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to create project type';
+      setNewTypeError(message);
+    } finally {
+      setCreatingType(false);
+    }
+  };
+
+  return (
+    <div className="p-4 md:p-6">
+      <div className="mx-auto max-w-3xl space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--tone-text-strong)]">Create a new project</h1>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            Group related tasks, assign owners, and monitor progress at a glance.
+          </p>
+        </div>
+
+        <Card>
+          <form className="space-y-5" onSubmit={handleSubmit} noValidate>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--tone-text-strong)]" htmlFor="project-name">
+                Project name
+              </label>
+              <Input
+                id="project-name"
+                name="name"
+                value={form.name}
+                onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                placeholder="Marketing website refresh"
+                aria-invalid={Boolean(formErrors.name)}
+                aria-describedby={formErrors.name ? 'project-name-error' : undefined}
+                required
+              />
+              {formErrors.name ? (
+                <p id="project-name-error" className="text-xs text-[var(--color-status-destructive)]">
+                  {formErrors.name}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--tone-text-strong)]" htmlFor="project-description">
+                Description
+              </label>
+              <Input
+                id="project-description"
+                name="description"
+                value={form.description}
+                onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                placeholder="Share context and goals for this project"
+              />
+              <p className="text-xs text-[var(--color-text-muted)]">Optional</p>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--tone-text-strong)]" htmlFor="project-type">
+                Project type
+              </label>
+              <div className="flex items-center gap-2">
+                <Select
+                  id="project-type"
+                  name="typeId"
+                  value={form.typeId}
+                  onChange={(event) => setForm((prev) => ({ ...prev, typeId: event.target.value }))}
+                  disabled={typesLoading}
+                  aria-invalid={Boolean(formErrors.typeId)}
+                  aria-describedby={formErrors.typeId ? 'project-type-error' : undefined}
+                  required
+                >
+                  <option value="" disabled>
+                    {typesLoading ? 'Loading types…' : 'Select a type'}
+                  </option>
+                  {types.map((type) => (
+                    <option key={type._id} value={type._id}>
+                      {type.name}
+                    </option>
+                  ))}
+                </Select>
+                <Dialog open={typeDialogOpen} onOpenChange={(next) => {
+                  setTypeDialogOpen(next);
+                  if (!next) {
+                    setNewTypeError(null);
+                    setNewTypeName('');
+                  }
+                }}>
+                  <DialogTrigger asChild>
+                    <Button type="button" variant="secondary" size="icon" aria-label="Add project type">
+                      <span aria-hidden="true" className="text-lg font-semibold text-[var(--brand-primary)]">
+                        +
+                      </span>
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <form className="space-y-4" onSubmit={handleCreateType}>
+                      <div className="space-y-2">
+                        <h2 className="text-lg font-semibold text-[var(--tone-text-strong)]">Add a project type</h2>
+                        <p className="text-sm text-[var(--color-text-muted)]">
+                          Give your new type a descriptive name so teammates can find it later.
+                        </p>
+                      </div>
+                      <div className="space-y-2">
+                        <label className="text-sm font-medium text-[var(--tone-text-strong)]" htmlFor="new-project-type">
+                          Type name
+                        </label>
+                        <Input
+                          id="new-project-type"
+                          value={newTypeName}
+                          onChange={(event) => {
+                            setNewTypeName(event.target.value);
+                            if (newTypeError) {
+                              setNewTypeError(null);
+                            }
+                          }}
+                          placeholder="General"
+                          autoFocus
+                        />
+                        {newTypeError ? (
+                          <p className="text-xs text-[var(--color-status-destructive)]">{newTypeError}</p>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center justify-end gap-3">
+                        <DialogClose asChild>
+                          <Button type="button" variant="ghost">
+                            Cancel
+                          </Button>
+                        </DialogClose>
+                        <Button type="submit" disabled={creatingType}>
+                          {creatingType ? 'Saving…' : 'Add type'}
+                        </Button>
+                      </div>
+                    </form>
+                  </DialogContent>
+                </Dialog>
+              </div>
+              {formErrors.typeId ? (
+                <p id="project-type-error" className="text-xs text-[var(--color-status-destructive)]">
+                  {formErrors.typeId}
+                </p>
+              ) : null}
+            </div>
+
+            {submitError ? (
+              <div className="rounded-[10px] border border-[var(--color-status-destructive)]/40 bg-[var(--status-destructive-soft)] p-3 text-sm text-[var(--color-status-destructive)]">
+                {submitError}
+              </div>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <Button type="button" variant="secondary" onClick={() => router.push('/projects')}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={submitting}>
+                {submitting ? 'Creating…' : 'Create project'}
+              </Button>
+            </div>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default function NewProjectPage() {
+  return (
+    <SessionProvider>
+      <NewProjectPageInner />
+    </SessionProvider>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { SessionProvider } from 'next-auth/react';
+import { Card } from '@/components/ui/card';
+import type { ProjectSummary } from '@/types/api/project';
+
+function ProjectsPageInner() {
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadProjects = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetch('/api/projects', { credentials: 'include' });
+        if (!response.ok) {
+          throw new Error('Unable to load projects');
+        }
+        const data = (await response.json()) as ProjectSummary[];
+        if (isMounted) {
+          setProjects(data);
+        }
+      } catch (err: unknown) {
+        if (!isMounted) return;
+        const message = err instanceof Error ? err.message : 'Unable to load projects';
+        setError(message);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadProjects();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--tone-text-strong)]">Projects</h1>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            Track initiatives, monitor progress, and drill into tasks for each project.
+          </p>
+        </div>
+        <Link
+          href="/projects/new"
+          className="inline-flex items-center justify-center rounded-[10px] bg-[var(--brand-primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--brand-primary)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2"
+        >
+          Add Project
+        </Link>
+      </div>
+
+      {loading ? (
+        <Card className="border-dashed text-sm text-[var(--color-text-muted)]">
+          Loading projects…
+        </Card>
+      ) : error ? (
+        <Card className="border-[var(--color-status-destructive)]/40 bg-[var(--status-destructive-soft)] text-sm text-[var(--color-status-destructive)]">
+          {error}
+        </Card>
+      ) : projects.length === 0 ? (
+        <Card className="flex flex-col items-start gap-4 text-sm text-[var(--color-text-muted)]">
+          <div>
+            <p className="text-base font-semibold text-[var(--tone-text-strong)]">No projects yet</p>
+            <p className="mt-1 max-w-xl text-sm text-[var(--color-text-muted)]">
+              Create your first project to organize related tasks and collaborate with your team.
+            </p>
+          </div>
+          <Link
+            href="/projects/new"
+            className="inline-flex items-center justify-center rounded-[10px] bg-[var(--brand-primary)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--brand-primary)]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary)] focus-visible:ring-offset-2"
+          >
+            Add Project
+          </Link>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {projects.map((project) => {
+            const description = project.description?.trim();
+            return (
+              <Link key={project._id} href={`/projects/${project._id}`} className="block h-full">
+                <Card className="flex h-full flex-col justify-between">
+                  <div className="space-y-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h2 className="text-lg font-semibold text-[var(--tone-text-strong)]">
+                          {project.name}
+                        </h2>
+                        {project.type?.name ? (
+                          <span className="mt-1 inline-flex items-center rounded-full bg-[var(--brand-primary)]/10 px-2.5 py-0.5 text-xs font-medium text-[var(--brand-primary)]">
+                            {project.type.name}
+                          </span>
+                        ) : null}
+                      </div>
+                      <span aria-hidden="true" className="text-xl text-[var(--color-text-muted)]">
+                        →
+                      </span>
+                    </div>
+                    <p className="line-clamp-3 text-sm text-[var(--color-text-muted)]">
+                      {description && description.length > 0
+                        ? description
+                        : 'No description provided yet.'}
+                    </p>
+                  </div>
+                  <div className="mt-6 grid grid-cols-3 gap-3">
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+                        Pending
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-[var(--tone-text-strong)]">
+                        {project.stats.pending}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+                        Done
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-[var(--tone-text-strong)]">
+                        {project.stats.done}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+                        Total
+                      </p>
+                      <p className="mt-1 text-lg font-semibold text-[var(--tone-text-strong)]">
+                        {project.stats.total}
+                      </p>
+                    </div>
+                  </div>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ProjectsPage() {
+  return (
+    <SessionProvider>
+      <ProjectsPageInner />
+    </SessionProvider>
+  );
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -53,6 +53,26 @@ const TasksIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const ProjectsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
+    <path
+      d="M4.5 6.75A2.25 2.25 0 016.75 4.5h3.19a2.25 2.25 0 011.74.84l.72.9a.75.75 0 00.58.28h4.27a1.5 1.5 0 011.5 1.5V18a1.5 1.5 0 01-1.5 1.5H6.75A2.25 2.25 0 014.5 17.25z"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+    <path
+      d="M8 14h8M8 11h5"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const ReportsIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" {...props}>
     <path
@@ -117,6 +137,7 @@ const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => (
 
 const NAVIGATION_LINKS: NavigationLink[] = [
   { href: "/dashboard", label: "Dashboard", icon: <DashboardIcon /> },
+  { href: "/projects", label: "Projects", icon: <ProjectsIcon /> },
   {
     href: "/tasks",
     label: "My Tasks",

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -61,6 +61,7 @@ export default function Sidebar({ collapsed = false }: SidebarProps) {
   const navItems = useMemo(
     () => [
       { href: '/dashboard', label: 'Dashboard', icon: DashboardIcon },
+      { href: '/projects', label: 'Projects', icon: ProjectsIcon },
       { href: '/tasks', label: 'My Tasks', icon: TasksIcon },
       { href: '/settings', label: 'Settings', icon: SettingsIcon },
     ],
@@ -182,6 +183,24 @@ function TasksIcon({ className }: { className?: string }) {
     >
       <path d="M9 11l2 2 4-4" />
       <rect x="3" y="4" width="18" height="16" rx="2" ry="2" />
+    </svg>
+  );
+}
+
+function ProjectsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3 7.5A2.5 2.5 0 015.5 5H9l1.2 1.6a2 2 0 001.6.8H18.5A2.5 2.5 0 0121 9.9V18a2 2 0 01-2 2H5.5A2.5 2.5 0 013 17.5z" />
+      <path d="M8 13h7M8 10h4" />
     </svg>
   );
 }

--- a/src/types/api/project.ts
+++ b/src/types/api/project.ts
@@ -1,0 +1,29 @@
+export interface ProjectTaskStats {
+  pending: number;
+  done: number;
+  total: number;
+}
+
+export interface ProjectType {
+  _id: string;
+  name: string;
+  normalized: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectSummary {
+  _id: string;
+  name: string;
+  description?: string | null;
+  type?: ProjectType | null;
+  stats: ProjectTaskStats;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ProjectDetail extends ProjectSummary {
+  organizationId: string;
+  createdBy: string;
+  updatedBy: string;
+}


### PR DESCRIPTION
## Summary
- add a Projects link to the shell and sidebar navigation with a matching icon
- introduce API response types plus authenticated routes for listing, viewing, and creating projects
- implement project list/detail UI with task overviews and a creation form including inline project-type creation

## Testing
- `npm run lint` *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e23011e4832886262171a1cc9adc