### PR TITLE
Handle tasks without project references

### DIFF
--- a/src/lib/serializeTask.ts
+++ b/src/lib/serializeTask.ts
@@ -12,7 +12,7 @@ export function serializeTask(task: ITask): TaskResponse {
     helpers: task.helpers?.map((id) => id.toString()),
     mentions: task.mentions?.map((id) => id.toString()),
     organizationId: task.organizationId.toString(),
-    projectId: task.projectId.toString(),
+    projectId: task.projectId ? task.projectId.toString() : undefined,
     teamId: task.teamId?.toString(),
     status: task.status,
     priority: task.priority,

--- a/src/types/api/task.ts
+++ b/src/types/api/task.ts
@@ -61,7 +61,7 @@ export interface TaskResponse {
   helpers?: string[] | undefined;
   mentions?: string[] | undefined;
   organizationId: string;
-  projectId: string;
+  projectId?: string | undefined;
   teamId?: string | undefined;
   status: TaskStatus;
   priority: TaskPriority;


### PR DESCRIPTION
## Summary
- allow task serialization to skip missing project references instead of throwing
- update the API task response type so consumers expect an optional projectId

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e82416b48328a9c501894144cf7f