### PR TITLE
Ensure task forms load projects on mount

### DIFF
--- a/src/app/tasks/[id]/edit/page.tsx
+++ b/src/app/tasks/[id]/edit/page.tsx
@@ -48,6 +48,10 @@ function EditTaskPageInner({ id }: { id: string }) {
   }, []);
 
   useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
     if (status === 'unauthenticated' && !isLoading) {
       router.push('/login');
     }

--- a/src/app/tasks/new/page.tsx
+++ b/src/app/tasks/new/page.tsx
@@ -45,6 +45,10 @@ function NewTaskPageInner() {
   }, []);
 
   useEffect(() => {
+    void loadProjects();
+  }, [loadProjects]);
+
+  useEffect(() => {
     if (status === 'unauthenticated' && !isLoading) {
       router.push('/login');
     }


### PR DESCRIPTION
## Summary
- trigger the project list fetch when mounting the new task page so preselected projects appear immediately
- do the same on the edit task page to keep behavior consistent when loading projects

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa0d207c832887e7de04f3d0aba8