### PR TITLE
Preselect project when adding task from project page

### DIFF
--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { SessionProvider } from 'next-auth/react';
 import useAuth from '@/hooks/useAuth';
 import { useToast } from '@/components/ui/toast-provider';
@@ -10,6 +10,7 @@ import type { ProjectSummary } from '@/types/api/project';
 
 function NewTaskPageInner() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { user, status, isLoading } = useAuth();
   const { showToast } = useToast();
   const [isRedirecting, setIsRedirecting] = useState(false);
@@ -58,12 +59,18 @@ function NewTaskPageInner() {
   }
 
   const currentUserId = user?.userId ?? '';
+  const preselectedProjectId = searchParams?.get('projectId') ?? undefined;
+  const isProjectLocked = Boolean(preselectedProjectId);
 
   return (
     <TaskForm
       currentUserId={currentUserId}
+      initialValues={
+        preselectedProjectId ? { projectId: preselectedProjectId } : undefined
+      }
       projects={projects}
       projectsLoading={projectsLoading}
+      projectSelectDisabled={isProjectLocked}
       onProjectsRefresh={loadProjects}
       submitLabel="Create Task"
       submitPendingLabel="Creating…"

--- a/src/components/task-form.tsx
+++ b/src/components/task-form.tsx
@@ -53,6 +53,7 @@ export interface TaskFormProps {
   initialValues?: Partial<TaskFormValues>;
   projects: ProjectSummary[];
   projectsLoading?: boolean;
+  projectSelectDisabled?: boolean;
   onProjectsRefresh?: () => Promise<void>;
   onSubmit: (values: TaskFormSubmitValues) => Promise<void | { error?: string }>;
   onCancel?: () => void;
@@ -137,6 +138,7 @@ export default function TaskForm({
   initialValues,
   projects,
   projectsLoading = false,
+  projectSelectDisabled = false,
   onProjectsRefresh,
   onSubmit,
   onCancel,
@@ -224,12 +226,12 @@ export default function TaskForm({
   }, [initialValues?.projectId]);
 
   useEffect(() => {
-    if (!projectId) return;
+    if (!projectId || projectsLoading) return;
     if (projects.some((project) => project._id === projectId)) {
       return;
     }
     setProjectId('');
-  }, [projectId, projects]);
+  }, [projectId, projects, projectsLoading]);
 
   useEffect(() => {
     setSteps(mapInitialSteps(initialValues?.steps, currentUserId));
@@ -443,7 +445,11 @@ export default function TaskForm({
                   clearFormFieldError('projectId');
                 }
               }}
-              disabled={projectsLoading || projects.length === 0}
+              disabled={
+                (projectSelectDisabled && Boolean(projectId)) ||
+                projectsLoading ||
+                projects.length === 0
+              }
               className={cn(
                 'border border-[#E5E7EB] bg-white text-[#111827]',
                 formErrors.projectId && 'border-red-500 focus:border-red-500 focus:ring-red-200',


### PR DESCRIPTION
## Summary
- read the selected project from the new task URL and pass it into the task form
- add support for disabling the project selector when a project is preselected
- avoid clearing a preselected project while the project list is still loading

## Testing
- npm run lint *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f831a2208328a2a3e6c327064c11