### PR TITLE
Add project selection to task flows and filters

### DIFF
--- a/src/app/tasks/page.test.ts
+++ b/src/app/tasks/page.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildTaskQueryParams, type TaskFilterState } from './page';
+
+describe('buildTaskQueryParams', () => {
+  const baseFilters: TaskFilterState = {
+    assignee: '',
+    priority: '',
+    dueFrom: '',
+    dueTo: '',
+    sort: '',
+    projectId: '',
+  };
+
+  it('includes projectId when provided', () => {
+    const params = buildTaskQueryParams(
+      { ...baseFilters, projectId: 'project-123' },
+      'design',
+      ['OPEN', 'IN_PROGRESS'],
+      2,
+    );
+
+    expect(params.get('projectId')).toBe('project-123');
+    expect(params.get('page')).toBe('2');
+    expect(params.getAll('status')).toEqual(['OPEN', 'IN_PROGRESS']);
+    expect(params.get('q')).toBe('design');
+  });
+
+  it('omits projectId when empty', () => {
+    const params = buildTaskQueryParams(baseFilters, '', ['DONE'], 1);
+
+    expect(params.get('projectId')).toBeNull();
+    expect(params.get('page')).toBe('1');
+    expect(params.getAll('status')).toEqual(['DONE']);
+  });
+});

--- a/src/components/task-card.tsx
+++ b/src/components/task-card.tsx
@@ -16,6 +16,10 @@ export interface TaskCardProps {
     priority?: string;
     status: string;
     tags?: string[];
+    project?: {
+      name: string;
+      typeName?: string;
+    };
   };
   onChange?: () => void;
   href?: string;
@@ -68,6 +72,28 @@ export default function TaskCard({ task, href }: TaskCardProps) {
           </span>
         )}
       </div>
+      {task.project ? (
+        <div className="flex items-center gap-2 text-xs text-slate-500">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-4 w-4"
+            aria-hidden="true"
+          >
+            <path d="M3 10h18v10H3z" />
+            <path d="M7 10V6a2 2 0 012-2h6a2 2 0 012 2v4" />
+          </svg>
+          <span className="font-medium text-slate-700">{task.project.name}</span>
+          {task.project.typeName ? (
+            <span className="text-slate-400">• {task.project.typeName}</span>
+          ) : null}
+        </div>
+      ) : null}
       {task.description && (
         <p className="text-sm text-[#6b7280] line-clamp-2">{task.description}</p>
       )}
@@ -88,7 +114,7 @@ export default function TaskCard({ task, href }: TaskCardProps) {
           {task.assignee && (
             <>
               <Avatar
-                src={task.assigneeAvatar}
+                {...(task.assigneeAvatar ? { src: task.assigneeAvatar } : {})}
                 fallback={task.assignee.charAt(0)}
                 className="h-6 w-6 text-xs"
               />

--- a/src/components/task-kanban-column.tsx
+++ b/src/components/task-kanban-column.tsx
@@ -14,6 +14,7 @@ export interface TaskKanbanColumnProps {
   onLoadMore?: () => void | Promise<void>;
   onTaskChange?: () => void | Promise<void>;
   currentUserId?: string;
+  projectLookup?: Record<string, { name: string; typeName?: string }>;
 }
 
 export default function TaskKanbanColumn({
@@ -25,6 +26,7 @@ export default function TaskKanbanColumn({
   onLoadMore,
   onTaskChange,
   currentUserId,
+  projectLookup,
 }: TaskKanbanColumnProps) {
   const cardTasks = tasks ?? [];
   const isEmpty = !isLoading && cardTasks.length === 0;
@@ -73,6 +75,9 @@ export default function TaskKanbanColumn({
                 currentUserId &&
                   (currentUserId === task.ownerId || currentUserId === extendedTask.assignee)
               );
+              const projectMeta = task.projectId
+                ? projectLookup?.[task.projectId]
+                : undefined;
               return (
                 <motion.div
                   key={task._id}
@@ -98,6 +103,7 @@ export default function TaskKanbanColumn({
                       priority: task.priority,
                       status: task.status,
                       tags: (task as Task & { tags?: string[] }).tags,
+                      ...(projectMeta ? { project: projectMeta } : {}),
                     }}
                     href={`/tasks/${task._id}`}
                     onChange={onTaskChange}


### PR DESCRIPTION
## Summary
- require selecting an existing project when creating or editing tasks, with inline validation and a quick link to create new projects
- load and pass project metadata into task creation/editing flows and surface it in task detail, list, and board views
- add a project filter to the tasks index and cover the query builder with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e42be8f08328a13f41da97dfef6f