### PR TITLE
Update task project selection UI and validate existing project on patch

### DIFF
--- a/src/app/api/tasks/[id]/route.test.ts
+++ b/src/app/api/tasks/[id]/route.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Types } from 'mongoose';
+
+const auth = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/auth', () => ({ auth }));
+
+const mockDbConnect = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/db', () => ({ default: mockDbConnect }));
+
+const canWriteTask = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/access', () => ({ canWriteTask }));
+
+const findTaskById = vi.hoisted(() => vi.fn());
+vi.mock('@/models/Task', () => ({ Task: { findById: findTaskById } }));
+
+const findUser = vi.hoisted(() => vi.fn());
+vi.mock('@/models/User', () => ({ User: { findOne: findUser } }));
+
+const findProject = vi.hoisted(() => vi.fn());
+vi.mock('@/models/Project', () => ({ Project: { findOne: findProject } }));
+
+const computeParticipants = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/taskParticipants', () => ({ computeParticipants }));
+
+const prepareLoopFromSteps = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/taskLoopSync', () => ({ prepareLoopFromSteps }));
+
+const createActivity = vi.hoisted(() => vi.fn());
+vi.mock('@/models/ActivityLog', () => ({ ActivityLog: { create: createActivity } }));
+
+const taskLoopFindOne = vi.hoisted(() => vi.fn());
+const taskLoopFindOneAndDelete = vi.hoisted(() => vi.fn());
+const taskLoopCreate = vi.hoisted(() => vi.fn());
+vi.mock('@/models/TaskLoop', () => ({
+  TaskLoop: {
+    findOne: taskLoopFindOne,
+    findOneAndDelete: taskLoopFindOneAndDelete,
+    create: taskLoopCreate,
+  },
+}));
+
+const loopHistoryCreate = vi.hoisted(() => vi.fn());
+const loopHistoryDeleteMany = vi.hoisted(() => vi.fn());
+vi.mock('@/models/LoopHistory', () => ({
+  LoopHistory: { create: loopHistoryCreate, deleteMany: loopHistoryDeleteMany },
+}));
+
+const scheduleTaskJobs = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/agenda', () => ({ scheduleTaskJobs }));
+
+const emitTaskUpdated = vi.hoisted(() => vi.fn());
+const emitLoopUpdated = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/ws', () => ({ emitTaskUpdated, emitLoopUpdated }));
+
+const serializeTask = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/serializeTask', () => ({ serializeTask }));
+
+import { PATCH } from './route';
+
+describe('PATCH /tasks/:id project validation', () => {
+  const sessionData = {
+    userId: new Types.ObjectId().toString(),
+    organizationId: new Types.ObjectId().toString(),
+    teamId: null,
+    role: 'ADMIN',
+  };
+
+  const taskId = new Types.ObjectId();
+  const existingOwnerId = new Types.ObjectId();
+  const newOwnerId = new Types.ObjectId();
+  const projectId = new Types.ObjectId();
+
+  let task: {
+    _id: Types.ObjectId;
+    ownerId: Types.ObjectId;
+    projectId: Types.ObjectId;
+    createdBy: Types.ObjectId;
+    helpers: Types.ObjectId[];
+    mentions: Types.ObjectId[];
+    steps: unknown[];
+    status: string;
+    currentStepIndex: number;
+    participantIds: Types.ObjectId[];
+    updatedAt: Date;
+    save: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    auth.mockResolvedValue(sessionData);
+    mockDbConnect.mockResolvedValue(undefined);
+    canWriteTask.mockReturnValue(true);
+
+    task = {
+      _id: taskId,
+      ownerId: existingOwnerId,
+      projectId,
+      createdBy: new Types.ObjectId(),
+      helpers: [],
+      mentions: [],
+      steps: [],
+      status: 'OPEN',
+      currentStepIndex: 0,
+      participantIds: [],
+      updatedAt: new Date(),
+      save: vi.fn().mockResolvedValue(null),
+    };
+
+    findTaskById.mockResolvedValue(task);
+    findUser.mockResolvedValue({ _id: newOwnerId });
+    findProject.mockResolvedValue({ _id: projectId });
+    computeParticipants.mockReturnValue([]);
+    prepareLoopFromSteps.mockReturnValue(null);
+    taskLoopFindOne.mockResolvedValue(null);
+    taskLoopFindOneAndDelete.mockResolvedValue(null);
+    taskLoopCreate.mockResolvedValue(null);
+    loopHistoryCreate.mockResolvedValue(null);
+    loopHistoryDeleteMany.mockResolvedValue(null);
+    createActivity.mockResolvedValue(null);
+    scheduleTaskJobs.mockResolvedValue(null);
+    emitTaskUpdated.mockReturnValue(undefined);
+    emitLoopUpdated.mockReturnValue(undefined);
+    serializeTask.mockReturnValue({ _id: taskId.toString() });
+  });
+
+  it('reuses the existing project when updating the owner only', async () => {
+    const req = new Request('http://localhost/api/tasks/' + taskId.toString(), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ownerId: newOwnerId.toString() }),
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: taskId.toString() }) });
+
+    expect(res.status).toBe(200);
+    expect(task.save).toHaveBeenCalledTimes(1);
+
+    expect(task.ownerId.toString()).toBe(newOwnerId.toString());
+    expect(task.projectId.toString()).toBe(projectId.toString());
+
+    expect(findProject).toHaveBeenCalledTimes(1);
+    const projectQuery = (findProject as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(projectQuery?._id?.toString()).toBe(projectId.toString());
+    expect(projectQuery?.organizationId?.toString()).toBe(sessionData.organizationId);
+
+    expect(serializeTask).toHaveBeenCalledWith(task);
+    const responseBody = await res.json();
+    expect(responseBody).toEqual({ _id: taskId.toString() });
+  });
+});

--- a/src/components/task-form.tsx
+++ b/src/components/task-form.tsx
@@ -419,14 +419,15 @@ export default function TaskForm({
     <div className="min-h-screen bg-[#F9FAFB] px-8 py-6">
       <form onSubmit={submitFlow} noValidate className="mx-auto max-w-3xl space-y-6">
         <Card className="space-y-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-1">
             <h2 className="text-lg font-semibold text-[#111827]">Project</h2>
-            <Link
-              href="/projects/new"
-              className="text-sm font-semibold text-indigo-600 hover:text-indigo-500"
-            >
-              Create project
-            </Link>
+            <p className="text-sm text-[#4B5563]">
+              Tasks must be associated with an existing project. Manage projects from the{' '}
+              <Link href="/projects" className="font-medium text-indigo-600 hover:text-indigo-500">
+                Projects page
+              </Link>
+              .
+            </p>
           </div>
           <div className="space-y-2">
             <label className="block text-sm font-medium text-[#4B5563]" htmlFor="task-project">
@@ -442,7 +443,7 @@ export default function TaskForm({
                   clearFormFieldError('projectId');
                 }
               }}
-              disabled={projects.length === 0}
+              disabled={projectsLoading || projects.length === 0}
               className={cn(
                 'border border-[#E5E7EB] bg-white text-[#111827]',
                 formErrors.projectId && 'border-red-500 focus:border-red-500 focus:ring-red-200',
@@ -450,22 +451,28 @@ export default function TaskForm({
               aria-invalid={Boolean(formErrors.projectId)}
             >
               <option value="" disabled>
-                {projectsLoading ? 'Loading projects…' : 'Select a project'}
+                {projectsLoading
+                  ? 'Loading projects…'
+                  : projects.length === 0
+                    ? 'No projects available'
+                    : 'Select a project'}
               </option>
-              {projects.map((project) => (
-                <option key={project._id} value={project._id}>
-                  {project.name}
-                  {project.type?.name ? ` • ${project.type.name}` : ''}
-                </option>
-              ))}
+              {!projectsLoading
+                ? projects.map((project) => (
+                  <option key={project._id} value={project._id}>
+                    {project.name}
+                    {project.type?.name ? ` • ${project.type.name}` : ''}
+                  </option>
+                ))
+                : null}
             </Select>
             {projects.length === 0 && !projectsLoading ? (
               <p className="text-sm text-[#4B5563]">
-                No projects yet.{' '}
-                <Link href="/projects/new" className="font-medium text-indigo-600 hover:text-indigo-500">
-                  Create a project
+                No projects yet. Visit the{' '}
+                <Link href="/projects" className="font-medium text-indigo-600 hover:text-indigo-500">
+                  Projects page
                 </Link>{' '}
-                to get started.
+                to create one before adding tasks.
               </p>
             ) : null}
             {formErrors.projectId ? (


### PR DESCRIPTION
## Summary
- remove the inline create-project action from the task form and update copy so users pick from the existing project dropdown
- disable the project selector while loading, improve empty-state guidance, and ensure only loaded projects populate the list
- reuse the current task project when updating owners through the PATCH API and add a regression test that covers the scenario

## Testing
- npm run test -- src/app/api/tasks/[id]/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7ed4b61808328b507647e0fe93073