### PR TITLE
Fix task detail initialization order for editable fields

### DIFF
--- a/src/components/task-detail.tsx
+++ b/src/components/task-detail.tsx
@@ -162,21 +162,6 @@ export default function TaskDetail({
   }, [loadProjectDetail, task?.projectId]);
 
   useEffect(() => {
-    if (!fieldsEditable) return;
-    void loadProjectOptions();
-  }, [fieldsEditable, loadProjectOptions]);
-
-  useEffect(() => {
-    if (!project) return;
-    setProjectOptions((prev) => {
-      if (prev.some((item) => item._id === project._id)) {
-        return prev;
-      }
-      return [...prev, project];
-    });
-  }, [project]);
-
-  useEffect(() => {
     const ownerId = task?.ownerId;
     if (!ownerId) {
       setOwnerName(null);
@@ -228,6 +213,21 @@ export default function TaskDetail({
   }, [canEditProp, task, user?.userId]);
 
   const fieldsEditable = canEdit && !readOnly;
+
+  useEffect(() => {
+    if (!fieldsEditable) return;
+    void loadProjectOptions();
+  }, [fieldsEditable, loadProjectOptions]);
+
+  useEffect(() => {
+    if (!project) return;
+    setProjectOptions((prev) => {
+      if (prev.some((item) => item._id === project._id)) {
+        return prev;
+      }
+      return [...prev, project];
+    });
+  }, [project]);
   const minDueDate = useMemo(() => getTodayDateInputValue(), []);
 
   const updateField = async (field: keyof Task, value: string) => {


### PR DESCRIPTION
## Summary
- ensure the `fieldsEditable` flag is defined before effects that depend on it to avoid runtime initialization errors in `TaskDetail`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f325a38083288eceef9cd157dea6